### PR TITLE
Fix Vagrant permissions on Canto data directory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,10 +2,10 @@ require 'yaml'
 settings = YAML.load_file './vagrant_config.yaml'
 
 $canto_setup_script = <<-SCRIPT
-  # Go to the Canto source directory
+  # Go to the Canto source directory.
   cd /home/canto/canto-master
 
-  # Initialise the Canto data directory
+  # Initialise the Canto data directory.
   ./script/canto_start --initialise /var/canto-data
   
   # Canto won't start unless the user running the script has permissions on
@@ -14,7 +14,7 @@ $canto_setup_script = <<-SCRIPT
 SCRIPT
 
 $ontology_loading_script = <<-SCRIPT
-  # Load ontologies from Gene Ontology, FYPO, and PSI-MOD
+  # Load ontologies from Gene Ontology, FYPO, and PSI-MOD.
   cd /home/canto/canto-master
   ./script/canto_load.pl \
     --ontology http://snapshot.geneontology.org/ontology/go-basic.obo \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ $canto_setup_script = <<-SCRIPT
   # Go to the Canto source directory
   cd /home/canto/canto-master
 
-  # Initialise the test data directory
+  # Initialise the Canto data directory
   ./script/canto_start --initialise /var/canto-data
   
   # Canto won't start unless the user running the script has permissions on

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,10 @@ $canto_setup_script = <<-SCRIPT
 
   # Initialise the test data directory
   ./script/canto_start --initialise /var/canto-data
+  
+  # Canto won't start unless the user running the script has permissions on
+  # the database.
+  chown -R canto:canto /var/canto-data
 SCRIPT
 
 $ontology_loading_script = <<-SCRIPT
@@ -35,10 +39,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "canto",
     type: "shell",
-    inline: $canto_setup_script,
-    # Don't run this script as a privileged user, since it causes permissions
-    # issues on the database that Canto creates.
-    privileged: false
+    inline: $canto_setup_script
 
   config.vm.provision "ontologies",
     type: "shell",


### PR DESCRIPTION
The configuration for PHI-Canto changed recently to use ` /var/canto-data/` as the data directory, to keep that particular setting in sync between the Vagrant environment and the testing server.

However, on the Vagrant box, only the root user has permissions to create the data directory at `/var/canto-data/`. Permissions have to be transferred to the `canto` user afterwards (the default SSH user), otherwise the `canto_start` script won't work.

Previously the the setup script wasn't run as a privileged user, because of ownership issues, but it's probably more reliable to do everything as root and then just transfer ownership afterwards.