### PR TITLE
Fix organismSelector dependencies

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3647,7 +3647,7 @@ var metagenotypeViewCtrl =
 canto.controller('MetagenotypeViewCtrl',
                  ['$scope', 'CantoGlobals', 'CursSettings', metagenotypeViewCtrl]);
 
-var organismSelector = function ($http, Curs, toaster, CantoGlobals, CantoConfig) {
+var organismSelector = function (Curs, toaster, CantoGlobals) {
   return {
     scope: {
       organismSelected: '&',
@@ -3842,7 +3842,7 @@ var organismSelectorCtrl = function ($scope, Curs, toaster, CantoGlobals) {
 };
 
 canto.directive('organismSelector', [
-  '$http', 'Curs', 'toaster', 'CantoGlobals', 'CantoConfig', organismSelector
+  'Curs', 'toaster', 'CantoGlobals', organismSelector
 ]);
 
 var GenotypeGeneListCtrl =

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3661,7 +3661,7 @@ var organismSelector = function ($http, Curs, toaster, CantoGlobals, CantoConfig
   };
 };
 
-var organismSelectorCtrl = function ($scope, Curs, CantoGlobals) {
+var organismSelectorCtrl = function ($scope, Curs, toaster, CantoGlobals) {
 
   $scope.app_static_path = CantoGlobals.app_static_path;
 


### PR DESCRIPTION
Fixes #1652 

Seems I forgot to inject `toaster` into `organismSelectorCtrl`, so this pull request fixes that. I've also removed some dependencies that were being injected but not used (as far as I could tell).

@kimrutherford I might just need you to confirm that `organismSelector` doesn't need the following dependencies:

* `$http` &ndash; I think this is already delegated to the `Curs` service, which depends on `$http` instead.

* `CantoConfig` &ndash; I'm not sure why I injected this in the first place, but I don't think it's needed since `organismSelector` gets its configuration through bindings.

