### PR TITLE
Add genotype management shortcut to metagenotype page

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1511,3 +1511,7 @@ a:not([href]) {
 .curs-organism-selector-select {
   width: 100%;
 }
+
+.metagenotype-genotype-shortcut {
+  padding-top: 20px;
+}

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6594,7 +6594,14 @@ var metagenotypeGenotypePicker =
           typeLabel: 'Host',
           genotypeType: 'host',
           isHost: false,
+          genotypeShortcutUrl: null
         };
+
+        function setGenotypeShortcut(organismType) {
+          return CantoGlobals.curs_root_uri + '/' +
+            organismType.toLowerCase() +
+            '_genotype_manage'
+        }
 
         $scope.readGenotypes = function() {
           CursGenotypeList.cursGenotypeList({ include_allele: 1 }).then(function(results) {
@@ -6662,6 +6669,8 @@ var metagenotypeGenotypePicker =
         }
 
         $scope.data.isHost = !$scope.isPathogen;
+
+        $scope.data.genotypeShortcutUrl = setGenotypeShortcut($scope.data.genotypeType);
 
         Metagenotype.pickerOrganismCallbacks[$scope.data.genotypeType] = function (organism) {
           $scope.data.selectedOrganism = organism;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6575,7 +6575,7 @@ canto.directive('wildGenotypeView', [wildGenotypeView]);
 
 
 var metagenotypeGenotypePicker =
-  function(CursGenotypeList, toaster, Metagenotype, StrainsService) {
+  function(CantoGlobals, CursGenotypeList, toaster, Metagenotype, StrainsService) {
     return {
       scope: {
         isPathogen: '=',
@@ -6679,7 +6679,7 @@ var metagenotypeGenotypePicker =
 };
 
 canto.directive('metagenotypeGenotypePicker',
-  ['CursGenotypeList', 'toaster', 'Metagenotype', 'StrainsService', metagenotypeGenotypePicker]);
+  ['CantoGlobals', 'CursGenotypeList', 'toaster', 'Metagenotype', 'StrainsService', metagenotypeGenotypePicker]);
 
 
 var metagenotypeListRow = function(CantoGlobals, Metagenotype, AnnotationTypeConfig) {

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -6,6 +6,7 @@
             genotype-type="data.genotypeType"
             organism-selected="data.pickerCallback(organism)">
         </organism-selector>
+        <p><a href="{{data.genotypeShortcutUrl}}">Create a new {{data.genotypeType}} genotype...</a></p>
         <div ng-if="data.selectedOrganism">
             <div class="curs-box-title">Single allele genotypes</div>
             <div ng-show="data.singleAllele.length == 0">

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -6,7 +6,9 @@
             genotype-type="data.genotypeType"
             organism-selected="data.pickerCallback(organism)">
         </organism-selector>
-        <p><a href="{{data.genotypeShortcutUrl}}">Create a new {{data.genotypeType}} genotype...</a></p>
+        <p class="metagenotype-genotype-shortcut">
+          <a href="{{data.genotypeShortcutUrl}}">Create a new {{data.genotypeType}} genotype...</a>
+        </p>
         <div ng-if="data.selectedOrganism">
             <div class="curs-box-title">Single allele genotypes</div>
             <div ng-show="data.singleAllele.length == 0">


### PR DESCRIPTION
(Partially implements #1661)

This adds links to the genotype picker columns on the metagenotype page to allow users to more quickly navigate back to the pathogen or host genotype management pages. I haven't yet implemented the feature of the genotype management page automatically selecting the organism that was selected on the metagenotype page, since we have to pass this information via the URL and I was concerned that it could conflict with the existing URL logic that handles visually highlighting the last created genotype, for example:

`http://localhost:5000/curs/5b38aa5238216ac8/pathogen_genotype_manage#/select/1`

@kimrutherford I chose to inject `CantoGlobals` to get access to `curs_root_uri`, but it seems that `curs_root_uri` is already on the window object, so I could just access it directly &ndash; this direct access doesn't seem like a good idea to me though. Let me know if you think otherwise.