### PR TITLE
Set width on organism selector to prevent overflow

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1507,3 +1507,7 @@ a:not([href]) {
 .gene-button-delete-text-disabled {
   color: whitesmoke;
 }
+
+.curs-organism-selector-select {
+  width: 100%;
+}

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -5,6 +5,7 @@
 <div class="curs-organism-selector" ng-if="data.organisms">
   <p ng-hide="data.hideLabel" class="curs-organism-selector-label"><b>{{label}}</b></p>
   <select ng-if="data.organisms.length > 1"
+      class="curs-organism-selector-select"
       name="select-organism"
       ng-model="data.selectedOrganism"
       ng-change="organismChanged()"


### PR DESCRIPTION
The organism names retrieved from UniProt sometimes include all their strains in the name, which makes the organism selector long enough to run into the next column. This pull request fixes that by setting `width: 100%` on the `select` element, ensuring the selector should always have a maximum width that matches its nearest container.

### Genotype management

#### Before

![orgselector_overflow](https://user-images.githubusercontent.com/37659591/48128734-44ee6c00-e27f-11e8-9b38-9c105b689859.PNG)

#### After

![orgselector_no_overflow](https://user-images.githubusercontent.com/37659591/48128740-4a4bb680-e27f-11e8-9c55-36d81e0e2156.PNG)

### Metagenotype management

This page also uses the organism selector, and the fix is maybe a bit less graceful here because the columns are wider. It still prevents overflow though, and makes the columns more visually consistent. I might be able to set `max-width` instead, if we don't want the `select` to get too big.

![orgselector_metagenotype](https://user-images.githubusercontent.com/37659591/48128834-9c8cd780-e27f-11e8-843f-7b1d85958956.PNG)


