### PR TITLE
Remove obsolete strain display in metagenotype list

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1515,3 +1515,6 @@ a:not([href]) {
 .metagenotype-genotype-shortcut {
   padding-top: 20px;
 }
+.metagenotype-list-strain {
+  display: inline-block;
+}

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6719,11 +6719,15 @@ var metagenotypeListRow = function(CantoGlobals, Metagenotype, AnnotationTypeCon
         replace: true,
         templateUrl: app_static_path + 'ng_templates/metagenotype_list_row.html',
         controller: function($scope) {
-            $scope.getName = function (type) {
+            $scope.getOrganismName = function (type) {
                 var metagenotype = $scope.metagenotype[type + '_genotype'];
                 var name = metagenotype.organism.full_name || '';
+                return name;
+            };
+            $scope.getStrainName = function (type) {
+                var metagenotype = $scope.metagenotype[type + '_genotype'];
                 var strain = metagenotype.strain_name || 'Wild type';
-                return name + ' (strain: ' + strain + ')';
+                return '(strain: ' + strain + ')';
             };
 
             $scope.getScope = function (type) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6723,7 +6723,7 @@ var metagenotypeListRow = function(CantoGlobals, Metagenotype, AnnotationTypeCon
                 var metagenotype = $scope.metagenotype[type + '_genotype'];
                 var name = metagenotype.organism.full_name || '';
                 var strain = metagenotype.strain_name || 'Wild type';
-                return name + ' ( strain: ' + strain + ')';
+                return name + ' (strain: ' + strain + ')';
             };
 
             $scope.getScope = function (type) {

--- a/root/static/ng_templates/metagenotype_list_row.html
+++ b/root/static/ng_templates/metagenotype_list_row.html
@@ -2,12 +2,10 @@
     <tr>
         <td>
             <p><strong>{{ getName('pathogen') }}</strong></p>
-            <p style="font-size: smaller;">{{ getScope('pathogen') }}</p>
         </td>
         <td>{{ metagenotype.pathogen_genotype.display_name }}</td>
         <td>
             <p><strong>{{ getName('host') }}</strong></p>
-            <p style="font-size: smaller;">{{ getScope('host') }}</p>
         </td>
         <td>{{ metagenotype.host_genotype.display_name }}</td>
         <td>{{ metagenotype.annotation_count }}</td>

--- a/root/static/ng_templates/metagenotype_list_row.html
+++ b/root/static/ng_templates/metagenotype_list_row.html
@@ -2,12 +2,12 @@
     <tr>
         <td>
           <b>{{ getOrganismName('pathogen') }}</b>
-          <span>{{ getStrainName('pathogen') }}</span>
+          <span class="metagenotype-list-strain">{{ getStrainName('pathogen') }}</span>
         </td>
         <td>{{ metagenotype.pathogen_genotype.display_name }}</td>
         <td>
           <b>{{ getOrganismName('host') }}</b>
-          <span>{{ getStrainName('host') }}</span>
+          <span class="metagenotype-list-strain">{{ getStrainName('host') }}</span>
         </td>
         <td>{{ metagenotype.host_genotype.display_name }}</td>
         <td>{{ metagenotype.annotation_count }}</td>

--- a/root/static/ng_templates/metagenotype_list_row.html
+++ b/root/static/ng_templates/metagenotype_list_row.html
@@ -1,8 +1,14 @@
 <tbody>
     <tr>
-        <td><b>{{ getName('pathogen') }}</b></td>
+        <td>
+          <b>{{ getOrganismName('pathogen') }}</b>
+          <span>{{ getStrainName('pathogen') }}</span>
+        </td>
         <td>{{ metagenotype.pathogen_genotype.display_name }}</td>
-        <td><b>{{ getName('host') }}</b></td>
+        <td>
+          <b>{{ getOrganismName('host') }}</b>
+          <span>{{ getStrainName('host') }}</span>
+        </td>
         <td>{{ metagenotype.host_genotype.display_name }}</td>
         <td>{{ metagenotype.annotation_count }}</td>
         <td class="table-row-actions">

--- a/root/static/ng_templates/metagenotype_list_row.html
+++ b/root/static/ng_templates/metagenotype_list_row.html
@@ -1,12 +1,8 @@
 <tbody>
     <tr>
-        <td>
-            <p><strong>{{ getName('pathogen') }}</strong></p>
-        </td>
+        <td><b>{{ getName('pathogen') }}</b></td>
         <td>{{ metagenotype.pathogen_genotype.display_name }}</td>
-        <td>
-            <p><strong>{{ getName('host') }}</strong></p>
-        </td>
+        <td><b>{{ getName('host') }}</b></td>
         <td>{{ metagenotype.host_genotype.display_name }}</td>
         <td>{{ metagenotype.annotation_count }}</td>
         <td class="table-row-actions">


### PR DESCRIPTION
Fixes #1702

The metagenotype list had two elements to display the host or pathogen strain, and one of them wasn't being used. I've removed the unused element, and also changed the styling on the new strain display so that:

* the strain name doesn't display as bold (only the organism name is displayed bold now), and

* the strain always appears on a new line.

Displaying the strain on its own line does add to the height, but I thought it was better to keep the organism name and strain separate, so not to risk confusing users into thinking the strain name was part of the organism name.

Here's what the list looks now:

![new_metagenotypes](https://user-images.githubusercontent.com/37659591/49443966-b8739280-f7c5-11e8-8b82-33f30d0a5c97.PNG)

And here's what it looked like before:

![old_metagenotypes](https://user-images.githubusercontent.com/37659591/49443985-c4f7eb00-f7c5-11e8-81d1-d8527195e3ad.PNG)

Unfortunately there is still some extra space, due to the list rows scaling to match the height of the shortcut links (to the right of each row). We could fix this by putting the shortcut links in a pop-up menu, like with the genotype management list:

![popup_menu_genotype](https://user-images.githubusercontent.com/37659591/49444309-ac3c0500-f7c6-11e8-80e8-14f30f97d979.PNG)