### PR TITLE
Add success notification when storing annotation

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -5199,6 +5199,12 @@ var annotationEditDialogCtrl =
       });
       q.then(function(annotation) {
         $uibModalInstance.close(annotation);
+        toaster.pop({
+          type: 'success',
+          title: 'Annotation stored successfully.',
+          timeout: 5000,
+          showCloseButton: true
+        });
       })
       .catch(function(message) {
         toaster.pop('error', message);


### PR DESCRIPTION
Fixes #1665 

The 'Copy and edit' link on a phenotype annotation provided no feedback when copying the annotation to a different genotype (e.g. changing the genotype from TRI5Δ to TRI5+). I've fixed this by adding a toaster notification in the success case that notifies the user that the 'Annotation stored successfully.'

We considered adding a link to the relevant genotype details page, so that the user can confirm that their genotype was copied with the expected details, but we decided to put this on hold for the following reasons:

* users may not notice the link in the notification;

* the code I've changed applies to every case where the annotation is stored, and restricting the notification to the case where the genotype is duplicated to a different 'page' is more complicated; and

* the copying of an existing annotation onto a new genotype might be a fairly rare use case; we haven't had any complaints about this lack of functionality yet, so it may not be worth further effort.