### PR TITLE
Update Vagrantfile to use Docker instead of Canto Vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,10 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# require 'yaml'
-
-# settings = YAML.load_file './config.yaml'
-
 setup_docker_folders = <<-SCRIPT
   cd /home/vagrant
   if [ ! -d canto-docker ]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,53 +1,45 @@
-require 'yaml'
-settings = YAML.load_file './vagrant_config.yaml'
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
 
-$canto_setup_script = <<-SCRIPT
-  # Go to the Canto source directory.
-  cd /home/canto/canto-master
+# require 'yaml'
 
-  # Initialise the Canto data directory.
-  ./script/canto_start --initialise /var/canto-data
-  
-  # Canto won't start unless the user running the script has permissions on
-  # the database.
-  chown -R canto:canto /var/canto-data
-SCRIPT
+# settings = YAML.load_file './config.yaml'
 
-$ontology_loading_script = <<-SCRIPT
-  # Load ontologies from Gene Ontology, FYPO, and PSI-MOD.
-  cd /home/canto/canto-master
-  ./script/canto_load.pl \
-    --ontology http://snapshot.geneontology.org/ontology/go-basic.obo \
-    --ontology http://curation.pombase.org/ontologies/fypo/latest/fypo-simple.obo \
-    --ontology http://curation.pombase.org/ontologies/PSI-MOD-2016-01-19.obo
+setup_docker_folders = <<-SCRIPT
+  cd /home/vagrant
+  if [ ! -d canto-docker ]
+  then
+    mkdir canto-docker
+  fi
+  cd canto-docker
+  mkdir data
+  mkdir import_export
 SCRIPT
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "canto"
-  config.vm.box_url = settings['box_url']
+  config.vm.box = "debian/stretch64"
+  config.vm.box_version = "9.4.0"
+  config.vm.box_check_update = false
+
+  config.vm.define "canto-vm"
+  config.vm.hostname = "canto-vm"
 
   config.vm.network "forwarded_port", guest: 5000, host: 5000
 
-  config.vm.synced_folder ".", "/home/canto/canto-master",
-    owner: "root"
-
-  # Disable the default synced folder, since the working directory is already
-  # synced somewhere else.
+  config.vagrant.plugins = "vagrant-vbguest"
+  
   config.vm.synced_folder ".", "/vagrant",
     disabled: true
+  
+  config.vm.synced_folder ".", "/home/vagrant/canto-docker/canto",
+    type: "virtualbox"
 
-  config.vm.provision "canto",
+  config.vm.provision "docker"
+
+  config.vm.provision "setup_docker_folders",
     type: "shell",
-    inline: $canto_setup_script
+    inline: setup_docker_folders,
+    privileged: false
 
-  config.vm.provision "ontologies",
-    type: "shell",
-    inline: $ontology_loading_script,
-    # If ontology loading is disabled, it can still be run manually with:
-    # $ vagrant provision --provision-with ontologies
-    run: settings['load_ontologies'] ? "once" : "never"
-
-  config.ssh.username = "canto"
-  config.ssh.password = "canto"
 end


### PR DESCRIPTION
The old virtual machine setup (which used a pre-provisioned Vagrant box) kept running into problems with VirtualBox synced folders, due to the the kernel headers for Debian sid changing repeatedly.

I've changed the Vagrantfile to wrap the Canto docker image inside a Vagrant virtual machine, which means we can use a stable distribution of Debian on the outside (Debian 9.4), which bypasses the problem. It should also bring my development environment in line with @barnabynorman.

This setup is able to sync the Canto source directory from outside the VM all the way into the Docker image, providing guest additions are installed. I'm using the `vagrant-vbguest` plugin ([see here](https://github.com/dotless-de/vagrant-vbguest)) to handle guest addition installation automatically, though it might help to have `rsync` as a fallback method for when the plugin isn't installed or fails to install.

@kimrutherford I thought it would be convenient to map the `import_export` directory onto another synced folder, so that users can effectively drag and drop files into a folder on the host (and maybe have them automatically loaded when the VM starts up) but I'm not sure where to map the folder to. My first thought was targeting a directory in the root of the Canto repository called `import_export` that is ignored in the `.gitignore` file, but if you're not keen on doing this, I can see about forcing the path to be specified by the user (to target some external folder on the host) using a configuration file.

Also, this PR should probably be merged to `metagenotype-dev` as well as `master`.
