### PR TITLE
Use the configured database name instead of 'PomBase'

### DIFF
--- a/root/curs/introduction.mhtml
+++ b/root/curs/introduction.mhtml
@@ -19,7 +19,7 @@ this paper yourself, or send it to a member of your lab to curate.
 
 Please annotate only the data that you have determined directly in the
 experiments described in this paper. If you have any questions, help is
-available on many pages, or you can contact the PomBase staff for
+available on many pages, or you can contact the <% $c->config()->{database_name} %> staff for
 assistance at any time.
     </p>
 

--- a/root/docs/instance_front.mhtml
+++ b/root/docs/instance_front.mhtml
@@ -1,5 +1,5 @@
 <!-- PAGE_TITLE: @@long_name@@ -->
-<!-- PAGE_SUBTITLE: Add your work to PomBase -->
+<!-- PAGE_SUBTITLE: Add your work to @@database_name@@ -->
 <!-- FLAGS: use_bootstrap -->
 
 <div class="row" style="padding-top: 20px">


### PR DESCRIPTION
Some of the text on the front page and the _introduction_ page (after finding a publication) was hard-coded to use 'PomBase' as the database name. This doesn't suit PHI-base, so I've amended the text to use the `database_name` as configured in `canto_deploy.yaml`.

@kimrutherford I'm hoping that this doesn't cause any problems with the PomBase Canto deployment, but it should be fine as long as the `database_name` is set to 'PomBase' on your side.