### PR TITLE
Fix permissions issue with Docker folders

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,9 +7,11 @@ setup_docker_folders = <<-SCRIPT
   then
     mkdir canto-docker
   fi
+  chown vagrant:vagrant canto-docker
   cd canto-docker
   mkdir data
   mkdir import_export
+  chown vagrant:vagrant data import_export
 SCRIPT
 
 Vagrant.configure("2") do |config|
@@ -35,7 +37,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "setup_docker_folders",
     type: "shell",
-    inline: setup_docker_folders,
-    privileged: false
+    inline: setup_docker_folders
 
 end


### PR DESCRIPTION
(Fixes an error with #1626)

Vagrant has 'permission denied' errors when creating sub-folders of `canto-docker`. I think it's because `canto-docker` is on the path created by mounting the `canto` synced folder, and while the folder itself is owned by `vagrant`, the containing folders are created with `root` as the owner. I've amended the directory creation script to run as `root` and use `chown` commands to transfer ownership to `vagrant` afterwards.