### PR TITLE
Fix display issues with metagenotype list row

### DIFF
--- a/root/static/ng_templates/metagenotype_list_row.html
+++ b/root/static/ng_templates/metagenotype_list_row.html
@@ -20,6 +20,7 @@
                   Start a {{ annotationType.display_name }} annotation ...
               </a>
               </div>
+            <div>
             <a
                 ng-class="{disabled: metagenotype.metagenotype_id == null }"
                 href="{{viewAnnotationUri}}">
@@ -29,6 +30,7 @@
                 ng-if="!read_only_curs"
                 confirm="Are you sure you want to remove this metagenotype from your session?"
                 ng-click="delete()">Delete</a>
+            </div>
         </td>
     </tr>
 </tbody>

--- a/root/static/ng_templates/metagenotype_list_row.html
+++ b/root/static/ng_templates/metagenotype_list_row.html
@@ -17,7 +17,7 @@
                 ng-class="{disabled: metagenotype.metagenotype_id == null }"
                 ng-if="!read_only_curs"
                 href="{{curs_root_uri + '/feature/metagenotype/annotate/' + metagenotype.metagenotype_id + '/start/' + annotationType.name + '/'}}">
-                  Start a {{ annotationType.display_name }} annotation ...
+                  Annotate {{ annotationType.display_name }} phenotype...
               </a>
               </div>
             <div>


### PR DESCRIPTION
Fixes #1683.

I've opened this pull request to fix all the sub-issues in the issue above. These fixes include:

* Some of the side-links in the meta-genotype list row weren't enclosed in a `<div>`, meaning they didn't match the selector `td.table-row-actions div`, and their styling was inconsistent.