### PR TITLE
Document how pathogen organisms are determined

### DIFF
--- a/root/docs/md/canto_admin/configuration_file.md
+++ b/root/docs/md/canto_admin/configuration_file.md
@@ -269,3 +269,5 @@ mode and the internal config setting `pathogen_host_mode` will be
 automatically set to 1.  Also `host_organisms` will be set to
 a list the Organism objects.  `multi_organism_mode` is also set to
 1/true.
+
+Note that when `pathogen_host_mode` is enabled, every organism that is in the organism table but _not_ in `host_organism_taxonids` will be assumed to be a pathogen organism.


### PR DESCRIPTION
(References #1403)

Just adding an explanation of how every organism that isn't explicitly specified as a host is assumed to be a pathogen by Canto's configuration.

@kimrutherford I'm not sure if I'm right about this only happening "when `pathogen_host_mode` is enabled", so please amend the text if there's a more accurate explanation.