### PR TITLE
Filter Genotype Management genotype list by selected organism

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4002,10 +4002,20 @@ var genotypeManageCtrl =
 
     var setGenotypes = function (genotypes) {
       $scope.data.genotypeMap = mapGenotypes(genotypes);
-      var selectedOrganismId = $scope.data.selectedOrganism.taxonid;
-      var currentGenotypes = $scope.data.genotypeMap[selectedOrganismId];
-      $scope.data.singleAlleleGenotypes = currentGenotypes['singleAlleleGenotypes'];
-      $scope.data.multiAlleleGenotypes = currentGenotypes['multiAlleleGenotypes'];
+      updateGenotypeLists();
+    };
+
+    var updateGenotypeLists = function () {
+      var selectedOrganism = $scope.data.selectedOrganism;
+      if (!selectedOrganism) {
+        $scope.data.singleAlleleGenotypes = [];
+        $scope.data.multiAlleleGenotypes = [];
+      } else {
+        var selectedOrganismId = $scope.data.selectedOrganism.taxonid;
+        var currentGenotypes = $scope.data.genotypeMap[selectedOrganismId];
+        $scope.data.singleAlleleGenotypes = currentGenotypes['singleAlleleGenotypes'];
+        $scope.data.multiAlleleGenotypes = currentGenotypes['multiAlleleGenotypes'];
+      }
     };
 
     $scope.backToSummary = function() {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4042,7 +4042,7 @@ var genotypeManageCtrl =
         var taxonId = genotype.organism.taxonid;
         if ( ! (taxonId in genotypeMap)) {
           genotypeMap[taxonId] = {
-            singleAlleGenotypes: [],
+            singleAlleleGenotypes: [],
             multiAlleleGenotypes: []
           };
         }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3934,6 +3934,7 @@ var genotypeManageCtrl =
       editGenotypeId: null,
       multiOrganismMode: false,
       metagenotypeDissabled: true,
+      showNoGenotypeNotice: true
     };
 
     CantoConfig.get('instance_organism').success(function(results) {
@@ -4024,6 +4025,17 @@ var genotypeManageCtrl =
           $scope.data.multiAlleleGenotypes = currentGenotypes['multiAlleleGenotypes'];
         }
       }
+      updateNoGenotypeNotice();
+    };
+
+    var updateNoGenotypeNotice = function () {
+      $scope.data.showNoGenotypeNotice = (
+        $scope.data.selectedOrganism
+        && (
+          $scope.data.singleAlleleGenotypes.length === 0
+          && $scope.data.multiAlleleGenotypes.length === 0
+        )
+      );
     };
 
     $scope.backToSummary = function() {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4038,9 +4038,8 @@ var genotypeManageCtrl =
 
     var mapGenotypes = function (genotypes) {
       var genotypeMap = {};
-      var taxonId = "";
-      $.each(genotypes, function (index, genotype) {
-        taxonId = genotype.organism.taxonid;
+      var addToGenotypeMap = function (index, genotype) {
+        var taxonId = genotype.organism.taxonid;
         if ( ! (taxonId in genotypeMap)) {
           genotypeMap[taxonId] = {};
         }
@@ -4055,7 +4054,8 @@ var genotypeManageCtrl =
           }
           genotypeMap[taxonId]['multiAlleleGenotypes'].push(genotype);
         }
-      });
+      };
+      $.each(genotypes, addToGenotypeMap);
       return genotypeMap;
     };
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3990,8 +3990,7 @@ var genotypeManageCtrl =
 
     $scope.readGenotypes = function() {
       CursGenotypeList.cursGenotypeList({ include_allele: 1 }).then(function(results) {
-        $scope.data.genotypeMap = mapGenotypes(results);
-        updateGenotypeLists();
+        setGenotypes(results);
         $scope.data.waitingForServer = false;
         $scope.data.metagenotypeDissabled = ($scope.data.genotypeMap.length < 1);
         CursGenotypeList.onListChange($scope.readGenotypesCallback);
@@ -4001,25 +4000,12 @@ var genotypeManageCtrl =
       });
     };
 
