### PR TITLE
Hide organism selector in single organism mode

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3813,6 +3813,13 @@ var GenotypeGeneListCtrl =
 
         $scope.hasDeletionHash = {};
 
+        if (!$scope.multiOrganismMode) {
+          Curs.list('organism')
+            .then(function(organisms) {
+              $scope.organismUpdated(organisms.data[0]);
+            });
+        }
+
         $scope.$watch('genotypes',
                      function() {
                        $scope.makeHasDeletionHash();

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -1,5 +1,6 @@
 <div class="curs-genotype-gene-list">
   <organism-selector
+    ng-if="multiOrganismMode"
     label="Organism"
     organism-selected="organismUpdated(organism)"
     genotype-type="genotypeType"


### PR DESCRIPTION
I'd like to be able to hide the:

    Organism
    Schizosaccharomyces pombe

from the genotype management page when in single user mode.

I tried `ng-if="multiOrganismMode"` as in this pull request but then the gene list disappears.  Is there an easy fix?
