### PR TITLE
Remove phenotype annotation links from gene page

### DIFF
--- a/root/curs/gene_page.mhtml
+++ b/root/curs/gene_page.mhtml
@@ -57,19 +57,6 @@ Choose curation type for <% $gene->display_name() %>:
 %     }
     </li>
 %    }
-%   } else {
-  <li class="annotation-type">
-    <a href="#" ng-click="singleAlleleQuick('<% $gene->display_name() |n %>', '<% $gene->primary_identifier() |n %>', <% $gene->gene_id() |n%>, '<%$annotation_type_name%>', <% $taxon_id %>)">
-      Single allele <% ucfirst $type_display_name %>
-    </a>
-    <help-icon key="gene_page_single_allele"></help-icon>
-  </li>
-  <li class="annotation-type">
-    <a href='<% "$curs_root_uri/genotype_manage" %>'>
-      Multiple allele <% ucfirst $type_display_name %>
-    </a>
-    <help-icon key="gene_page_multi_allele"></help-icon>
-  </li>
 %   }
 % }
   </ul>


### PR DESCRIPTION
(Fixes #1477)

The phenotype annotation shortcuts on the gene page weren't working well in PHI-Canto, since both the single- and multiple-allele phenotype links were repeated for each of the three PHIPO namespaces (making six links in total). Also, the multiple-allele links had the old `genotype_manage` page as their destination, which is related to the problem I was trying to solve in #1606.

For now, we decided to simply remove the links, which I've done by removing the template code. (@kimrutherford if there's a better way to handle this through the Canto configuration, please let me know.)

This change will only affect PHI-Canto for now, since we're merging to `metagenotype-dev`, but we might want a better fix in place before merging that branch to `master`. In terms of what this better fix could be, I've included some thoughts in #1477 (see comment).

