### PR TITLE
Add genotype section heading to summary page

### DIFF
--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -52,7 +52,11 @@ Edit gene list ...
 % if ($genotype_annotation_configured) {
   <div class="curs-box-title">
     <div>
-      Annotate genotypes
+% if ($read_only_curs) {
+Genotypes from this publication
+% } else {
+Annotate genotypes
+% }
     </div>
   </div>
 %   if ($pathogen_host_mode) {

--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -39,7 +39,7 @@ Annotate genes
 % }
   <div style="margin-top: 20px;">
 % if (!$read_only_curs) {
-  <div class="feature-list-action">
+  <div class="feature-list-action" style="margin-bottom: 20px;">
     <a href="<% $edit_path %>">
 %   if ($multi_organism_mode) {
 Edit genes and organisms ...

--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -9,13 +9,11 @@ var organismsAndGenes = <% $organisms_and_genes_js |n %>;
 <div class="curs-box">
   <div class="curs-box-title">
     <div>
-% my $and_genotypes = '';
-% $and_genotypes = ' and genotypes' if $genotype_annotation_configured;
 
 % if ($read_only_curs) {
-Genes<% $and_genotypes %> from this publication
+Genes from this publication
 % } else {
-Annotate genes<% $and_genotypes %>
+Annotate genes
 % }
     <& /curs/inline_help.mhtml, key => 'choose_gene' &>
     </div>
@@ -52,6 +50,11 @@ Edit gene list ...
   </div>
 % }
 % if ($genotype_annotation_configured) {
+  <div class="curs-box-title">
+    <div>
+      Annotate genotypes
+    </div>
+  </div>
 %   if ($pathogen_host_mode) {
   <div class="feature-list-action">
     <a href="<% $pathogen_genotype_manage_url %>"><% $read_only_curs ? 'View pathogen genotypes ...' : 'Pathogen genotype management ...' %></a>

--- a/t/90_curs_annotation_check.t
+++ b/t/90_curs_annotation_check.t
@@ -38,7 +38,7 @@ test_psgi $app, sub {
     my $res = $cb->(GET "$root_url/");
     is $res->code, 200;
 
-    like ($res->content(), qr/Annotate genes and genotypes/s);
+    like ($res->content(), qr/Annotate genes/s);
     like ($res->content(), qr/Publication details/s);
 
     is($status_storage->retrieve($curs_key, 'annotation_status'),

--- a/t/90_curs_annotation_check.t
+++ b/t/90_curs_annotation_check.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 29;
+use Test::More tests => 28;
 
 use Plack::Test;
 use Plack::Util;

--- a/t/90_curs_annotation_check.t
+++ b/t/90_curs_annotation_check.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 27;
+use Test::More tests => 29;
 
 use Plack::Test;
 use Plack::Util;

--- a/t/90_curs_annotation_check.t
+++ b/t/90_curs_annotation_check.t
@@ -39,6 +39,7 @@ test_psgi $app, sub {
     is $res->code, 200;
 
     like ($res->content(), qr/Annotate genes/s);
+    like ($res->content(), qr/Annotate genotypes/s);
     like ($res->content(), qr/Publication details/s);
 
     is($status_storage->retrieve($curs_key, 'annotation_status'),

--- a/t/90_curs_controller_actions.t
+++ b/t/90_curs_controller_actions.t
@@ -250,7 +250,7 @@ test_psgi $app, sub {
 
     my $scrape_res = $page_scrape->scrape($redirect_res->content());
 
-    like ($scrape_res->{gene_list}, qr/Annotate genes and genotypes/);
+    like ($scrape_res->{gene_list}, qr/Annotate genes/);
     like ($scrape_res->{pub_title}, qr/Inactivating pentapeptide insertions/);
   }
 

--- a/t/90_curs_finished_annotation.t
+++ b/t/90_curs_finished_annotation.t
@@ -41,7 +41,7 @@ test_psgi $app, sub {
 
     is $res->code, 200;
 
-    like ($res->content(), qr/Annotate genes and genotypes/s);
+    like ($res->content(), qr/Annotate genes/s);
     like ($res->content(), qr/Publication details/s);
 
     is($status_storage->retrieve($curs_key, 'annotation_status'),
@@ -129,7 +129,7 @@ test_psgi $app, sub {
 
     (my $content = $res->content()) =~ s/\s+/ /g;
 
-    like ($content, qr/Genes and genotypes from this publication/s);
+    like ($content, qr/Genes from this publication/s);
     like ($content, qr/Reviewing session for PMID:18426916/s);
 
     is($status_storage->retrieve($curs_key, 'annotation_status'), "NEEDS_APPROVAL");

--- a/t/90_curs_finished_annotation.t
+++ b/t/90_curs_finished_annotation.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 33;
+use Test::More tests => 35;
 
 use Plack::Test;
 use Plack::Util;

--- a/t/90_curs_finished_annotation.t
+++ b/t/90_curs_finished_annotation.t
@@ -130,6 +130,7 @@ test_psgi $app, sub {
     (my $content = $res->content()) =~ s/\s+/ /g;
 
     like ($content, qr/Genes from this publication/s);
+    like ($content, qr/Genotypes from this publication/s);
     like ($content, qr/Reviewing session for PMID:18426916/s);
 
     is($status_storage->retrieve($curs_key, 'annotation_status'), "NEEDS_APPROVAL");

--- a/t/90_curs_finished_annotation.t
+++ b/t/90_curs_finished_annotation.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 35;
+use Test::More tests => 34;
 
 use Plack::Test;
 use Plack::Util;

--- a/t/90_curs_pause_annotation.t
+++ b/t/90_curs_pause_annotation.t
@@ -43,7 +43,7 @@ test_psgi $app, sub {
 
     is $res->code, 200;
 
-    like ($res->content(), qr/Annotate genes and genotypes/s);
+    like ($res->content(), qr/Annotate genes/s);
     like ($res->content(), qr/Publication details/s);
 
     is($status_storage->retrieve($curs_key, 'annotation_status'),
@@ -137,7 +137,7 @@ test_psgi $app, sub {
     unlike ($content, qr/$curation_paused_message/);
 
     like ($content, qr/Session has been restarted/);
-    like ($content, qr/Annotate genes and genotypes/);
+    like ($content, qr/Annotate genes/);
 
     is($status_storage->retrieve($curs_key, 'annotation_status'), "CURATION_IN_PROGRESS");
   }


### PR DESCRIPTION
(See #1485)

This adds an extra heading on the curation summary page to separate the genotype links from the gene links. Here's how it looks:

![summary_genotype_heading](https://user-images.githubusercontent.com/37659591/47494737-444ee200-d84a-11e8-96a7-12674bc85979.PNG)

I've also ensured that the genotype link supports read-only mode, in the same way that the gene link does:

![genotype_heading_read_only](https://user-images.githubusercontent.com/37659591/47494808-752f1700-d84a-11e8-8810-43d4ca4a087c.PNG)

Unfortunately the genotype heading is missing help text, because I don't know how to configure the text. It's possible that this heading doesn't need it though, since the genotype links are more self-explanatory.

@kimrutherford I've copied your `curs-box-title` pattern from elsewhere in the template. I checked `style.css` to make sure there weren't any contextual selectors affecting how `curs-box-title` was styled (e.g. whether it depended on being nested within a `curs-box`), and I couldn't see any. Please let me know if there's anything wrong with the markup.

**Note**: I've used `metagenotype-dev` as the base branch, but if you'd prefer this to be merged to `master`, I can rebase my commits.