### PR TITLE
Rename disease_formation_phenotype to new name

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6657,7 +6657,7 @@ var metagenotypeListRow = function(CantoGlobals, Metagenotype) {
 
             $scope.read_only_curs = CantoGlobals.read_only_curs;
             $scope.createAnnotationUri = CantoGlobals.curs_root_uri + '/feature/metagenotype/annotate/' + $scope.metagenotype.metagenotype_id
-                + '/start/disease_formation_phenotype/';
+                + '/start/pathogen_host_interaction_phenotype/';
             $scope.viewAnnotationUri = CantoGlobals.curs_root_uri + '/feature/metagenotype/view/' + $scope.metagenotype.metagenotype_id;
             if (CantoGlobals.read_only_curs) {
                 $scope.viewAnnotationUri += '/ro';

--- a/root/static/ng_templates/metagenotype_list_row.html
+++ b/root/static/ng_templates/metagenotype_list_row.html
@@ -16,7 +16,7 @@
                 ng-class="{disabled: metagenotype.metagenotype_id == null }"
                 ng-if="!read_only_curs"
                 href="{{createAnnotationUri}}">
-                    Start&nbsp;a&nbsp;disease&nbsp;formation&nbsp;phenotype&nbsp;annotation</a><br/>
+                    Start&nbsp;a&nbsp;pathogen&#8209;host&nbsp;interaction&nbsp;phenotype&nbsp;annotation</a><br/>
             <a
                 ng-class="{disabled: metagenotype.metagenotype_id == null }"
                 href="{{viewAnnotationUri}}">


### PR DESCRIPTION
(Fixes #1641)

The latest version of PHIPO has renamed 'disease_formation_phenotype' to 'pathogen_host_interaction_phenotype'. Unfortunately, 'disease_formation_phenotype' is hard-coded in the meta-genotype template and controller.

For now, I've updated the namespace names so that they match the new PHIPO version.

@kimrutherford is there a way we could avoid hard-coding this name? Could we retrieve the correct annotation type from the `CantoConfig` service, e.g. by looking for annotations with `feature_type: 'metagenotype'`?