### PR TITLE
Change canto-modules.js to store taxon ID and strain for genotypes

### DIFF
--- a/root/curs/gene_page.mhtml
+++ b/root/curs/gene_page.mhtml
@@ -59,7 +59,7 @@ Choose curation type for <% $gene->display_name() %>:
 %    }
 %   } else {
   <li class="annotation-type">
-    <a href="#" ng-click="singleAlleleQuick('<% $gene->display_name() |n %>', '<% $gene->primary_identifier() |n %>', <% $gene->gene_id() |n%>, '<%$annotation_type_name%>')">
+    <a href="#" ng-click="singleAlleleQuick('<% $gene->display_name() |n %>', '<% $gene->primary_identifier() |n %>', <% $gene->gene_id() |n%>, '<%$annotation_type_name%>', <% $taxon_id %>)">
       Single allele <% ucfirst $type_display_name %>
     </a>
     <help-icon key="gene_page_single_allele"></help-icon>
@@ -137,6 +137,7 @@ Genotypes for <% $gene->display_name() %> in this session
 <%init>
 my $gene_id = $gene->gene_id();
 my $gene_name = $gene->{primary_name} // '';
+my $taxon_id = $gene->taxonid();
 
 my $gene_org_name = $gene->organism_details()->{full_name};
 

--- a/root/static/ng_templates/allele_edit.html
+++ b/root/static/ng_templates/allele_edit.html
@@ -27,14 +27,14 @@
           </td>
         </tr>
 
-        <tr ng-if="alleleData.showStrainPicker" class="curs-allele-type-select">
+        <tr ng-if="showStrainPicker" class="curs-allele-type-select">
           <td>Strain used</td>
           <td>
               <select
                   class="form-control"
-                  ng-model="alleleData.selectedStrain"
+                  ng-model="selectedStrain"
                   name="curs-allele-type"
-                  ng-options="st.strain_name for st in alleleData.strains(alleleData.taxon_id) track by st.strain_name">
+                  ng-options="st.strain_name for st in strains(taxonId) track by st.strain_name">
                   <option value="">Choose a strain ...</option>
               </select>
           </td>


### PR DESCRIPTION
This pull request changes the JavaScript code to pass the taxon ID and strain name when creating and editing genotypes.

It also changes the way that the taxon ID and strain are passed in and out of the allele edit dialog.