### PR TITLE
Factor out the organism selector into a directive

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3526,6 +3526,7 @@ var organismSelector = function ($http, Curs, toaster, CantoGlobals, CantoConfig
   return {
     scope: {
       selectedOrganism: '=',
+      organismSelected: '&',
       genotypeType: '<'
     },
     restrict: 'E',
@@ -3540,7 +3541,10 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   
   $scope.data = {
     organisms: null,
-    selected: null,
+  };
+  
+  $scope.organismChanged = function (organism) {
+    $scope.organismSelected({organism: this.selectedOrganism});
   };
 
   $scope.selectionChanged = function() {
@@ -3640,9 +3644,13 @@ var GenotypeGeneListCtrl =
                        $scope.makeHasDeletionHash();
                      }, true);
 
+        $scope.organismSelected = function (organism) {
+          $scope.data.selectedOrganism = organism;
+        };
+                     
         $scope.getSelectedOrganism = function() {
-          return $scope.selectedOrganism;
-        }
+          return $scope.data.selectedOrganism;
+        };
 
         $scope.hasDeletionGenotype = function(gene_id) {
           return !!$scope.hasDeletionHash[gene_id];

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3570,7 +3570,7 @@ var organismSelectorCtrl = function ($scope) {
   };
   
   var setSelectedOrganism = function () {
-    if ($scope.organisms.length == 1) {
+    if ($scope.data.organisms.length == 1) {
       $scope.data.selectedOrganism = $scope.organisms[0];
     }
   };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3522,6 +3522,72 @@ var metagenotypeViewCtrl =
 canto.controller('MetagenotypeViewCtrl',
                  ['$scope', 'CantoGlobals', 'CursSettings', metagenotypeViewCtrl]);
 
+var organismSelector = function (Curs, toaster, CantoGlobals, CantoConfig) {
+  return {
+    scope: {
+      selectedOrganism: '=',
+      genotypeType: '<',
+      label: '@',
+    },
+    restrict: 'E',
+    templateUrl: app_static_path + 'ng_templates/organism_selector.html',
+    controller: organismSelectorCtrl,
+  };
+};
+
+var organismSelectorCtrl = function ($scope) {
+  
+  $scope.data = {
+    organisms: null,
+  };
+
+  var filterOrganisms = function (organisms, genotypeType) {
+    var buildOrganismFilter = function (type) {
+      return function (organism) {
+        return organism['pathogen_or_host'] === type;
+      };
+    };
+    var byOrganismType = buildOrganismFilter(genotypeType);
+    return organisms.filter(byOrganismType);
+  };
+  
+  var getOrganismsFromServer = function () {
+    Curs.list('organism').success(function(organisms) {
+      return organisms;
+    }).error(function() {
+      toaster.pop('error', 'failed to get organism list from server');
+    });
+  };
+  
+  var setOrganisms = function (organisms, genotypeType) {
+    if (genotypeType === 'host' || genotypeType === 'pathogen') {
+      $scope.data.organisms = filterOrganisms(organisms, genotypeType);
+    } else {
+      $scope.data.organisms = organisms;
+    }
+  };
+  
+  var setSelectedOrganism = function () {
+    if ($scope.organisms.length == 1) {
+      $scope.data.selectedOrganism = $scope.organisms[0];
+    }
+  };
+  
+  var getSelectedOrganism = function () {
+    return $scope.selectedOrganism;
+  };
+  
+  $scope.reloadOrganisms = function () {
+    setOrganisms(getOrganismsFromServer(), $scope.genotypeType);
+    $scope.setSelectedOrganism();
+  };
+  
+  $scope.reloadOrganisms();
+};
+
+canto.directive('organismSelector', [
+  'Curs', 'toaster', 'CantoGlobals', 'CantoConfig', organismSelector
+]);
 
 var GenotypeGeneListCtrl =
   function($uibModal, $http, Curs, CursGenotypeList, CantoGlobals,

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3599,7 +3599,8 @@ var GenotypeGeneListCtrl =
         genotypes: '=',
         organisms: '=',
         multiOrganismMode: '=',
-        label: '@'
+        label: '@',
+        selectedOrganism: '=',
       },
       restrict: 'E',
       replace: true,
@@ -3610,29 +3611,13 @@ var GenotypeGeneListCtrl =
 
         $scope.hasDeletionHash = {};
 
-        $scope.data = {
-          selectedOrganism: null
-        };
-
-        if ($scope.organisms.length == 1) {
-          $scope.data.selectedOrganism = $scope.organisms[0];
-        }
-
         $scope.$watch('genotypes',
                      function() {
                        $scope.makeHasDeletionHash();
                      }, true);
 
         $scope.getSelectedOrganism = function() {
-          if ($scope.data.selectedOrganism) {
-            return $scope.data.selectedOrganism;
-          } else {
-            if ($scope.organisms.length == 1) {
-              return $scope.organisms[0];
-            } else {
-              return null;
-            }
-          }
+          return $scope.selectedOrganism;
         }
 
         $scope.hasDeletionGenotype = function(gene_id) {
@@ -3676,7 +3661,7 @@ var GenotypeGeneListCtrl =
         };
 
         $scope.makeDeletionAllele = function(gene_id) {
-          if (!$scope.data.selectedOrganism) {
+          if (!$scope.getSelectedOrganism()) {
             return;
           }
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3540,6 +3540,11 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   
   $scope.data = {
     organisms: null,
+    selected: null,
+  };
+
+  $scope.selectionChanged = function() {
+    $scope.selectedOrganism = $scope.data.selected;
   };
   
   var setLabelText = function (genotypeType) {
@@ -3590,7 +3595,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
 
   var setSelectedOrganism = function () {
     if ($scope.data.organisms.length === 1) {
-      $scope.data.selectedOrganism = $scope.data.organisms[0];
+      $scope.selectedOrganism = $scope.data.organisms[0];
     }
   };
   
@@ -3615,13 +3620,16 @@ var GenotypeGeneListCtrl =
         organisms: '=',
         multiOrganismMode: '=',
         label: '@',
-        selectedOrganism: '=',
         genotypeType: '<'
       },
       restrict: 'E',
       replace: true,
       templateUrl: app_static_path + 'ng_templates/genotype_gene_list.html',
       controller: function($scope) {
+        $scope.data = {
+          selectedOrganism: {}
+        };
+
         $scope.curs_root_uri = CantoGlobals.curs_root_uri;
         $scope.read_only_curs = CantoGlobals.read_only_curs;
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3546,10 +3546,6 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   $scope.organismChanged = function (organism) {
     $scope.organismSelected({organism: this.selectedOrganism});
   };
-
-  $scope.selectionChanged = function() {
-    $scope.selectedOrganism = $scope.data.selected;
-  };
   
   var setLabelText = function (genotypeType) {
     var calculateLabelText = function (genotypeType) {
@@ -3584,27 +3580,11 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
       toaster.pop('error', 'failed to get organism list from server');
     });
   };
-  
-  $scope.getSelectedOrganism = function () {
-    if ($scope.data.selectedOrganism) {
-      return $scope.data.selectedOrganism;
-    } else {
-      if ($scope.organisms.length === 1) {
-        return $scope.organisms[0];
-      } else {
-        return null;
-      }
-    }
-  };
 
   var setSelectedOrganism = function () {
     if ($scope.data.organisms.length === 1) {
       $scope.selectedOrganism = $scope.data.organisms[0];
     }
-  };
-  
-  var getSelectedOrganism = function () {
-    return $scope.selectedOrganism;
   };
   
   $scope.getOrganismsFromServer($scope.genotypeType);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3607,6 +3607,7 @@ var GenotypeGeneListCtrl =
     return {
       scope: {
         genotypes: '=',
+        organisms: '=',
         multiOrganismMode: '=',
         label: '@',
         genotypeType: '<'

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3603,7 +3603,6 @@ var GenotypeGeneListCtrl =
     return {
       scope: {
         genotypes: '=',
-        organisms: '=',
         multiOrganismMode: '=',
         label: '@',
         genotypeType: '<'

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3583,7 +3583,9 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
 
   var setSelectedOrganism = function () {
     if ($scope.data.organisms.length === 1) {
-      $scope.selectedOrganism = $scope.data.organisms[0];
+      var defaultOrganism = $scope.data.organisms[0];
+      $scope.selectedOrganism = defaultOrganism;
+      $scope.organismSelected({organism: defaultOrganism});
     }
   };
   

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3740,27 +3740,6 @@ var GenotypeGenesPanelCtrl =
 
         $scope.app_static_path = CantoGlobals.app_static_path;
 
-        $scope.data = {
-          organisms: null,
-        };
-
-        function removeNoGeneHosts(organisms) {
-          function hasGenes(organism) {
-            return organism.genes.length > 0;
-          }
-          return organisms.filter(hasGenes)
-        }
-        
-        $scope.getOrganismsFromServer = function() {
-          Curs.list('organism').success(function(results) {
-            $scope.data.organisms = removeNoGeneHosts(results);
-          }).error(function() {
-            toaster.pop('error', 'failed to get gene list from server');
-          });
-        };
-
-        $scope.getOrganismsFromServer();
-
         $scope.openSingleGeneAddDialog = function() {
           var modal = openSingleGeneAddDialog($uibModal);
           modal.result.then(function () {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3581,7 +3581,7 @@ var organismSelectorCtrl = function ($scope, Curs) {
   
   $scope.reloadOrganisms = function () {
     setOrganisms(getOrganismsFromServer(), $scope.genotypeType);
-    $scope.setSelectedOrganism();
+    setSelectedOrganism();
   };
   
   $scope.reloadOrganisms();

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3535,7 +3535,7 @@ var organismSelector = function ($http, Curs, toaster, CantoGlobals, CantoConfig
   };
 };
 
-var organismSelectorCtrl = function ($scope, Curs) {
+var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   
   $scope.app_static_path = CantoGlobals.app_static_path;
   
@@ -3554,8 +3554,8 @@ var organismSelectorCtrl = function ($scope, Curs) {
   };
   
   var getOrganismsFromServer = function () {
-    Curs.list('organism').success(function(organisms) {
-      return organisms;
+    Curs.list('organism').success(function(response) {
+      return response.data;
     }).error(function() {
       toaster.pop('error', 'failed to get organism list from server');
     });

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3541,6 +3541,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   
   $scope.data = {
     organisms: null,
+    defaultOrganism: null
   };
   
   $scope.organismChanged = function (organism) {
@@ -3582,11 +3583,14 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   };
 
   var setSelectedOrganism = function () {
+    var organismToSet;
     if ($scope.data.organisms.length === 1) {
-      var defaultOrganism = $scope.data.organisms[0];
-      $scope.selectedOrganism = defaultOrganism;
-      $scope.organismSelected({organism: defaultOrganism});
+      $scope.data.defaultOrganism = $scope.data.organisms[0];
+      organismToSet = $scope.data.defaultOrganism;
+    } else {
+      organismToSet = $scope.selectedOrganism;
     }
+    $scope.organismSelected({organism: organismToSet});
   };
   
   $scope.getOrganismsFromServer($scope.genotypeType);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3522,7 +3522,7 @@ var metagenotypeViewCtrl =
 canto.controller('MetagenotypeViewCtrl',
                  ['$scope', 'CantoGlobals', 'CursSettings', metagenotypeViewCtrl]);
 
-var organismSelector = function (Curs, toaster, CantoGlobals, CantoConfig) {
+var organismSelector = function ($http, Curs, toaster, CantoGlobals, CantoConfig) {
   return {
     scope: {
       selectedOrganism: '=',
@@ -3588,7 +3588,7 @@ var organismSelectorCtrl = function ($scope) {
 };
 
 canto.directive('organismSelector', [
-  'Curs', 'toaster', 'CantoGlobals', 'CantoConfig', organismSelector
+  '$http', 'Curs', 'toaster', 'CantoGlobals', 'CantoConfig', organismSelector
 ]);
 
 var GenotypeGeneListCtrl =

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3570,14 +3570,27 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
           genotypeType
         );
       }
+      setSelectedOrganism();
     }).error(function() {
       toaster.pop('error', 'failed to get organism list from server');
     });
   };
+  
+  $scope.getSelectedOrganism = function () {
+    if ($scope.data.selectedOrganism) {
+      return $scope.data.selectedOrganism;
+    } else {
+      if ($scope.organisms.length === 1) {
+        return $scope.organisms[0];
+      } else {
+        return null;
+      }
+    }
+  };
 
   var setSelectedOrganism = function () {
     if ($scope.data.organisms.length === 1) {
-      $scope.data.selectedOrganism = $scope.organisms[0];
+      $scope.data.selectedOrganism = $scope.data.organisms[0];
     }
   };
   

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3553,22 +3553,20 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     return organisms.filter(byOrganismType);
   };
   
-  var getOrganismsFromServer = function () {
+  $scope.getOrganismsFromServer = function (genotypeType) {
     Curs.list('organism').success(function(response) {
-      return response.data;
+      $scope.data.organisms = response;
+      if (genotypeType === 'host' || genotypeType === 'pathogen') {
+        $scope.data.organisms = filterOrganisms(
+          $scope.data.organisms,
+          genotypeType
+        );
+      }
     }).error(function() {
       toaster.pop('error', 'failed to get organism list from server');
     });
   };
-  
-  var setOrganisms = function (organisms, genotypeType) {
-    if (genotypeType === 'host' || genotypeType === 'pathogen') {
-      $scope.data.organisms = filterOrganisms(organisms, genotypeType);
-    } else {
-      $scope.data.organisms = organisms;
-    }
-  };
-  
+
   var setSelectedOrganism = function () {
     if ($scope.data.organisms.length === 1) {
       $scope.data.selectedOrganism = $scope.organisms[0];
@@ -3579,12 +3577,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     return $scope.selectedOrganism;
   };
   
-  $scope.reloadOrganisms = function () {
-    setOrganisms(getOrganismsFromServer(), $scope.genotypeType);
-    setSelectedOrganism();
-  };
-  
-  $scope.reloadOrganisms();
+  $scope.getOrganismsFromServer();
 };
 
 canto.directive('organismSelector', [

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3526,8 +3526,7 @@ var organismSelector = function ($http, Curs, toaster, CantoGlobals, CantoConfig
   return {
     scope: {
       selectedOrganism: '=',
-      genotypeType: '<',
-      label: '@',
+      genotypeType: '<'
     },
     restrict: 'E',
     templateUrl: app_static_path + 'ng_templates/organism_selector.html',
@@ -3541,6 +3540,15 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   
   $scope.data = {
     organisms: null,
+  };
+  
+  var setLabelText = function (genotypeType) {
+    var calculateLabelText = function (genotypeType) {
+      return genotypeType === 'host' || genotypeType === 'pathogen'
+        ? capitalizeFirstLetter(genotypeType)
+        : 'Organism';
+    };
+    $scope.label = calculateLabelText(genotypeType);
   };
 
   var filterOrganisms = function (organisms, genotypeType) {
@@ -3578,6 +3586,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   };
   
   $scope.getOrganismsFromServer($scope.genotypeType);
+  setLabelText($scope.genotypeType);
 };
 
 canto.directive('organismSelector', [

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3537,6 +3537,8 @@ var organismSelector = function (Curs, toaster, CantoGlobals, CantoConfig) {
 
 var organismSelectorCtrl = function ($scope) {
   
+  $scope.app_static_path = CantoGlobals.app_static_path;
+  
   $scope.data = {
     organisms: null,
   };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3535,7 +3535,7 @@ var organismSelector = function ($http, Curs, toaster, CantoGlobals, CantoConfig
   };
 };
 
-var organismSelectorCtrl = function ($scope) {
+var organismSelectorCtrl = function ($scope, Curs) {
   
   $scope.app_static_path = CantoGlobals.app_static_path;
   

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3570,7 +3570,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   };
   
   var setSelectedOrganism = function () {
-    if ($scope.data.organisms.length == 1) {
+    if ($scope.data.organisms.length === 1) {
       $scope.data.selectedOrganism = $scope.organisms[0];
     }
   };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3577,7 +3577,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     return $scope.selectedOrganism;
   };
   
-  $scope.getOrganismsFromServer();
+  $scope.getOrganismsFromServer($scope.genotypeType);
 };
 
 canto.directive('organismSelector', [
@@ -3594,6 +3594,7 @@ var GenotypeGeneListCtrl =
         multiOrganismMode: '=',
         label: '@',
         selectedOrganism: '=',
+        genotypeType: '<'
       },
       restrict: 'E',
       replace: true,
@@ -3712,6 +3713,7 @@ var GenotypeGenesPanelCtrl =
       scope: {
         genotypes: '=',
         multiOrganismMode: '=',
+        genotypeType: '<',
       },
       restrict: 'E',
       replace: true,

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -1,6 +1,4 @@
 <div class="curs-genotype-gene-list">
-  SELECTED_ORGANISM: {{data.selectedOrganism}}
-
   <organism-selector
     label="Organism"
     organism-selected="organismSelected(organism)"

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -1,6 +1,9 @@
 <div class="curs-genotype-gene-list">
+  SELECTED_ORGANISM: {{data.selectedOrganism}}
+
   <organism-selector
     label="Organism"
+    selected-organism="data.selectedOrganism"
     genotype-type="genotypeType" />
   <div class="curs-genotype-edit-gene-list"
        ng-if="getSelectedOrganism()">

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -1,5 +1,7 @@
 <div class="curs-genotype-gene-list">
-  <organism-selector></organism-selector>
+  <organism-selector
+    label="Organism"
+    genotype-type="genotypeType" />
   <div class="curs-genotype-edit-gene-list"
        ng-if="getSelectedOrganism()">
     <span ng-show="multiOrganismMode">

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -1,10 +1,6 @@
 <div class="curs-genotype-gene-list" ng-show="organisms">
   <div ng-show="!getSelectedOrganism()">
-    <span ng-show="label">{{label}}</span>
-    <select name="select-organism" ng-model="data.selectedOrganism"
-            ng-options="o as o.full_name for o in organisms">
-      <option value="">Select an organism ...</option>
-    </select>
+    <organism-selector></organism-selector>
   </div>
   <div class="curs-genotype-edit-gene-list"
        ng-if="getSelectedOrganism()">

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -3,8 +3,8 @@
 
   <organism-selector
     label="Organism"
-    selected-organism="data.selectedOrganism"
-    genotype-type="genotypeType" />
+    organism-selected="organismSelected(organism)"
+    genotype-type="genotypeType"></organism-selector>
   <div class="curs-genotype-edit-gene-list"
        ng-if="getSelectedOrganism()">
     <span ng-show="multiOrganismMode">

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -1,7 +1,5 @@
-<div class="curs-genotype-gene-list" ng-show="organisms">
-  <div ng-show="!getSelectedOrganism()">
-    <organism-selector></organism-selector>
-  </div>
+<div class="curs-genotype-gene-list">
+  <organism-selector></organism-selector>
   <div class="curs-genotype-edit-gene-list"
        ng-if="getSelectedOrganism()">
     <span ng-show="multiOrganismMode">

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -5,15 +5,6 @@
     genotype-type="genotypeType"></organism-selector>
   <div class="curs-genotype-edit-gene-list"
        ng-if="getSelectedOrganism()">
-    <span ng-show="multiOrganismMode">
-      <span ng-show="label">{{label}}</span>
-      <span style="font-size: 90%; font-weight: bold;">
-        {{getSelectedOrganism().full_name}}
-      </span>
-      <span ng-show="organisms.length != 1">
-        (<a ng-click="data.selectedOrganism = null">change ...</a>)
-      </span>
-    </span>
     <table class="list" ng-if="selectedOrganismGenes().length > 0">
       <thead>
         <tr>

--- a/root/static/ng_templates/genotype_genes_panel.html
+++ b/root/static/ng_templates/genotype_genes_panel.html
@@ -1,14 +1,7 @@
 <div>
-  <div ng-if="!data.organisms">
-    <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img>
-    loading organisms ...
-  </div>
-  <div ng-if="data.organisms">
-    <div ng-if="data.organisms.length != 0">
       <genotype-gene-list genotypes="genotypes" organisms="data.organisms"
                           multi-organism-mode="multiOrganismMode">
       </genotype-gene-list>
-    </div>
     <a ng-click="openSingleGeneAddDialog()">Add another gene ...</a>
   </div>
 </div>

--- a/root/static/ng_templates/genotype_genes_panel.html
+++ b/root/static/ng_templates/genotype_genes_panel.html
@@ -1,7 +1,9 @@
 <div>
-      <genotype-gene-list genotypes="genotypes" organisms="data.organisms"
-                          multi-organism-mode="multiOrganismMode">
-      </genotype-gene-list>
+      <genotype-gene-list
+        genotypes="genotypes"
+        organisms="data.organisms"
+        multi-organism-mode="multiOrganismMode"
+        genotype-type="genotypeType" />
     <a ng-click="openSingleGeneAddDialog()">Add another gene ...</a>
   </div>
 </div>

--- a/root/static/ng_templates/genotype_genes_panel.html
+++ b/root/static/ng_templates/genotype_genes_panel.html
@@ -1,9 +1,9 @@
 <div>
-      <genotype-gene-list
-        genotypes="genotypes"
-        organisms="data.organisms"
-        multi-organism-mode="multiOrganismMode"
-        genotype-type="genotypeType" />
+    <genotype-gene-list
+      genotypes="genotypes"
+      organisms="data.organisms"
+      multi-organism-mode="multiOrganismMode"
+      genotype-type="genotypeType">
+    </genotype-gene-list>
     <a ng-click="openSingleGeneAddDialog()">Add another gene ...</a>
-  </div>
 </div>

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -32,7 +32,10 @@
             <div class="row">
                 <div ng-if="!read_only_curs">
                     <div class="col-sm-3 col-md-3">
-                        <genotype-genes-panel genotypes="data.genotypes" multi-organism-mode="data.multiOrganismMode" />
+                        <genotype-genes-panel
+                          genotypes="data.genotypes"
+                          multi-organism-mode="data.multiOrganismMode"
+                          genotype-type="genotypeType" />
                     </div>
                 </div>
 

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -11,5 +11,5 @@
       ng-options="o as o.full_name for o in data.organisms">
     <option value="">Select an organism...</option>
   </select>
-  <p ng-if="data.organisms.length === 1">{{selectedOrganism.full_name}}</p>
+  <span ng-if="data.organisms.length === 1">{{data.defaultOrganism.full_name}}</span>
 </div>

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -3,7 +3,7 @@
   loading organisms ...
 </div>
 <div class="curs-organism-selector" ng-if="data.organisms">
-  <span ng-show="label">{{label}}</span>
+  <span class="curs-organism-selector-label">{{label}}</span>
   <select
       name="select-organism"
       ng-model="selectedOrganism"

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -3,7 +3,7 @@
   Loading organisms...
 </div>
 <div class="curs-organism-selector" ng-if="data.organisms">
-  <b class="curs-organism-selector-label">{{label}}</b>
+  <p class="curs-organism-selector-label"><b>{{label}}</b></p>
   <select ng-if="data.organisms.length > 1"
       name="select-organism"
       ng-model="selectedOrganism"

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -6,9 +6,10 @@
   <b class="curs-organism-selector-label">{{label}}</b>
   <select ng-if="data.organisms.length > 1"
       name="select-organism"
-      ng-model="selectedOrganism"
+      ng-model="data.selected"
+      ng-change="selectionChanged()"
       ng-options="o as o.full_name for o in data.organisms">
     <option value="">Select an organism...</option>
   </select>
-  <p ng-if="data.organisms.length === 1">{{data.getSelectedOrganism().full_name}}</p>
+  <p ng-if="data.organisms.length === 1">{{selectedOrganism.full_name}}</p>
 </div>

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -1,6 +1,6 @@
 <div ng-if="!data.organisms">
   <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img>
-  loading organisms ...
+  Loading organisms...
 </div>
 <div class="curs-organism-selector" ng-if="data.organisms">
   <span class="curs-organism-selector-label">{{label}}</span>

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -1,0 +1,9 @@
+<div class="curs-organism-selector">
+  <span ng-show="label">{{label}}</span>
+  <select
+      name="select-organism"
+      ng-model="selectedOrganism"
+      ng-options="o as o.full_name for o in organisms">
+    <option value="">Select an organism...</option>
+  </select>
+</div>

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -1,4 +1,8 @@
-<div class="curs-organism-selector">
+<div ng-if="!data.organisms">
+  <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img>
+  loading organisms ...
+</div>
+<div class="curs-organism-selector" ng-if="data.organisms">
   <span ng-show="label">{{label}}</span>
   <select
       name="select-organism"

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -6,8 +6,8 @@
   <b class="curs-organism-selector-label">{{label}}</b>
   <select ng-if="data.organisms.length > 1"
       name="select-organism"
-      ng-model="data.selected"
-      ng-change="selectionChanged()"
+      ng-model="selectedOrganism"
+      ng-change="organismChanged()"
       ng-options="o as o.full_name for o in data.organisms">
     <option value="">Select an organism...</option>
   </select>

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -3,11 +3,12 @@
   Loading organisms...
 </div>
 <div class="curs-organism-selector" ng-if="data.organisms">
-  <span class="curs-organism-selector-label">{{label}}</span>
-  <select
+  <b class="curs-organism-selector-label">{{label}}</b>
+  <select ng-if="data.organisms.length > 1"
       name="select-organism"
       ng-model="selectedOrganism"
       ng-options="o as o.full_name for o in data.organisms">
     <option value="">Select an organism...</option>
   </select>
+  <p ng-if="data.organisms.length === 1">{{data.getSelectedOrganism().full_name}}</p>
 </div>

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -3,7 +3,7 @@
   <select
       name="select-organism"
       ng-model="selectedOrganism"
-      ng-options="o as o.full_name for o in organisms">
+      ng-options="o as o.full_name for o in data.organisms">
     <option value="">Select an organism...</option>
   </select>
 </div>


### PR DESCRIPTION
(Implements #1558)

This PR extracts the organism selector from `genotype_gene_list.html` into its own directive `organismSelector` (with controller `organismSelectorCtrl` and template `organism_selector.html`).

The new organism selector is responsible for getting its own list of organisms, and it sends the selected organism back to its parent controller using the callback `organismSelected(organism)`. The selector seems to work on the Genotype Management page, but hasn't been tested on the Meta-genotype Management page yet. It should work as expected as long as the controller for the containing directive implements the `organismSelected` method.

Note that this new selector behaves somewhat differently to the old one: the drop-down isn't hidden when an organism is selected, except when there is only one organism in the list. @kimrutherford I'm not sure if you'll be happy with this, but it was the only way I could handle the display of the 'default' organism name in the case where there was only one organism.

@kimrutherford Also, there are conflicting changes in the **pombase/add-organism-selector** branch, which is why I've chosen to merge into **pombase/metagenotype-dev**.