-    var updateGenotypeLists = function () {
-
-      var _getOrganismGenotypes = function (type) {
-        if ($scope.data.selectedOrganism === null
-            || $scope.data.selectedOrganism === undefined) {
-          return [];
-        }
-        var currentTaxonId = $scope.data.selectedOrganism.taxonid;
-        var currentOrganismGenotypes = $scope.data.genotypeMap[currentTaxonId];
-        return currentOrganismGenotypes[type];
-      };
-
-      $scope.data.singleAlleleGenotypes = _getOrganismGenotypes(
-        'singleAlleleGenotypes'
-      );
-      $scope.data.multiAlleleGenotypes = _getOrganismGenotypes(
-        'multiAlleleGenotypes'
-      );
-
+    var setGenotypes = function (genotypes) {
+      $scope.data.genotypeMap = mapGenotypes(genotypes);
+      var selectedOrganismId = $scope.data.selectedOrganism.taxonid;
+      var currentGenotypes = $scope.data.genotypeMap[selectedOrganismId];
+      $scope.data.singleAlleleGenotypes = currentGenotypes['singleAlleleGenotypes'];
+      $scope.data.multiAlleleGenotypes = currentGenotypes['multiAlleleGenotypes'];
     };
 
     $scope.backToSummary = function() {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4041,19 +4041,15 @@ var genotypeManageCtrl =
       var addToGenotypeMap = function (index, genotype) {
         var taxonId = genotype.organism.taxonid;
         if ( ! (taxonId in genotypeMap)) {
-          genotypeMap[taxonId] = {};
+          genotypeMap[taxonId] = {
+            singleAlleGenotypes: [],
+            multiAlleleGenotypes: []
+          };
         }
-        if (isSingleAlleleGenotype(genotype)) {
-          if ( ! ('singleAlleleGenotypes' in genotypeMap[taxonId])) {
-            genotypeMap[taxonId]['singleAlleleGenotypes'] = [];
-          }
-          genotypeMap[taxonId]['singleAlleleGenotypes'].push(genotype);
-        } else {
-          if ( ! ('multiAlleleGenotypes' in genotypeMap[taxonId])) {
-            genotypeMap[taxonId]['multiAlleleGenotypes'] = [];
-          }
-          genotypeMap[taxonId]['multiAlleleGenotypes'].push(genotype);
-        }
+        var genotypeType = isSingleAlleleGenotype(genotype)
+          ? 'singleAlleleGenotypes'
+          : 'multiAlleleGenotypes';
+        genotypeMap[taxonId][genotypeType].push(genotype);
       };
       $.each(genotypes, addToGenotypeMap);
       return genotypeMap;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3746,7 +3746,8 @@ var GenotypeGeneListCtrl =
         multiOrganismMode: '=',
         label: '@',
         genotypeType: '<',
-        lastAddedGene: '<'
+        lastAddedGene: '<',
+        onOrganismSelect: '&'
       },
       restrict: 'E',
       replace: true,
@@ -3766,8 +3767,9 @@ var GenotypeGeneListCtrl =
                        $scope.makeHasDeletionHash();
                      }, true);
 
-        $scope.organismSelected = function (organism) {
+        $scope.organismUpdated = function (organism) {
           $scope.data.selectedOrganism = organism;
+          $scope.onOrganismSelect({organism: organism});
         };
 
         $scope.getSelectedOrganism = function() {
@@ -3874,7 +3876,8 @@ var GenotypeGenesPanelCtrl =
         genotypes: '=',
         multiOrganismMode: '=',
         genotypeType: '<',
-        lastAddedGene: '<'
+        lastAddedGene: '<',
+        onOrganismSelect: '&',
       },
       restrict: 'E',
       replace: true,
@@ -3888,6 +3891,10 @@ var GenotypeGenesPanelCtrl =
           modal.result.then(function (geneObj) {
             $scope.lastAddedGene = geneObj.new_gene_id;
           });
+        };
+
+        var organismUpdated = function (organism) {
+          $scope.onOrganismSelect({organism: organism});
         };
       }
     };
