### PR TITLE
Fix gene list not updating when using gene adding shortcut

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3527,7 +3527,8 @@ var organismSelector = function ($http, Curs, toaster, CantoGlobals, CantoConfig
     scope: {
       selectedOrganism: '=',
       organismSelected: '&',
-      genotypeType: '<'
+      genotypeType: '<',
+      lastAddedGene: '<'
     },
     restrict: 'E',
     templateUrl: app_static_path + 'ng_templates/organism_selector.html',
@@ -3543,6 +3544,12 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     organisms: null,
     defaultOrganism: null
   };
+
+  $scope.$watch('lastAddedGene', function () {
+    if ($scope.lastAddedGene) {
+      $scope.getOrganismsFromServer($scope.genotypeType);
+    }
+  });
 
   $scope.organismChanged = function (organism) {
     $scope.organismSelected({organism: this.selectedOrganism});
@@ -3610,7 +3617,8 @@ var GenotypeGeneListCtrl =
         organisms: '=',
         multiOrganismMode: '=',
         label: '@',
-        genotypeType: '<'
+        genotypeType: '<',
+        lastAddedGene: '<'
       },
       restrict: 'E',
       replace: true,
@@ -3738,6 +3746,7 @@ var GenotypeGenesPanelCtrl =
         genotypes: '=',
         multiOrganismMode: '=',
         genotypeType: '<',
+        lastAddedGene: '<'
       },
       restrict: 'E',
       replace: true,
@@ -3748,8 +3757,8 @@ var GenotypeGenesPanelCtrl =
 
         $scope.openSingleGeneAddDialog = function() {
           var modal = openSingleGeneAddDialog($uibModal);
-          modal.result.then(function () {
-            $scope.getOrganismsFromServer();
+          modal.result.then(function (geneObj) {
+            $scope.lastAddedGene = geneObj.new_gene_id;
           });
         };
       }

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -2,7 +2,9 @@
   <organism-selector
     label="Organism"
     organism-selected="organismSelected(organism)"
-    genotype-type="genotypeType"></organism-selector>
+    genotype-type="genotypeType"
+    last-added-gene="lastAddedGene">
+  </organism-selector>
   <div class="curs-genotype-edit-gene-list"
        ng-if="getSelectedOrganism()">
     <table class="list" ng-if="selectedOrganismGenes().length > 0">

--- a/root/static/ng_templates/genotype_genes_panel.html
+++ b/root/static/ng_templates/genotype_genes_panel.html
@@ -3,7 +3,8 @@
       genotypes="genotypes"
       organisms="data.organisms"
       multi-organism-mode="multiOrganismMode"
-      genotype-type="genotypeType">
+      genotype-type="genotypeType"
+      last-added-gene="lastAddedGene">
     </genotype-gene-list>
     <a ng-click="openSingleGeneAddDialog()">Add another gene ...</a>
 </div>


### PR DESCRIPTION
(Fixes #1565)

Previously, `organismSelectorCtrl` was not refreshing the list of organisms after a gene was added on the genotype management page by the 'Add another gene...' link. This was previously the responsibility of `GenotypeGenesPanelCtrl` &ndash; I've moved it to `organismSelectorCtrl` instead.

`organismSelector` now has a binding to `lastAddedGene`, which is set in 
`GenotypeGenesPanelCtrl` by `openSingleGeneAddDialog()`, and then passed from 
`GenotypeGenesPanelCtrl` to `GenotypeGeneListCtrl`, and finally to 
`organismSelector`. The `organismSelector` has a `$watch` on `lastAddedGene`, and when it notices a change, it reloads the list of organisms from the server.

Note that currently the selection on the  `<select>` element in `organismSelector` gets reset 
by this process, which isn't ideal, but I haven't figured out a fix for this yet.