### PR TITLE
Automatically select organisms when adding genes

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3541,7 +3541,6 @@ canto.controller('MetagenotypeViewCtrl',
 var organismSelector = function ($http, Curs, toaster, CantoGlobals, CantoConfig) {
   return {
     scope: {
-      selectedOrganism: '=',
       organismSelected: '&',
       genotypeType: '<',
       lastAddedGene: '<',
@@ -3558,6 +3557,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   $scope.app_static_path = CantoGlobals.app_static_path;
 
   $scope.data = {
+    selectedOrganism: null,
     organisms: null,
     defaultOrganism: null
   };
@@ -3569,7 +3569,9 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   });
 
   $scope.organismChanged = function (organism) {
-    $scope.organismSelected({organism: this.selectedOrganism});
+    $scope.organismSelected({
+      organism: $scope.data.selectedOrganism
+    });
   };
 
   var setLabelText = function (genotypeType) {
@@ -3612,7 +3614,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
       $scope.data.defaultOrganism = $scope.data.organisms[0];
       organismToSet = $scope.data.defaultOrganism;
     } else {
-      organismToSet = $scope.selectedOrganism;
+      organismToSet = $scope.data.selectedOrganism;
     }
     $scope.organismSelected({organism: organismToSet});
   };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3638,8 +3638,15 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
       var filteredOrganisms = filterOrganisms(organisms, genotypeType);
       var defaultOrganism = getDefaultOrganism(filteredOrganisms);
       setOrganisms(filteredOrganisms);
-      reloadSelectedOrganism(selectedOrganism, filteredOrganisms, lastAddedGene);
-      setDefaultOrganism(defaultOrganism);
+      if (defaultOrganism) {
+        setDefaultOrganism(defaultOrganism);
+      } else {
+        reloadSelectedOrganism(
+          selectedOrganism,
+          filteredOrganisms,
+          lastAddedGene
+        );
+      }
     }).error(function () {
       toaster.pop('error', 'failed to get organism list from server');
     });

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3622,9 +3622,10 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   var reloadOrganisms = function (selectedOrganism, genotypeType) {
     getOrganisms().success(function (organisms) {
       var filteredOrganisms = filterOrganisms(organisms, genotypeType);
+      var defaultOrganism = getDefaultOrganism(filteredOrganisms);
       setOrganisms(filteredOrganisms);
       reloadSelectedOrganism(selectedOrganism, filteredOrganisms);
-      setDefaultOrganism();
+      setDefaultOrganism(defaultOrganism);
     }).error(function() {
       toaster.pop('error', 'failed to get organism list from server');
     });
@@ -3644,10 +3645,14 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     return newSelectedOrganism;
   };
 