@@ -3919,6 +3926,7 @@ var genotypeManageCtrl =
     $scope.data = {
       genotypeMap: {},
       waitingForServer: true,
+      selectedOrganism: null,
       selectedGenotypeId: null,
       editingGenotype: false,
       editGenotypeId: null,
@@ -3931,6 +3939,13 @@ var genotypeManageCtrl =
         $scope.data.multiOrganismMode = true;
       }
     });
+
+    $scope.organismUpdated = function (organism) {
+      $scope.data.selectedOrganism = organism;
+      console.log(
+        'genotypeManageCtrl selectedOrganism = ' + $scope.data.selectedOrganism
+      );
+    };
 
     function hashChangedHandler() {
       var path = $location.path();

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4006,15 +4006,23 @@ var genotypeManageCtrl =
     };
 
     var updateGenotypeLists = function () {
+      var organismHasNoGenotypes = function (taxonId) {
+        return ! $scope.data.genotypeMap.hasOwnProperty(taxonId);
+      };
       var selectedOrganism = $scope.data.selectedOrganism;
       if (!selectedOrganism) {
         $scope.data.singleAlleleGenotypes = [];
         $scope.data.multiAlleleGenotypes = [];
       } else {
         var selectedOrganismId = $scope.data.selectedOrganism.taxonid;
-        var currentGenotypes = $scope.data.genotypeMap[selectedOrganismId];
-        $scope.data.singleAlleleGenotypes = currentGenotypes['singleAlleleGenotypes'];
-        $scope.data.multiAlleleGenotypes = currentGenotypes['multiAlleleGenotypes'];
+        if (organismHasNoGenotypes(selectedOrganismId)) {
+          $scope.data.singleAlleleGenotypes = [];
+          $scope.data.multiAlleleGenotypes = [];
+        } else {
+          var currentGenotypes = $scope.data.genotypeMap[selectedOrganismId];
+          $scope.data.singleAlleleGenotypes = currentGenotypes['singleAlleleGenotypes'];
+          $scope.data.multiAlleleGenotypes = currentGenotypes['multiAlleleGenotypes'];
+        }
       }
     };
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4003,7 +4003,8 @@ var genotypeManageCtrl =
     var updateGenotypeLists = function () {
 
       var _getOrganismGenotypes = function (type) {
-        if ($scope.data.selectedOrganism === null) {
+        if ($scope.data.selectedOrganism === null
+            || $scope.data.selectedOrganism === undefined) {
           return [];
         }
         var currentTaxonId = $scope.data.selectedOrganism.taxonid;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3977,7 +3977,7 @@ var genotypeManageCtrl =
       CursGenotypeList.cursGenotypeList({ include_allele: 1 }).then(function(results) {
         $scope.data.genotypeMap = mapGenotypes(results);
         $scope.data.waitingForServer = false;
-        $scope.data.metagenotypeDissabled = ($scope.data.genotypes.length < 1);
+        $scope.data.metagenotypeDissabled = ($scope.data.genotypeMap.length < 1);
         CursGenotypeList.onListChange($scope.readGenotypesCallback);
       }).catch(function() {
         toaster.pop('error', "couldn't read the genotype list from the server");

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3917,9 +3917,7 @@ var genotypeManageCtrl =
     $scope.metagenotypeUrl = CantoGlobals.curs_root_uri + '/metagenotype_manage';
 
     $scope.data = {
-      genotypes: [],
-      singleAlleleGenotypes: [],
-      multiAlleleGenotypes: [],
+      genotypeMap: {},
       waitingForServer: true,
       selectedGenotypeId: null,
       editingGenotype: false,

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3991,6 +3991,7 @@ var genotypeManageCtrl =
     $scope.readGenotypes = function() {
       CursGenotypeList.cursGenotypeList({ include_allele: 1 }).then(function(results) {
         $scope.data.genotypeMap = mapGenotypes(results);
+        updateGenotypeLists();
         $scope.data.waitingForServer = false;
         $scope.data.metagenotypeDissabled = ($scope.data.genotypeMap.length < 1);
         CursGenotypeList.onListChange($scope.readGenotypesCallback);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3925,6 +3925,8 @@ var genotypeManageCtrl =
 
     $scope.data = {
       genotypeMap: {},
+      singleAlleleGenotypes: [],
+      multiAlleleGenotypes: [],
       waitingForServer: true,
       selectedOrganism: null,
       selectedGenotypeId: null,
@@ -3942,9 +3944,7 @@ var genotypeManageCtrl =
 
     $scope.organismUpdated = function (organism) {
       $scope.data.selectedOrganism = organism;
-      console.log(
-        'genotypeManageCtrl selectedOrganism = ' + $scope.data.selectedOrganism
-      );
+      updateGenotypeLists();
     };
 
     function hashChangedHandler() {
@@ -3998,6 +3998,26 @@ var genotypeManageCtrl =
         toaster.pop('error', "couldn't read the genotype list from the server");
         $scope.data.waitingForServer = false;
       });
+    };
+
+    var updateGenotypeLists = function () {
+
+      var _getOrganismGenotypes = function (type) {
+        if ($scope.data.selectedOrganism === null) {
+          return [];
+        }
+        var currentTaxonId = $scope.data.selectedOrganism.taxonid;
+        var currentOrganismGenotypes = $scope.data.genotypeMap[currentTaxonId];
+        return currentOrganismGenotypes[type];
+      };
+
+      $scope.data.singleAlleleGenotypes = _getOrganismGenotypes(
+        'singleAlleleGenotypes'
+      );
+      $scope.data.multiAlleleGenotypes = _getOrganismGenotypes(
+        'multiAlleleGenotypes'
+      );
+
     };
 
     $scope.backToSummary = function() {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3999,6 +3999,29 @@ var genotypeManageCtrl =
         (CantoGlobals.read_only_curs ? '/ro' : '');
     };
 
+    var mapGenotypes = function (genotypes) {
+      var genotypeMap = {};
+      var taxonId = "";
+      $.each(genotypes, function (index, genotype) {
+        taxonId = genotype.organism.taxonid;
+        if ( ! (taxonId in genotypeMap)) {
+          genotypeMap[taxonId] = {};
+        }
+        if (isSingleAlleleGenotype(genotype)) {
+          if ( ! ('singleAlleleGenotypes' in genotypeMap[taxonId])) {
+            genotypeMap[taxonId]['singleAlleleGenotypes'] = [];
+          }
+          genotypeMap[taxonId]['singleAlleleGenotypes'].push(genotype);
+        } else {
+          if ( ! ('multiAlleleGenotypes' in genotypeMap[taxonId])) {
+            genotypeMap[taxonId]['multiAlleleGenotypes'] = [];
+          }
+          genotypeMap[taxonId]['multiAlleleGenotypes'].push(genotype);
+        }
+      });
+      return genotypeMap;
+    };
+
     $scope.readGenotypes();
 
     },

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3975,9 +3975,7 @@ var genotypeManageCtrl =
 
     $scope.readGenotypes = function() {
       CursGenotypeList.cursGenotypeList({ include_allele: 1 }).then(function(results) {
-        $scope.data.genotypes = results;
-        $scope.data.singleAlleleGenotypes = $.grep(results, isSingleAlleleGenotype);
-        $scope.data.multiAlleleGenotypes = $.grep(results, isMultiAlleleGenotype);
+        $scope.data.genotypeMap = mapGenotypes(results);
         $scope.data.waitingForServer = false;
         $scope.data.metagenotypeDissabled = ($scope.data.genotypes.length < 1);
         CursGenotypeList.onListChange($scope.readGenotypesCallback);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3893,7 +3893,7 @@ var GenotypeGenesPanelCtrl =
           });
         };
 
-        var organismUpdated = function (organism) {
+        $scope.organismUpdated = function (organism) {
           $scope.onOrganismSelect({organism: organism});
         };
       }

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -1,7 +1,7 @@
 <div class="curs-genotype-gene-list">
   <organism-selector
     label="Organism"
-    organism-selected="organismSelected(organism)"
+    organism-selected="organismUpdated(organism)"
     genotype-type="genotypeType"
     last-added-gene="lastAddedGene">
   </organism-selector>

--- a/root/static/ng_templates/genotype_genes_panel.html
+++ b/root/static/ng_templates/genotype_genes_panel.html
@@ -1,6 +1,7 @@
 <div>
     <genotype-gene-list
       genotypes="genotypes"
+      on-organism-select="organismUpdated(organism)"
       multi-organism-mode="multiOrganismMode"
       genotype-type="genotypeType"
       last-added-gene="lastAddedGene">

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -73,7 +73,7 @@
                                 />
                             </div>
 
-                            <div ng-if="!readOnlyCurs" ng-show="data.genotypes.length == 0">
+                            <div ng-if="!readOnlyCurs" ng-show="data.showNoGenotypeNotice">
                                 No genotypes in this session.  Try adding one.
                             </div>
                         </div>

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -34,7 +34,7 @@
                     <div class="col-sm-3 col-md-3">
                         <genotype-genes-panel
                           on-organism-select="organismUpdated(organism)"
-                          genotypes="data.genotypes"
+                          genotypes="data.singleAlleleGenotypes"
                           multi-organism-mode="data.multiOrganismMode"
                           genotype-type="genotypeType" />
                     </div>

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -33,6 +33,7 @@
                 <div ng-if="!read_only_curs">
                     <div class="col-sm-3 col-md-3">
                         <genotype-genes-panel
+                          on-organism-select="organismUpdated(organism)"
                           genotypes="data.genotypes"
                           multi-organism-mode="data.multiOrganismMode"
                           genotype-type="genotypeType" />


### PR DESCRIPTION
The genotype list on the Genotype Management page now only shows the genotypes for the organism that is currently selected (using the `organismSelector` directive).

The main changes were to re-index the genotype model by the taxon ID of the organisms, such that the shape of the data now looks like this:

```
genotypeMap = {
  taxonid: {
    singleAlleleGenotypes: [...]
    multiAlleleGenotypes: [...]
  }
  ...
}
```

Other changes include:

* Passing only the single-allele genotypes into `GenotypeGeneList`

* Adding bindings to pass the selected organism back up to the page controller (so that it can filter the genotypes passed down to the genotype list).

* Storing the result of the test of whether to show the message 'No genotypes in this session. Try adding one.' into a scope variable `showNoGenotypeNotice`, since checking `genotypeMap` is now more complex, and probably doesn't need to checked constantly.

@kimrutherford Some of these changes go beyond what you asked for, so feel free to (ask me to) revert them if you think they're excessive or unnecessary. One thing in particular is that I've kept `scope.data` variables around for `singleAlleleGenotypes` and `multiAlleleGenotypes` in `genotypeManageCtrl`, because I thought it would be a bit verbose to reference their index in the `genotypeMap` directly in the template, for example:

```
data.genotypeMap[data.selectedOrganism.taxonid].singleAlleleGenotypes
```
I think I've made it so the other variables just store references to these indexes, so I'm hoping it won't cause a performance impact, but I'm not sure how it works in practice.
