### PR TITLE
Fix 'Edit...' link on genotype details view

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3591,6 +3591,7 @@ var genotypeViewCtrl =
     $scope.init = function(annotationCount, organismType) {
       $scope.annotationCount = annotationCount;
       ctrl.organismType = organismType;
+      ctrl.genotypeManagePath = getGenotypeManagePath(ctrl.organismType);
     };
 
     $scope.advancedMode = function() {
@@ -3599,12 +3600,14 @@ var genotypeViewCtrl =
 
     $scope.editGenotype = function(genotypeId) {
       window.location.href =
-        CantoGlobals.curs_root_uri + '/genotype_manage#/edit/' + genotypeId;
+        CantoGlobals.curs_root_uri +
+        '/' + ctrl.genotypeManagePath +
+        '#/edit/' + genotypeId;
     };
 
     $scope.backToGenotypes = function() {
       window.location.href = CantoGlobals.curs_root_uri +
-        '/' + getGenotypeManagePath(ctrl.organismType) +
+        '/' + ctrl.genotypeManagePath +
         (CantoGlobals.read_only_curs ? '/ro' : '');
     };
   };


### PR DESCRIPTION
(Partially fixes #1606)

Somehow I managed to miss another reference to `genotype_manage` in `genotypeViewCtrl`, right next to the one I fixed. Note that this won't yet have the intended effect, since the 'Edit...' and 'Duplicate...' links are broken anyway (see #1627).