-  var setDefaultOrganism = function () {
-    if ($scope.data.organisms.length === 1) {
-      var defaultOrganism = $scope.data.organisms[0];
-      $scope.data.defaultOrganism = defaultOrganism
+  var getDefaultOrganism = function (organisms) {
+    return organisms.length === 1 ? organisms[0] : null;
+  };
+
+  var setDefaultOrganism = function (defaultOrganism) {
+    $scope.data.defaultOrganism = defaultOrganism;
+    // we must check for null, or the default organism will always be set
+    if (defaultOrganism) {
       $scope.organismSelected({organism: defaultOrganism});
     }
   };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3590,6 +3590,9 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   };
 
   var filterOrganisms = function (organisms, genotypeType) {
+    if (genotypeType !== 'host' && genotypeType !== 'pathogen') {
+      return organisms;
+    }
     var buildOrganismFilter = function (type) {
       return function (organism) {
         return organism['pathogen_or_host'] === type;
@@ -3610,12 +3613,10 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   var reloadOrganisms = function (genotypeType) {
     getOrganisms().success(function (organisms) {
       setOrganisms(organisms);
-      if (genotypeType === 'host' || genotypeType === 'pathogen') {
-        $scope.data.organisms = filterOrganisms(
-          $scope.data.organisms,
-          genotypeType
-        );
-      }
+      $scope.data.organisms = filterOrganisms(
+        $scope.data.organisms,
+        genotypeType
+      );
       if ($scope.data.selectedOrganism) {
         $scope.data.selectedOrganism = getNewSelectedOrganism(
           $scope.data.selectedOrganism,

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3609,7 +3609,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
         );
         $scope.organismSelected({organism: $scope.data.selectedOrganism});
       }
-      // setSelectedOrganism();
+      setDefaultOrganism();
     }).error(function() {
       toaster.pop('error', 'failed to get organism list from server');
     });
@@ -3629,15 +3629,12 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     return newSelectedOrganism;
   };
 
-  var setSelectedOrganism = function () {
-    var organismToSet;
+  var setDefaultOrganism = function () {
     if ($scope.data.organisms.length === 1) {
-      $scope.data.defaultOrganism = $scope.data.organisms[0];
-      organismToSet = $scope.data.defaultOrganism;
-    } else {
-      organismToSet = $scope.data.selectedOrganism;
+      var defaultOrganism = $scope.data.organisms[0];
+      $scope.data.defaultOrganism = defaultOrganism
+      $scope.organismSelected({organism: defaultOrganism});
     }
-    $scope.organismSelected({organism: organismToSet});
   };
 
   $scope.data.hideLabel = $scope.hideLabel || false;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3608,8 +3608,8 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   };
 
   var reloadOrganisms = function (genotypeType) {
-    getOrganisms().success(function(response) {
-      setOrganisms(response);
+    getOrganisms().success(function (organisms) {
+      setOrganisms(organisms);
       if (genotypeType === 'host' || genotypeType === 'pathogen') {
         $scope.data.organisms = filterOrganisms(
           $scope.data.organisms,

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3599,8 +3599,12 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     return organisms.filter(byOrganismType);
   };
 
+  var getOrganisms = function () {
+    return Curs.list('organism');
+  };
+
   var reloadOrganisms = function (genotypeType) {
-    Curs.list('organism').success(function(response) {
+    getOrganisms().success(function(response) {
       $scope.data.organisms = response;
       if (genotypeType === 'host' || genotypeType === 'pathogen') {
         $scope.data.organisms = filterOrganisms(

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3602,7 +3602,14 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
           genotypeType
         );
       }
-      setSelectedOrganism();
+      if ($scope.data.selectedOrganism) {
+        $scope.data.selectedOrganism = getNewSelectedOrganism(
+          $scope.data.selectedOrganism,
+          $scope.data.organisms
+        );
+        $scope.organismSelected({organism: $scope.data.selectedOrganism});
+      }
+      // setSelectedOrganism();
     }).error(function() {
       toaster.pop('error', 'failed to get organism list from server');
     });
@@ -3618,7 +3625,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     var newSelectedOrganism = $.grep(
       organisms,
       finder('taxonid', previousTaxonId)
-    );
+    )[0];
     return newSelectedOrganism;
   };
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3612,11 +3612,8 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
 
   var reloadOrganisms = function (genotypeType) {
     getOrganisms().success(function (organisms) {
-      setOrganisms(organisms);
-      $scope.data.organisms = filterOrganisms(
-        $scope.data.organisms,
-        genotypeType
-      );
+      var filteredOrganisms = filterOrganisms(organisms, genotypeType)
+      setOrganisms(filteredOrganisms);
       if ($scope.data.selectedOrganism) {
         $scope.data.selectedOrganism = getNewSelectedOrganism(
           $scope.data.selectedOrganism,

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3564,7 +3564,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
 
   $scope.$watch('lastAddedGene', function () {
     if ($scope.lastAddedGene) {
-      $scope.getOrganismsFromServer($scope.genotypeType);
+      reloadOrganisms($scope.genotypeType);
     }
   });
 
@@ -3576,7 +3576,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
 
   var onInit = function () {
     $scope.data.hideLabel = $scope.hideLabel || false;
-    $scope.getOrganismsFromServer($scope.genotypeType);
+    reloadOrganisms($scope.genotypeType);
     setLabelText($scope.genotypeType);
   };
 
@@ -3599,7 +3599,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     return organisms.filter(byOrganismType);
   };
 
-  $scope.getOrganismsFromServer = function (genotypeType) {
+  var reloadOrganisms = function (genotypeType) {
     Curs.list('organism').success(function(response) {
       $scope.data.organisms = response;
       if (genotypeType === 'host' || genotypeType === 'pathogen') {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3610,17 +3610,20 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     $scope.data.organisms = organisms;
   };
 
+  var reloadSelectedOrganism = function (previousOrganism, organisms) {
+    if (! previousOrganism) {
+      return;
+    }
+    var newOrganism = getNewSelectedOrganism(previousOrganism, organisms);
+    $scope.data.selectedOrganism = newOrganism;
+    $scope.organismSelected({organism: $scope.data.selectedOrganism});
+  };
+
   var reloadOrganisms = function (genotypeType) {
     getOrganisms().success(function (organisms) {
       var filteredOrganisms = filterOrganisms(organisms, genotypeType)
       setOrganisms(filteredOrganisms);
-      if ($scope.data.selectedOrganism) {
-        $scope.data.selectedOrganism = getNewSelectedOrganism(
-          $scope.data.selectedOrganism,
-          $scope.data.organisms
-        );
-        $scope.organismSelected({organism: $scope.data.selectedOrganism});
-      }
+      reloadSelectedOrganism(previousOrganism, filteredOrganisms);
       setDefaultOrganism();
     }).error(function() {
       toaster.pop('error', 'failed to get organism list from server');

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3608,6 +3608,20 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     });
   };
 
+  var getNewSelectedOrganism = function (previousOrganism, organisms) {
+    var finder = function(key, value) {
+      return function (obj) {
+        return obj[key] === value;
+      };
+    };
+    var previousTaxonId = previousOrganism.taxonid;
+    var newSelectedOrganism = $.grep(
+      organisms,
+      finder('taxonid', previousTaxonId)
+    );
+    return newSelectedOrganism;
+  };
+
   var setSelectedOrganism = function () {
     var organismToSet;
     if ($scope.data.organisms.length === 1) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3658,8 +3658,8 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     var findOrganismWithLastAddedGene = function (organisms, geneId) {
       var i, j, organism, genes, gene;
 
-      // simple 'for' loops are helpful here, since we should break out of the
-      // loop as soon as the gene is found.
+      // simple 'for' loops are helpful here: we can break out of the
+      // loop as soon as the gene is found, since the gene ID is unique.
       for (i = 0; i < organisms.length; i += 1) {
         organism = organisms[i];
         genes = organism.genes;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3626,7 +3626,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
       setOrganisms(filteredOrganisms);
       reloadSelectedOrganism(selectedOrganism, filteredOrganisms);
       setDefaultOrganism(defaultOrganism);
-    }).error(function() {
+    }).error(function () {
       toaster.pop('error', 'failed to get organism list from server');
     });
   };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3574,6 +3574,12 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     });
   };
 
+  var onInit = function () {
+    $scope.data.hideLabel = $scope.hideLabel || false;
+    $scope.getOrganismsFromServer($scope.genotypeType);
+    setLabelText($scope.genotypeType);
+  };
+
   var setLabelText = function (genotypeType) {
     var calculateLabelText = function (genotypeType) {
       return genotypeType === 'host' || genotypeType === 'pathogen'
@@ -3637,10 +3643,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     }
   };
 
-  $scope.data.hideLabel = $scope.hideLabel || false;
-
-  $scope.getOrganismsFromServer($scope.genotypeType);
-  setLabelText($scope.genotypeType);
+  onInit();
 };
 
 canto.directive('organismSelector', [

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3655,6 +3655,20 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   var getNewSelectedOrganism = function (previousOrganism, organisms, lastAddedGene) {
     var newOrganism = null;
 
+    var refreshPreviousOrganism = function (previousOrganism, organisms) {
+      var finder = function(key, value) {
+        return function (obj) {
+          return obj[key] === value;
+        };
+      };
+      var previousTaxonId = previousOrganism.taxonid;
+      var newSelectedOrganism = $.grep(
+        organisms,
+        finder('taxonid', previousTaxonId)
+      )[0];
+      return newSelectedOrganism;
+    };
+
     var findOrganismWithLastAddedGene = function (organisms, geneId) {
       var i, j, organism, genes, gene;
 
@@ -3682,8 +3696,12 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     if (previousOrganism) {
       // check the previously selected organism first, assuming the user is
       // more likely to add genes for the selected organism.
+      var newPreviousOrganism = refreshPreviousOrganism(
+        previousOrganism,
+        organisms
+      );
       newOrganism = findOrganismWithLastAddedGene(
-        [previousOrganism],
+        [newPreviousOrganism],
         lastAddedGene
       );
     }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3619,13 +3619,17 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   };
 
   var reloadSelectedOrganism = function (previousOrganism, organisms, lastAddedGene) {
-    if (! previousOrganism) {
-      return;
+    var selectedOrganism;
+    // if lastAddedGene is undefined, then the page has just been loaded,
+    // so no organism should be selected.
+    if (lastAddedGene === undefined) {
+      selectedOrganism = null;
+    } else {
+      selectedOrganism = getNewSelectedOrganism(
+        previousOrganism, organisms, lastAddedGene
+      );
     }
-    var newOrganism = getNewSelectedOrganism(
-      previousOrganism, organisms, lastAddedGene
-    );
-    $scope.data.selectedOrganism = newOrganism;
+    $scope.data.selectedOrganism = selectedOrganism;
     $scope.organismSelected({organism: $scope.data.selectedOrganism});
   };
 
@@ -3642,9 +3646,11 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
   };
 
   var getNewSelectedOrganism = function (previousOrganism, organisms, lastAddedGene) {
+    var newOrganism = null;
 
     var findOrganismWithLastAddedGene = function (organisms, geneId) {
       var i, j, organism, genes, gene;
+
       // simple 'for' loops are helpful here, since we should break out of the
       // loop as soon as the gene is found.
       for (i = 0; i < organisms.length; i += 1) {
@@ -3666,14 +3672,18 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
       };
     };
 
-    // check the previously selected organism first, assuming the user is more
-    // likely to add genes for the selected organism.
-    var newOrganism = findOrganismWithLastAddedGene(
-      [previousOrganism],
-      lastAddedGene
-    );
+    if (previousOrganism) {
+      // check the previously selected organism first, assuming the user is
+      // more likely to add genes for the selected organism.
+      newOrganism = findOrganismWithLastAddedGene(
+        [previousOrganism],
+        lastAddedGene
+      );
+    }
     if (! newOrganism) {
-      var remainingOrganisms = organisms.filter(excluding(previousOrganism));
+      var remainingOrganisms = previousOrganism
+        ? organisms.filter(excluding(previousOrganism))
+        : organisms;
       newOrganism = findOrganismWithLastAddedGene(
         remainingOrganisms,
         lastAddedGene

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3621,6 +3621,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
 
   var reloadOrganisms = function (genotypeType) {
     getOrganisms().success(function (organisms) {
+      var previousOrganism = angular.copy($scope.data.selectedOrganism);
       var filteredOrganisms = filterOrganisms(organisms, genotypeType)
       setOrganisms(filteredOrganisms);
       reloadSelectedOrganism(previousOrganism, filteredOrganisms);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3564,7 +3564,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
 
   $scope.$watch('lastAddedGene', function () {
     if ($scope.lastAddedGene) {
-      reloadOrganisms($scope.genotypeType);
+      reloadOrganisms($scope.data.selectedOrganism, $scope.genotypeType);
     }
   });
 
@@ -3576,7 +3576,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
 
   var onInit = function () {
     $scope.data.hideLabel = $scope.hideLabel || false;
-    reloadOrganisms($scope.genotypeType);
+    reloadOrganisms($scope.data.selectedOrganism, $scope.genotypeType);
     setLabelText($scope.genotypeType);
   };
 
@@ -3619,12 +3619,11 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     $scope.organismSelected({organism: $scope.data.selectedOrganism});
   };
 
-  var reloadOrganisms = function (genotypeType) {
+  var reloadOrganisms = function (selectedOrganism, genotypeType) {
     getOrganisms().success(function (organisms) {
-      var previousOrganism = angular.copy($scope.data.selectedOrganism);
-      var filteredOrganisms = filterOrganisms(organisms, genotypeType)
+      var filteredOrganisms = filterOrganisms(organisms, genotypeType);
       setOrganisms(filteredOrganisms);
-      reloadSelectedOrganism(previousOrganism, filteredOrganisms);
+      reloadSelectedOrganism(selectedOrganism, filteredOrganisms);
       setDefaultOrganism();
     }).error(function() {
       toaster.pop('error', 'failed to get organism list from server');

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3603,9 +3603,13 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     return Curs.list('organism');
   };
 
+  var setOrganisms = function (organisms) {
+    $scope.data.organisms = organisms;
+  };
+
   var reloadOrganisms = function (genotypeType) {
     getOrganisms().success(function(response) {
-      $scope.data.organisms = response;
+      setOrganisms(response);
       if (genotypeType === 'host' || genotypeType === 'pathogen') {
         $scope.data.organisms = filterOrganisms(
           $scope.data.organisms,

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3633,7 +3633,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
     $scope.organismSelected({organism: $scope.data.selectedOrganism});
   };
 
-  var reloadOrganisms = function (selectedOrganism, genotypeType, lastAddedGene) {
+  var reloadOrganisms = function (oldSelectedOrganism, genotypeType, lastAddedGene) {
     getOrganisms().success(function (organisms) {
       var filteredOrganisms = filterOrganisms(organisms, genotypeType);
       var defaultOrganism = getDefaultOrganism(filteredOrganisms);
@@ -3642,7 +3642,7 @@ var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
         setDefaultOrganism(defaultOrganism);
       } else {
         reloadSelectedOrganism(
-          selectedOrganism,
+          oldSelectedOrganism,
           filteredOrganisms,
           lastAddedGene
         );

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -8,7 +8,7 @@
       name="select-organism"
       ng-model="data.selectedOrganism"
       ng-change="organismChanged()"
-      ng-options="o as o.full_name for o in data.organisms">
+      ng-options="o as o.full_name for o in data.organisms track by o.taxonid">
     <option value="">Select an organism...</option>
   </select>
   <span ng-if="data.organisms.length === 1">{{data.defaultOrganism.full_name}}</span>

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -6,7 +6,7 @@
   <p ng-hide="data.hideLabel" class="curs-organism-selector-label"><b>{{label}}</b></p>
   <select ng-if="data.organisms.length > 1"
       name="select-organism"
-      ng-model="selectedOrganism"
+      ng-model="data.selectedOrganism"
       ng-change="organismChanged()"
       ng-options="o as o.full_name for o in data.organisms">
     <option value="">Select an organism...</option>


### PR DESCRIPTION
(Fixes #1571)
(Might be related to #1600)

This fixes multiple issues with the interaction between the organism selector and the 'Add another gene' shortcut on the genotype management page.

Now, the organism selector will always change its selection to the organism that corresponds to the gene that is added. This works even if the newly added gene corresponds to an organism that is not in the session (the modal that adds the gene also adds the organism, and the new organism is fetched when the organism selector reloads its organism list). 

I've tested this under the following cases:

✓ Adding a new gene to an **unselected** organism with **zero genes**.
✓ Adding a new gene to an **unselected** organism with **one gene**.

✓ Adding a new gene to the **selected** organism with **zero genes**.
✓ Adding a new gene to the **selected** organism with **one gene**.

✓ Adding a new gene to the **default** organism with **zero genes**.
✓ Adding a new gene to the **default** organism with **one gene**.

✓ Adding a new gene to a **new** organism (that wasn't in the session).

**Note**: I also tested the changes on the metagenotype management page, but I'm getting a strange bug there where the gene list isn't updating to match the selected organism. I don’t think the problem was caused by the changes in this PR, since it still occurs on the latest checkout of `pombase:metagenotype-dev`, but maybe we shouldn't merge this until that problem is resolved. I've opened an issue about this at #1600.