### PR TITLE
Fix genotype_manage link on genotype feature view

### DIFF
--- a/root/curs/genotype_page.mhtml
+++ b/root/curs/genotype_page.mhtml
@@ -6,7 +6,7 @@ $annotation_count
 @annotation_type_list
 </%args>
 
-<div ng-controller="GenotypeViewCtrl" ng-init="init(<% $annotation_count %>)">
+<div ng-controller="GenotypeViewCtrl" ng-init="init(<% $annotation_count %>,  '<% $org_details->{pathogen_or_host} %>')">
 % if (!$read_only_curs) {
 <div class="curs-box curs-half-width-section">
   <div class="curs-box-title">

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -156,6 +156,7 @@ function isMultiAlleleGenotype(genotype) {
 
 function getGenotypeManagePath(organismMode) {
   var paths = {
+    'unknown': 'genotype_manage',
     'normal': 'genotype_manage',
     'pathogen': 'pathogen_genotype_manage',
     'host': 'host_genotype_manage'

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3571,8 +3571,11 @@ canto.directive('genotypeEdit',
 
 var genotypeViewCtrl =
   function($scope, CantoGlobals, CursSettings) {
-    $scope.init = function(annotationCount) {
+    var ctrl = this;
+
+    $scope.init = function(annotationCount, organismType) {
       $scope.annotationCount = annotationCount;
+      ctrl.organismType = organismType;
     };
 
     $scope.advancedMode = function() {
@@ -3586,7 +3589,8 @@ var genotypeViewCtrl =
 
     $scope.backToGenotypes = function() {
       window.location.href = CantoGlobals.curs_root_uri +
-        '/genotype_manage' + (CantoGlobals.read_only_curs ? '/ro' : '');
+        '/' + getGenotypeManagePath(ctrl.organismType) +
+        (CantoGlobals.read_only_curs ? '/ro' : '');
     };
   };
 


### PR DESCRIPTION
This fixes the 'Back to genotypes' link on the genotype feature view page (which corresponds to the Mason template `genotype_page.mhtml`). The controller handling the button is `GenotypeViewCtrl`, and the solution involves passing the `pathogen_or_host` field from the `$org_details` Perl object to the controller.

Note: as part of this PR I've also updated the `getGenotypeManagePath` function to handle the 'unknown' organism type, which is used when Canto is in single organism mode. It might be necessary to amend the changes in #1638 to reflect this.