### PR TITLE
Revert Pathogen–Host organism pickers

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3650,36 +3650,12 @@ var GenotypeGenesPanelCtrl =
         $scope.app_static_path = CantoGlobals.app_static_path;
 
         $scope.data = {
-          allOrganisms: null,
-          hostOrganisms: [],
-          pathogenOrganisms: [],
-          unknownOrganisms: [], // not host and not pathogen
+          organisms: null,
         };
 
         $scope.getOrganismsFromServer = function() {
           Curs.list('organism').success(function(results) {
-            $scope.data.allOrganisms = results;
-
-            $scope.data.hostOrganisms = [];
-            $scope.data.pathogenOrganisms = [];
-            $scope.data.unknownOrganisms = [];
-
-            $.map($scope.data.allOrganisms,
-                  function(organism) {
-                    if ($scope.multiOrganismMode &&
-                        organism.pathogen_or_host === 'pathogen') {
-                      $scope.data.pathogenOrganisms.push(organism);
-                    } else {
-                      if ($scope.multiOrganismMode &&
-                          organism.pathogen_or_host === 'host') {
-                        $scope.data.hostOrganisms.push(organism);
-                      } else {
-                        $scope.data.unknownOrganisms.push(organism);
-                      }
-                    }
-                  });
-
-
+            $scope.data.organisms = results;
           }).error(function() {
             toaster.pop('error', 'failed to get gene list from server');
           });

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3653,9 +3653,16 @@ var GenotypeGenesPanelCtrl =
           organisms: null,
         };
 
+        function removeNoGeneHosts(organisms) {
+          function hasGenes(organism) {
+            return organism.genes.length > 0;
+          }
+          return organisms.filter(hasGenes)
+        }
+        
         $scope.getOrganismsFromServer = function() {
           Curs.list('organism').success(function(results) {
-            $scope.data.organisms = results;
+            $scope.data.organisms = removeNoGeneHosts(results);
           }).error(function() {
             toaster.pop('error', 'failed to get gene list from server');
           });

--- a/root/static/ng_templates/genotype_genes_panel.html
+++ b/root/static/ng_templates/genotype_genes_panel.html
@@ -4,7 +4,7 @@
     loading genes ...
   </div>
   <div ng-if="data.organisms">
-    <div ng-if="data.unknownOrganisms.length != 0">
+    <div ng-if="data.organisms.length != 0">
       <genotype-gene-list genotypes="genotypes" organisms="data.organisms"
                           multi-organism-mode="multiOrganismMode">
       </genotype-gene-list>

--- a/root/static/ng_templates/genotype_genes_panel.html
+++ b/root/static/ng_templates/genotype_genes_panel.html
@@ -1,27 +1,14 @@
 <div>
-  <div ng-if="!data.allOrganisms">
+  <div ng-if="!data.organisms">
     <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img>
     loading genes ...
   </div>
-  <div ng-if="data.allOrganisms">
+  <div ng-if="data.organisms">
     <div ng-if="data.unknownOrganisms.length != 0">
-      <genotype-gene-list genotypes="genotypes" organisms="data.unknownOrganisms"
+      <genotype-gene-list genotypes="genotypes" organisms="data.organisms"
                           multi-organism-mode="multiOrganismMode">
       </genotype-gene-list>
     </div>
-    <div ng-if="data.pathogenOrganisms.length != 0">
-      <genotype-gene-list genotypes="genotypes" organisms="data.pathogenOrganisms"
-                          label="Pathogen: "
-                          multi-organism-mode="multiOrganismMode">
-      </genotype-gene-list>
-    </div>
-    <div ng-if="data.hostOrganisms.length != 0">
-      <genotype-gene-list genotypes="genotypes" organisms="data.hostOrganisms"
-                          label="Host: "
-                          multi-organism-mode="multiOrganismMode">
-      </genotype-gene-list>
-    </div>
-
     <a ng-click="openSingleGeneAddDialog()">Add another gene ...</a>
   </div>
 </div>


### PR DESCRIPTION
(Fixes #1555)

This request isn't ready to merge yet, but I'm putting it here to get feedback on the changes.

Since we decided to split the creation of genotypes and the creation of meta-genotypes, some of the changes we made to the Genotype Management page are redundant &ndash; namely the use of two organism pickers.

The key changes are:

* Replaced all of the filtered lists in the `GenotypeGenesPanelCtrl` data with a generic list called `organisms`.
* Updated the controller templates to match the new variable names.
* Added logic in the `GenotypeGenesPanelCtrl` to filter out host organisms with no genes.

The following still needs to be done:

* Move organism filtering logic (e.g. by Pathogen or Host) to `GenotypeManageCtrl`.
* Add some variable or toggle to control whether Pathogens or Hosts are displayed, so that we can have individual links for Pathogen Genotype Management and Host Genotype Management.

Note that the `removeNoGeneHosts()` function that I've added to `GenotypeGenesPanelCtrl` is private to that controller at the moment (it's not bound to `$scope`), but it might be better to extract it as a utility function if we need to filter out host organisms with no genes elsewhere