### PR TITLE
Correct some typos and omissions in host organism test data

### DIFF
--- a/t/data/host_organisms.csv
+++ b/t/data/host_organisms.csv
@@ -1,5 +1,5 @@
-Nicotiana,tabacum,4097,tabaco
+Nicotiana,tabacum,4097,tobacco
 Oryza,sativa,4530,rice
-Rattus,rattus,10117
+Rattus,rattus,10117,black rat
 Solanum,lycopersicum,4081,tomato
 Zea,mays,4577,maize


### PR DESCRIPTION
It's only test data, but there was a typo on 'tobacco', and GitHub pointed out that _Rattus rattus_ was missing a common name.

@kimrutherford I'm not sure if the common name needs to be one word, whether you'd like it quoted, or whether it even needs to be there. Feel free to make any necessary changes.