### PR TITLE
Update Vagrantfile to use a pre-provisioned box, synced folders, and custom configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ pombe_data
 *.sqlite3-shm
 *.sqlite3-wal
 .vagrant
+vagrant_config.yaml
 
 FYPO_A_E_config
 GO_BP_A_E_config

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,29 +1,36 @@
-$canto_script = <<-SCRIPT
-  if [ ! -d root-canto ]
-  then
-    git clone /vagrant root-canto
-    (cd root-canto; perl Makefile.PL < /dev/null; make)
-  fi
+require 'yaml'
+settings = YAML.load_file './vagrant_config.yaml'
 
-  if [ ! -d canto ]
-  then
-    su - vagrant -c '
-      git clone /vagrant canto;
-      (cd canto && perl Makefile.PL < /dev/null)'
-  fi
+$canto_setup_script = <<-SCRIPT
+  # Go to the Canto source directory
+  cd /home/canto/canto-master
 
-  if [ ! -d data ]
-  then
-    su - vagrant -c '(cd canto; ./script/canto_start --initialise ~/data && echo Canto data initialised)'
-  fi
+  # Initialise the test data directory
+  ./script/canto_start --initialise /home/canto/canto_data
 SCRIPT
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "canto"
+  config.vm.box_url = settings['box_url']
 
   config.vm.network "forwarded_port", guest: 5000, host: 5000
 
-  config.vm.provision "puppet"
-  config.vm.provision "shell", inline: $canto_script
+  config.vm.synced_folder ".", "/home/canto/canto-master",
+    owner: "root"
+
+  # Disable the default synced folder, since the working directory is already
+  # synced somewhere else.
+  config.vm.synced_folder ".", "/vagrant",
+    disabled: true
+
+  config.vm.provision "canto",
+    type: "shell",
+    inline: $canto_setup_script,
+    # Don't run this script as a privileged user, since it causes permissions
+    # issues on the database that Canto creates.
+    privileged: false
+
+  config.ssh.username = "canto"
+  config.ssh.password = "canto"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ SCRIPT
 
 $ontology_loading_script = <<-SCRIPT
   # Load ontologies from Gene Ontology, FYPO, and PSI-MOD
+  cd /home/canto/canto-master
   ./script/canto_load.pl \
     --ontology http://snapshot.geneontology.org/ontology/go-basic.obo \
     --ontology http://curation.pombase.org/ontologies/fypo/latest/fypo-simple.obo \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,14 @@ $canto_setup_script = <<-SCRIPT
   ./script/canto_start --initialise /home/canto/canto_data
 SCRIPT
 
+$ontology_loading_script = <<-SCRIPT
+  # Load ontologies from Gene Ontology, FYPO, and PSI-MOD
+  ./script/canto_load.pl \
+    --ontology http://snapshot.geneontology.org/ontology/go-basic.obo \
+    --ontology http://curation.pombase.org/ontologies/fypo/latest/fypo-simple.obo \
+    --ontology http://curation.pombase.org/ontologies/PSI-MOD-2016-01-19.obo
+SCRIPT
+
 Vagrant.configure("2") do |config|
 
   config.vm.box = "canto"
@@ -30,6 +38,13 @@ Vagrant.configure("2") do |config|
     # Don't run this script as a privileged user, since it causes permissions
     # issues on the database that Canto creates.
     privileged: false
+
+  config.vm.provision "ontologies",
+    type: "shell",
+    inline: $ontology_loading_script,
+    # If ontology loading is disabled, it can still be run manually with:
+    # $ vagrant provision --provision-with ontologies
+    run: settings['load_ontologies'] ? "once" : "never"
 
   config.ssh.username = "canto"
   config.ssh.password = "canto"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,29 +1,29 @@
-Vagrant::Config.run do |config|
+$canto_script = <<-SCRIPT
+  if [ ! -d root-canto ]
+  then
+    git clone /vagrant root-canto
+    (cd root-canto; perl Makefile.PL < /dev/null; make)
+  fi
 
