### PR TITLE
[WIP] Fix incorrect links to genotype_manage

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4571,6 +4571,22 @@ var genotypeListViewCtrl =
       replace: true,
       templateUrl: app_static_path + 'ng_templates/genotype_list_view.html',
       controller: function($scope) {
+
+        function getOrganismType(genotypes) {
+          if (CantoGlobals.pathogen_host_mode === "1") {
+            var genotype = genotypes[0];
+            if ('organism' in genotype) {
+              var organism = genotype.organism;
+              if ('pathogen_or_host' in organism) {
+                return organism.pathogen_or_host;
+              }
+            }
+          }
+          return 'normal';
+        }
+
+        $scope.organismType = getOrganismType($scope.genotypeList);
+
         $scope.checkBoxChecked = {};
 
         $scope.columnsToHide = { background: true,
@@ -4625,7 +4641,9 @@ var genotypeListViewCtrl =
 
           storePromise.then(function(result) {
             window.location.href =
-              CantoGlobals.curs_root_uri + '/genotype_manage#/select/' + result.data.genotype_id;
+              CantoGlobals.curs_root_uri +
+                '/' + getGenotypeManagePath($scope.organismType) +
+                '#/select/' + result.data.genotype_id;
             $scope.checkBoxChecked = {};
           });
         };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -154,6 +154,18 @@ function isMultiAlleleGenotype(genotype) {
   return !isSingleAlleleGenotype(genotype);
 }
 
+function getGenotypeManagePath(organismMode) {
+  var paths = {
+    'normal': 'genotype_manage',
+    'pathogen': 'pathogen_genotype_manage',
+    'host': 'host_genotype_manage'
+  };
+  if (organismMode in paths) {
+    return paths[organismMode];
+  }
+  return paths.normal;
+}
+
 canto.filter('breakExtensions', function() {
   return function(text) {
     if (text) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4479,18 +4479,11 @@ var genotypeListRowLinksCtrl =
         };
       },
       link: function($scope) {
-        if ($scope.navigateOnClick) {
-          $scope.detailsUrl =
-            CantoGlobals.curs_root_uri + '/genotype_manage' +
-            (CantoGlobals.read_only_curs ? '/ro' : '') + '#/select/' +
-            $scope.genotype.id_or_identifier;
-        } else {
-          $scope.detailsUrl = '#';
-          $scope.viewAnnotationUri =
-            CantoGlobals.curs_root_uri + '/feature/genotype/view/' + $scope.genotypeId;
-          if (CantoGlobals.read_only_curs) {
-            $scope.viewAnnotationUri += '/ro';
-          }
+        $scope.detailsUrl = '#';
+        $scope.viewAnnotationUri =
+          CantoGlobals.curs_root_uri + '/feature/genotype/view/' + $scope.genotypeId;
+        if (CantoGlobals.read_only_curs) {
+          $scope.viewAnnotationUri += '/ro';
         }
       },
     };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4408,7 +4408,9 @@ var genotypeListRowLinksCtrl =
 
         $scope.editGenotype = function(genotypeId) {
           window.location.href =
-            CantoGlobals.curs_root_uri + '/genotype_manage#/edit/' + genotypeId;
+            CantoGlobals.curs_root_uri +
+              '/' + getGenotypeManagePath(genotypePathogenOrHost) +
+              '#/edit/' + genotypeId;
         };
 
         $scope.editAllele = function(genotypeId) {
@@ -4434,7 +4436,9 @@ var genotypeListRowLinksCtrl =
 
               storePromise.then(function(result) {
                 window.location.href =
-                  CantoGlobals.curs_root_uri + '/genotype_manage#/select/' + result.data.genotype_id;
+                  CantoGlobals.curs_root_uri +
+                    '/' + getGenotypeManagePath(genotypePathogenOrHost) +
+                    '#/select/' + result.data.genotype_id;
               });
             });
           });

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3891,7 +3891,10 @@ var GenotypeGeneListCtrl =
 
             storePromise.then(function(result) {
               window.location.href =
-                CantoGlobals.curs_root_uri + '/genotype_manage#/select/' + result.data.genotype_id;
+                CantoGlobals.curs_root_uri +
+                  '/' + getGenotypeManagePath($scope.genotypeType) +
+                  '#/select/' +
+                  result.data.genotype_id;
             });
           });
         };
@@ -3936,7 +3939,10 @@ var GenotypeGeneListCtrl =
 
           storePromise.then(function(result) {
             window.location.href =
-              CantoGlobals.curs_root_uri + '/genotype_manage#/select/' + result.data.genotype_id;
+              CantoGlobals.curs_root_uri +
+                '/' + getGenotypeManagePath($scope.genotypeType) +
+                '#/select/' +
+                result.data.genotype_id;
           });
         };
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4368,6 +4368,10 @@ var genotypeListRowLinksCtrl =
           })[0];
         var genotypePathogenOrHost = genotype.organism.pathogen_or_host;
 
+        $scope.genotypeManagePath = getGenotypeManagePath(
+          genotypePathogenOrHost
+        );
+
         $scope.canDelete = true;
         $scope.deleteTitle = '';
 

--- a/root/static/ng_templates/genotype_list_row_links.html
+++ b/root/static/ng_templates/genotype_list_row_links.html
@@ -22,7 +22,7 @@
       ng-click="editAllele(genotypeId)">Copy and edit ...</a>
     <a ng-show="alleleCount != 1"
       ng-class="{disabled: genotypeId == null }"
-      href="{{curs_root_uri + '/genotype_manage#/duplicate/' + genotypeId}}">Copy and edit ...</a>
+      href="{{curs_root_uri + '/' + genotypeManagePath + '#/duplicate/' + genotypeId}}">Copy and edit ...</a>
   </div>
   <div ng-if="!read_only_curs">
     <a ng-class="{disabled: genotypeId == null }"


### PR DESCRIPTION
(Will fix #1606 once finished)

This pull request replaces references to `genotype_manage` with the correct path for pathogen&ndash;host mode (either `host_genotype_manage` or `pathogen_genotype_manage`).

So far, I've fixed bugs caused by the following actions:

- Creating an allele (#1614)
- _Edit_, on a single or multi-allele genotype
- _Copy and edit_, on a single or multi-allele genotype

Other actions, such as viewing annotations and starting a phenotype annotation, still contain incorrect links to `genotype_manage`. The problems with these are covered [here](https://github.com/pombase/canto/issues/1606#issuecomment-428924623).