### PR TITLE
Fix form control overflow on modal dialogs

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1382,8 +1382,11 @@ a.curs-editable-table-field img, a.curs-editable-table-long-field img
   filter: alpha(opacity=50);
 }
 
-.form-control, .help-block {
+help-block {
   width: auto;
+}
+
+.form-control, .help-block {
   display: inline;
 }
 

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1399,6 +1399,11 @@ help-block {
   max-width: 600px;
 }
 
+.curs-feature-chooser select,
+.curs-evidence-directive select {
+  width: auto;
+}
+
 table tr td.curs-table-row-remove {
   border-style: none;
 }


### PR DESCRIPTION
(Fixes #1479)

The rule for setting form control width to 100% was being overridden in the main stylesheet by the following selector:

https://github.com/pombase/canto/blob/0f046bc6fd463891fcfba615569e52b0f207bea1/root/static/css/style.css#L1385-L1388

I've changed it so that automatic width is only set on the selector for `.help-block`.

@kimrutherford for your information, the selectors apply to the following pages:

```
.help-block
root/static/ng_templates/allele_edit.html
root/static/ng_templates/annotation_edit.html
root/static/ng_templates/annotation_evidence.html
root/static/ng_templates/extension_relation_edit.html

.form-control
root/static/ng_templates/allele_edit.html
root/static/ng_templates/annotation_edit.html
root/static/ng_templates/annotation_evidence.html
root/static/ng_templates/feature_chooser.html
root/static/ng_templates/genotype_background_edit.html
root/static/ng_templates/term_name_complete.html
```