-$canto_script = <<SCRIPT
-if [ ! -d root-canto ]
-then
-  git clone /vagrant root-canto
-  (cd root-canto; perl Makefile.PL < /dev/null; make)
-fi
+  if [ ! -d canto ]
+  then
+    su - vagrant -c '
+      git clone /vagrant canto;
+      (cd canto && perl Makefile.PL < /dev/null)'
+  fi
 
-if [ ! -d canto ]
-then
-  su - vagrant -c '
-    git clone /vagrant canto;
-    (cd canto && perl Makefile.PL < /dev/null)'
-fi
-
-if [ ! -d data ]
-then
-  su - vagrant -c '(cd canto; ./script/canto_start --initialise ~/data && echo Canto data initialised)'
-fi
+  if [ ! -d data ]
+  then
+    su - vagrant -c '(cd canto; ./script/canto_start --initialise ~/data && echo Canto data initialised)'
+  fi
 SCRIPT
 
-config.vm.box = "precise64"
-  config.vm.forward_port 5000, 5500
-  config.vm.provision :puppet
-  config.vm.provision :shell,
-    :inline => $canto_script
-end
+Vagrant.configure("2") do |config|
 
+  config.vm.box = "hashicorp/precise64"
+
+  config.vm.network "forwarded_port", guest: 5000, host: 5000
+
+  config.vm.provision "puppet"
+  config.vm.provision "shell", inline: $canto_script
+end

--- a/template.vagrant_config.yaml
+++ b/template.vagrant_config.yaml
@@ -1,0 +1,8 @@
+---
+# COPY AND RENAME THIS FILE to 'vagrant_config.yaml' if you want to customise 
+# certain settings in the Vagrantfile. You should only edit this file if you 
+# need to add new configuration options.
+
+# Specify the path to the Vagrant box (default name 'package.box') as a URL, 
+# e.g. "file:///path/to/package.box"
+box_url: ""

--- a/template.vagrant_config.yaml
+++ b/template.vagrant_config.yaml
@@ -1,8 +1,13 @@
 ---
-# COPY AND RENAME THIS FILE to 'vagrant_config.yaml' if you want to customise 
-# certain settings in the Vagrantfile. You should only edit this file if you 
+# COPY AND RENAME THIS FILE to 'vagrant_config.yaml' if you want to customise
+# certain settings in the Vagrantfile. You should only edit this file if you
 # need to add new configuration options.
 
-# Specify the path to the Vagrant box (default name 'package.box') as a URL, 
+# Specify the path to the Vagrant box (default name 'package.box') as a URL,
 # e.g. "file:///path/to/package.box"
 box_url: ""
+
+# Choose whether to load ontologies when provisioning the Vagrant box.
+# Loading ontologies can take a long time, so you may set this to 'false' if
+# you need to bring vagrant up quickly.
+load_ontologies: true


### PR DESCRIPTION
The previous Vagrantfile was using an old configuration version, and didn't work reliably.

The main changes in this fix include:

- Updating the Vagrantfile syntax to version 2.

- Enabling synced folders.

- Using a pre-provisioned base box (see below).

- Adding a new (optional) provisioner to load ontologies at any time.

- Allowing the Vagrantfile to be further configured by copying and renaming `template.vagrant_config.yaml` to `vagrant_config.yaml`, and changing the options accordingly.

@kimrutherford previously put together a VirtualBox image that had all of Canto's dependencies already installed: the new Vagrantfile uses a Vagrant box based on this image, rather than provisioning from scratch. 

Unfortunately, since the Vagrant box isn't currently hosted (on [Vagrant Cloud](https://app.vagrantup.com/boxes/search) or elsewhere), developers will have to keep the box on their local machine and specify the path by setting the `box_url` property in `vagrant_config.yaml`.

Note that the new Vagrantfile omits a step in the old shell provisioner that tests the build, since in the past `perl Makefile.PL` has prompted me for user input, and that can't be easily simulated with the shell provisioner. These tests can still be run manually once the box is started.