### PR TITLE
Fix genotype_manage link on phenotype annotation page

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2684,9 +2684,16 @@ var ontologyWorkflowCtrl =
         $scope.annotationType = annotationType;
 
         if (annotationType.feature_type == 'genotype') {
-          $scope.backToFeatureUrl =
-            CantoGlobals.curs_root_uri + '/genotype_manage' +
-            '#/select/' + $attrs.featureId;
+          CursGenotypeList.getGenotypeById(Number($attrs.featureId))
+            .then(function (genotype) {
+              var organismMode = genotype !== null
+                ? genotype.organism.pathogen_or_host
+                : 'normal';
+              $scope.backToFeatureUrl =
+                CantoGlobals.curs_root_uri +
+                '/' + getGenotypeManagePath(organismMode) +
+                '#/select/' + $attrs.featureId;
+            });
         } else {
           $scope.backToFeatureUrl =
             CantoGlobals.curs_root_uri + '/feature/' + annotationType.feature_type +

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2484,7 +2484,7 @@ canto.directive('extensionOrGroupDisplay',
 
 var ontologyWorkflowCtrl =
   function($scope, toaster, $http, CantoGlobals, AnnotationTypeConfig, CantoService,
-           CantoConfig, CursStateService, $attrs) {
+           CantoConfig, CursGenotypeList, CursStateService, $attrs) {
     $scope.states = ['searching', 'selectingEvidence', 'buildExtension', 'commenting'];
 
     CursStateService.setState($scope.states[0]);
@@ -2698,7 +2698,7 @@ var ontologyWorkflowCtrl =
 canto.controller('OntologyWorkflowCtrl',
                  ['$scope', 'toaster', '$http', 'CantoGlobals',
                   'AnnotationTypeConfig', 'CantoService',
-                  'CantoConfig', 'CursStateService', '$attrs',
+                  'CantoConfig', 'CursGenotypeList', 'CursStateService', '$attrs',
                   ontologyWorkflowCtrl]);
 
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2679,6 +2679,13 @@ var ontologyWorkflowCtrl =
       });
     };
 
+    function getOrganismMode(genotype, pathogenHostMode) {
+      if (genotype !== null && pathogenHostMode) {
+        return genotype.organism.pathogen_or_host;
+      }
+      return 'normal';
+    }
+
     AnnotationTypeConfig.getByName($scope.annotationTypeName)
       .then(function(annotationType) {
         $scope.annotationType = annotationType;
@@ -2686,9 +2693,10 @@ var ontologyWorkflowCtrl =
         if (annotationType.feature_type == 'genotype') {
           CursGenotypeList.getGenotypeById(Number($attrs.featureId))
             .then(function (genotype) {
-              var organismMode = genotype !== null
-                ? genotype.organism.pathogen_or_host
-                : 'normal';
+              var organismMode = getOrganismMode(
+                genotype,
+                CantoGlobals.pathogen_host_mode
+              );
               $scope.backToFeatureUrl =
                 CantoGlobals.curs_root_uri +
                 '/' + getGenotypeManagePath(organismMode) +


### PR DESCRIPTION
(Follow-up from #1629; partially fixes #1606)

This PR fixes the reference to `genotype_manage` in `ontologyWorkflowCtrl`. I think the solution is a bit of a kludge, since it requires injecting the entire `CursGenotypeList` service just to query one field of one genotype.

I'm querying the `CursGenotypeList` with the `feature_id` provided by the Mason template, since it seems to be equivalent to the genotype ID expected by the service, but I'm not sure if this is always the case. I think the service is only queried when the `feature_type` is a genotype, so it shouldn't have serious side effects. @kimrutherford could you confirm if the `feature_id` is equivalent to the `genotype_id` in this case?

I think I've handled most of the edge cases: when the genotype is `null`, I've opted to set `genotype_manage` as the 'default' URL, but I'm not sure if this is the best choice (it might be better to set the summary page as the fallback URL, so not to ruin the genotype manage page for users in pathogen&ndash;host mode). I've added some logic to handle single organism mode, but I haven't tested it under that configuration.

@kimrutherford if you think this solution is too overkill for the problem, or if you'd prefer if  `ontologyWorkflowCtrl` wasn't forced to depend on `CursGenotypeList`, then another option is to modify the Perl template at `ontology.mhtml` to provide the organism type that corresponds to the genotype being annotated, similar to how the `feature_id` is provided.