### PR TITLE
Fix undefined error in setSingleAllele and setMultiAllele

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6242,15 +6242,29 @@ var metagenotypeGenotypePicker =
           };
 
           $scope.setSingleAllele = function () {
-            $scope.data.singleAllele =  $scope.data.genotypes.filter(function (e) {
-              return ((e.organism.taxonid === $scope.data.selectedOrganism.taxonid) && (e.alleles.length === 1));
-            });
+            if ($scope.data.selectedOrganism == null) {
+              $scope.data.singleAllele = [];
+            } else {
+              $scope.data.singleAllele =  $scope.data.genotypes.filter(function (e) {
+                return (
+                  (e.organism.taxonid === $scope.data.selectedOrganism.taxonid)
+                  && (e.alleles.length === 1)
+                );
+              });
+            }
           }
 
           $scope.setMultiAllele = function () {
+            if ($scope.data.selectedOrganism == null) {
+              $scope.data.multiAllele = [];
+            } else {
               $scope.data.multiAllele = $scope.data.genotypes.filter(function (e) {
-              return ((e.organism.taxonid === $scope.data.selectedOrganism.taxonid) && (e.alleles.length > 1));
-            });
+                return (
+                  (e.organism.taxonid === $scope.data.selectedOrganism.taxonid)
+                  && (e.alleles.length > 1)
+                );
+              });
+            }
           }
 
           $scope.setWildtypeOrganism = function () {


### PR DESCRIPTION
The functions `setSingleAllele` and `setMultiAllele` didn't have any tests to guard against `selectedOrganism` being null or undefined. This commit fixes that by using the _abstract equality operator_ to test for both cases at once:

```js
if ($scope.data.selectedOrganism == null) {...}
```

If the test passes, the genotype lists are set to the empty list.