### PR TITLE
Add support for host organisms with no genes

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1456,3 +1456,7 @@ a:not([href]) {
   margin: 6px;
   margin-bottom: 12px;
 }
+
+.curs-genotype-no-gene-notice {
+  margin-top: 10px;
+}

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -1,8 +1,8 @@
-<div class="curs-genotype-gene-list" ng-show="genes">
+<div class="curs-genotype-gene-list" ng-show="organisms">
   <div ng-show="!data.selectedOrganism">
     <span ng-show="label">{{label}}</span>
     <select name="select-organism" ng-model="data.selectedOrganism"
-            ng-options="o as o.full_name for o in data.organismsOfGenes">
+            ng-options="o as o.full_name for o in organisms">
       <option value="">Select an organism ...</option>
     </select>
   </div>
@@ -13,12 +13,11 @@
       <span style="font-size: 90%; font-weight: bold;">
         {{data.selectedOrganism.full_name}} genes
       </span>
-      <span ng-show="data.organismsOfGenes.length != 1">
+      <span ng-show="organisms.length != 1">
         (<a ng-click="data.selectedOrganism = null">change ...</a>)
       </span>
     </span>
-
-    <table class="list">
+    <table class="list" ng-if="selectedOrganismGenes().length > 0">
       <thead>
         <tr>
           <th>Gene</th>
@@ -42,5 +41,9 @@
         </tr>
       </tbody>
     </table>
+    <p class="curs-genotype-no-gene-notice"
+       ng-if="selectedOrganismGenes().length === 0">
+      No genes have been added for this organism.
+    </p>
   </div>
 </div>

--- a/root/static/ng_templates/genotype_genes_panel.html
+++ b/root/static/ng_templates/genotype_genes_panel.html
@@ -1,22 +1,22 @@
 <div>
-  <div ng-if="!data.allGenes">
+  <div ng-if="!data.allOrganisms">
     <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img>
     loading genes ...
   </div>
-  <div ng-if="data.allGenes">
-    <div ng-if="data.unknownGenes.length != 0">
-      <genotype-gene-list genotypes="genotypes" genes="data.unknownGenes"
+  <div ng-if="data.allOrganisms">
+    <div ng-if="data.unknownOrganisms.length != 0">
+      <genotype-gene-list genotypes="genotypes" organisms="data.unknownOrganisms"
                           multi-organism-mode="multiOrganismMode">
       </genotype-gene-list>
     </div>
-    <div ng-if="data.pathogenGenes.length != 0">
-      <genotype-gene-list genotypes="genotypes" genes="data.pathogenGenes"
+    <div ng-if="data.pathogenOrganisms.length != 0">
+      <genotype-gene-list genotypes="genotypes" organisms="data.pathogenOrganisms"
                           label="Pathogen: "
                           multi-organism-mode="multiOrganismMode">
       </genotype-gene-list>
     </div>
-    <div ng-if="data.hostGenes.length != 0">
-      <genotype-gene-list genotypes="genotypes" genes="data.hostGenes"
+    <div ng-if="data.hostOrganisms.length != 0">
+      <genotype-gene-list genotypes="genotypes" organisms="data.hostOrganisms"
                           label="Host: "
                           multi-organism-mode="multiOrganismMode">
       </genotype-gene-list>


### PR DESCRIPTION
(Implements #1403)

This makes the following key changes to the genotype management page:

* Organisms with no specified genes now can be selected in the organism drop-down menus.

* `genotype_gene_list.html` now shows a message, instead of showing the gene list, when the selected organism has no genes.

* Genes are now retrieved from the organism, rather than the other way round.
  * Redundant processing related to genes has been removed.

- - -

@kimrutherford might need to fix a bug related to Firefox where the gene list isn't being displayed before this can be merged.