### PR TITLE
Fix support for strains in multi-allele genotypes

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4622,6 +4622,14 @@ var genotypeListViewCtrl =
       templateUrl: app_static_path + 'ng_templates/genotype_list_view.html',
       controller: function($scope) {
 
+        function hasDifferentStrains(genotypes) {
+          var firstStrain = genotypes[0].strain_name;
+          var strainsAreEqual = genotypes.every(function (genotype) {
+            return genotype.strain_name === firstStrain;
+          });
+          return ! strainsAreEqual;
+        }
+
         function getOrganismType(genotypes) {
           if (CantoGlobals.pathogen_host_mode === "1") {
             var genotype = genotypes[0];

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4670,6 +4670,14 @@ var genotypeListViewCtrl =
               return !!$scope.checkBoxChecked[genotype.genotype_id];
             });
 
+          if (hasDifferentStrains(checkedGenotypes)) {
+            toaster.pop(
+              'warning',
+              "Can't create a multi-allele genotype from different strains."
+            );
+            return;
+          }
+
           var allelesForGenotype =
             $.map(checkedGenotypes, function(genotype) {
               return genotype.alleles[0];

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4703,9 +4703,10 @@ var genotypeListViewCtrl =
           }
 
           var strain = $scope.genotypeList[0].strain_name;
+          var taxonid = $scope.genotypeList[0].organism.taxonid;
 
           var storePromise =
-            CursGenotypeList.storeGenotype(toaster, $http, undefined, undefined, newBackground, allelesForGenotype, undefined, strain);
+            CursGenotypeList.storeGenotype(toaster, $http, undefined, undefined, newBackground, allelesForGenotype, taxonid, strain);
 
           storePromise.then(function(result) {
             window.location.href =

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4686,8 +4686,10 @@ var genotypeListViewCtrl =
             newBackground = newBackgroundParts.join(' ');
           }
 
+          var strain = $scope.genotypeList[0].strain_name;
+
           var storePromise =
-            CursGenotypeList.storeGenotype(toaster, $http, undefined, undefined, newBackground, allelesForGenotype);
+            CursGenotypeList.storeGenotype(toaster, $http, undefined, undefined, newBackground, allelesForGenotype, undefined, strain);
 
           storePromise.then(function(result) {
             window.location.href =

--- a/root/static/ng_templates/genotype_list_row.html
+++ b/root/static/ng_templates/genotype_list_row.html
@@ -17,7 +17,7 @@
   <td rowspan="{{genotype.alleles.length}}" ng-hide="columnsToHide.background">
     <span ng-bind-html="genotype.background | wrapAtSpaces | encodeAlleleSymbols | toTrusted"></span>
   </td>
-  <td>{{ strain }}</td>
+  <td rowspan="{{genotype.alleles.length}}">{{ strain }}</td>
   <td style="width: 4em;" rowspan="{{genotype.alleles.length}}">
     {{genotype.annotation_count}}
     <div ng-if="navigateOnClick == 'false'" class="table-row-actions"


### PR DESCRIPTION
(Fixes #1703; fixes #1700; workaround for #1704)

Previously, creating a multi-allele genotype didn't save the `strain_name` or the `taxonid` of the organism for the combined genotypes. This fix retrieves both of those values from the first genotype in the list (I'm relying on the interface to prevent the display of genotypes that don't belong to the selected organism, but we might need extra checks on the server side to ensure this isn't the case).

I've also added a check to ensure that all of the `strain_name` values for the selected genotypes are equal; if they're not, Canto toasts a warning messages and returns from `combineGenotypes` early, doing nothing. A better solution would be to **a)** disable the genotype selection checkboxes for incompatible genotypes after the first genotype is selected, or **b)** disable the 'Combine selected genotypes' button and show a different `title` attribute explaining why it's been disabled.