### PR TITLE
Redesign the organism table for compactness and consistency

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -371,6 +371,10 @@ table.curs-genotype-list tbody.odd, table.curs-genotype-list tbody:nth-child(odd
 .organism-table > tbody:nth-child(odd) {
   background-color: #EEEEDD;
 }
+.organism-table__no-gene-notice {
+  text-align: center;
+  color: #555;
+}
 .list_page th {
   white-space: normal !important;
 }

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -331,7 +331,9 @@ div#footer .sponsor, .canto-front-page .footer .sponsor {
   padding: 10px;
 }
 
-table.list, table.curs-genotype-list {
+table.list,
+table.curs-genotype-list,
+.organism-table {
   margin: 5px 0 5px 0;
   border-width: 0px;
   border-spacing: 5px;
@@ -341,7 +343,9 @@ table.list, table.curs-genotype-list {
   font-size: 90%;
   max-width: 80%;
 }
-table.list th, table.curs-genotype-list th {
+table.list th,
+table.curs-genotype-list th,
+.organism-table th {
   padding: 3px;
   background-color: #d0d0c0;
   font-weight: bold;
@@ -361,6 +365,12 @@ table.list tr.odd, table.list tr:nth-child(odd),
 table.curs-genotype-list tbody.odd, table.curs-genotype-list tbody:nth-child(odd){
   background-color: white;
 }
+.organism-table > tbody:nth-child(even) {
+  background-color: #FFFFFF;
+}
+.organism-table > tbody:nth-child(odd) {
+  background-color: #EEEEDD;
+}
 .list_page th {
   white-space: normal !important;
 }
@@ -374,7 +384,8 @@ table.list td, table.curs-genotype-list td {
   vertical-align: top;
 }
 
-table.list tr td {
+table.list tr td,
+.organism-table tr td {
   border-width: 1px;
   padding: 3px;
   border-style: solid;

--- a/root/static/ng_templates/edit_organisms.html
+++ b/root/static/ng_templates/edit_organisms.html
@@ -1,8 +1,6 @@
 <div>
   <edit-organisms-table title="Pathogen genes" organisms="getPathogens"></edit-organisms-table>
-  <br>
   <edit-organisms-table title="Host genes" organisms="getHosts"></edit-organisms-table>
-
   <div class="submit">
     <a href="{{addGenesUrl}}" class="btn btn-primary">Add more genes and organisms</a>&nbsp;
     <a href="{{continueUrl}}" ng-disabled="getContiueUrlDisabled()" class="btn btn-primary" title="{{ getContinueButtonTitle() }}">Continue</a>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -6,11 +6,11 @@
   <div ng-show="organisms().length > 0" class="curs-box-body">
     <table class="list">
       <thead>
-        <tr class="info">
+        <tr>
           <th>Organisms</th>
           <th colspan="5">Genes</th>
         </tr>
-        <tr class="info">
+        <tr>
             <th></th>
             <th>ID</th>
             <th>Name</th>
@@ -20,8 +20,8 @@
         </tr>
       </thead>
       <tbody ng-repeat-start="o in organisms() track by o.taxonid">
-        <tr ng-class="{'active': o.row % 2 == 0, 'success': o.row % 2 != 0}">
           <td rowspan="{{ o.genes.length }}">
+        <tr>
             <b>{{ o.scientific_name }}</b> <span ng-if="o.common_name">({{ o.common_name }})</span> [{{ o.taxonid }}]
           </td>
           <td ng-if="o.genes.length > 0">{{ firstGene(o.genes).systematic_identifier }}</td>
@@ -43,8 +43,7 @@
           </td>
         </tr>
         <tr ng-if="o.genes.length > 0"
-          ng-repeat="g in otherGenes(o.genes) track by g.systematic_identifier"
-          ng-class="{'active': o.row % 2 == 0, 'success': o.row % 2 != 0}">
+          ng-repeat="g in otherGenes(o.genes) track by g.systematic_identifier">
           <td>{{ g.systematic_identifier }}</td>
           <td>{{ g.name }}</td>
           <td>{{ g.synonyms.join(', ') }}</td>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -61,6 +61,5 @@
       <tr><td colspan="6"><strain-picker taxon-id="{{ o.taxonid }}"></strain-picker></td></tr>
       <tbody ng-repeat-end></tbody>
     </table>
-    <br>
   </div>
 </div>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -4,7 +4,7 @@
     <p>No genes have been added.</p>
   </div>
   <div ng-show="organisms().length > 0" class="curs-box-body">
-    <table class="table table-bordered">
+    <table class="list">
       <thead>
         <tr class="info">
           <th>Organisms</th>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -22,24 +22,8 @@
       <tbody ng-repeat-start="o in organisms() track by o.taxonid">
         <tr ng-class="{'active': o.row % 2 == 0, 'success': o.row % 2 != 0}">
           <td rowspan="{{ o.genes.length }}">
-            <table>
-              <tr>
-                <th width="150">Taxon ID:</th>
-                <td>{{ o.taxonid }}</td>
-              </tr>
-              <tr>
-                <th>Organism:</th>
-                <td>{{ o.scientific_name }}</td>
-              </tr>
-              <tr>
-                <th>Common name:</th>
-                <td>{{ o.common_name }}</td>
-              </tr>
-              <tr><td>&nbsp;</td></tr>
-              <tr>
-                <td colspan="2"><strain-picker taxon-id="{{ o.taxonid }}"></strain-picker></td>
-              </tr>
-            </table></td>
+            <i>{{ o.scientific_name }}</i> <span ng-if="o.common_name">({{ o.common_name }})</span> [{{ o.taxonid }}]
+          </td>
           <td ng-if="o.genes.length > 0">{{ firstGene(o.genes).systematic_identifier }}</td>
           <td ng-if="o.genes.length > 0">{{ firstGene(o.genes).name }}</td>
           <td ng-if="o.genes.length > 0">{{ firstGene(o.genes).synonyms.join(', ') }}</td>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -4,7 +4,7 @@
     <p>No genes have been added.</p>
   </div>
   <div ng-show="organisms().length > 0" class="curs-box-body">
-    <table class="list">
+    <table class="organism-table">
       <thead>
         <tr>
           <th>Organisms</th>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -20,8 +20,8 @@
         </tr>
       </thead>
       <tbody ng-repeat-start="o in organisms() track by o.taxonid">
-          <td rowspan="{{ o.genes.length }}">
         <tr>
+          <td rowspan="{{ o.genes.length === 0 ? 1 : o.genes.length }}">
             <b>{{ o.scientific_name }}</b> <span ng-if="o.common_name">({{ o.common_name }})</span> [{{ o.taxonid }}]
           </td>
           <td ng-if="o.genes.length > 0">{{ firstGene(o.genes).systematic_identifier }}</td>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -19,7 +19,7 @@
             <th>&nbsp;</th>
         </tr>
       </thead>
-      <tbody ng-repeat-start="o in organisms() track by o.taxonid">
+      <tbody ng-repeat="o in organisms() track by o.taxonid">
         <tr>
           <td rowspan="{{ o.genes.length === 0 ? 1 : o.genes.length }}">
             <b>{{ o.scientific_name }}</b> <span ng-if="o.common_name">({{ o.common_name }})</span> [{{ o.taxonid }}]
@@ -58,7 +58,6 @@
         </tr>
         <tr><td colspan="6"><strain-picker taxon-id="{{ o.taxonid }}"></strain-picker></td></tr>
       </tbody>
-      <tbody ng-repeat-end></tbody>
     </table>
   </div>
 </div>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -58,6 +58,7 @@
           </td>
         </tr>
       </tbody>
+      <tr><td colspan="6"><strain-picker taxon-id="{{ o.taxonid }}"></strain-picker></td></tr>
       <tbody ng-repeat-end></tbody>
     </table>
     <br>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -22,7 +22,7 @@
       <tbody ng-repeat-start="o in organisms() track by o.taxonid">
         <tr ng-class="{'active': o.row % 2 == 0, 'success': o.row % 2 != 0}">
           <td rowspan="{{ o.genes.length }}">
-            <i>{{ o.scientific_name }}</i> <span ng-if="o.common_name">({{ o.common_name }})</span> [{{ o.taxonid }}]
+            <b>{{ o.scientific_name }}</b> <span ng-if="o.common_name">({{ o.common_name }})</span> [{{ o.taxonid }}]
           </td>
           <td ng-if="o.genes.length > 0">{{ firstGene(o.genes).systematic_identifier }}</td>
           <td ng-if="o.genes.length > 0">{{ firstGene(o.genes).name }}</td>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -35,8 +35,8 @@
             ng-click="removeGene(firstGene(o.genes).gene_id)">
               <span ng-class="{'gene-button-delete-text-disabled': firstGene(o.genes).disabled}">X</span></button>
           </td>
-          <td ng-if="o.genes.length == 0" colspan="4" rowspan="2">No genes for this organism</td>
-          <td ng-if="o.genes.length == 0" rowspan="2"><button
+          <td ng-if="o.genes.length == 0" colspan="4">No genes for this organism</td>
+          <td ng-if="o.genes.length == 0"><button
             ng-class="{'btn-danger': (!g.disabled)}"
             title="Remove host"
             ng-click="removeHost(o.taxonid)">X</button>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -57,8 +57,8 @@
             <span ng-class="{'gene-button-delete-text-disabled': g.disabled}">X</span></button>
           </td>
         </tr>
+        <tr><td colspan="6"><strain-picker taxon-id="{{ o.taxonid }}"></strain-picker></td></tr>
       </tbody>
-      <tr><td colspan="6"><strain-picker taxon-id="{{ o.taxonid }}"></strain-picker></td></tr>
       <tbody ng-repeat-end></tbody>
     </table>
   </div>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -4,7 +4,7 @@
     <p>No genes have been added.</p>
   </div>
   <div ng-show="organisms().length > 0" class="curs-box-body">
-    <table class="organism-table">
+    <table class="curs-genotype-list">
       <thead>
         <tr>
           <th>Organisms</th>
@@ -35,7 +35,7 @@
             ng-click="removeGene(firstGene(o.genes).gene_id)">
               <span ng-class="{'gene-button-delete-text-disabled': firstGene(o.genes).disabled}">X</span></button>
           </td>
-          <td ng-if="o.genes.length == 0" colspan="4">No genes for this organism</td>
+          <td ng-if="o.genes.length == 0" class="organism-table__no-gene-notice" colspan="4">(No genes for this organism)</td>
           <td ng-if="o.genes.length == 0"><button
             ng-class="{'btn-danger': (!g.disabled)}"
             title="Remove host"

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -12,7 +12,7 @@
         </tr>
         <tr class="info">
             <th></th>
-            <th>Reference<br>Genome ID</th>
+            <th>ID</th>
             <th>Name</th>
             <th>Synonyms</th>
             <th>Product</th>


### PR DESCRIPTION
(Fixes #1676 and #1687)

Val Wood made a request for the organism table (on the 'Gene and host organism list' page) to take up less screen space, and also requested the strain selector to be more clearly separated from the rows containing the organisms's genes. I've done both of these things, and I've also switched the organism table to use consistent styling with the rest of Canto's tables. Here's how the organism table looks now:

![1676-row-striping-done](https://user-images.githubusercontent.com/37659591/51183999-e53dbe00-18ca-11e9-9f92-9b9fdd88f0ef.PNG)

Compared to how the table looked before:

![1676-old-organism-table](https://user-images.githubusercontent.com/37659591/51185528-410a4600-18cf-11e9-836b-bfc2a4d12d56.PNG)

Note that I've added a slightly different implementation of row striping, such that the colours alternate by organism rather than by gene (that is, by `<tbody>` rather than `<tr>`). This meant adding a new style class, `organism-table`, that inherits most rules from the `table.list` style class. I've since realised that I should probably have used the `curs-genotype-list` style class instead, since this does almost everything I need already &ndash; the only problem is that the row striping is in the opposite sequence to what I have now (i.e. odd rows are coloured, not even), and I think having even rows coloured is clearer in this case. @kimrutherford would you prefer if I re-used the existing `curs-genotype-list` class?

- - -

Note that I've also made some slight changes to the design of the text that shows when an organism has no genes. Here's how it looked before:

![1676-no-gene-before](https://user-images.githubusercontent.com/37659591/51184133-4feef980-18cb-11e9-897e-91d79312f0a0.PNG)

And here's how it looks now:

![1676-no-gene-after](https://user-images.githubusercontent.com/37659591/51184142-554c4400-18cb-11e9-8266-f379c8a16e8d.PNG)

My reason for the above change is that I thought it would make row groups with zero genes very visually distinct from rows with one gene. Previously I wasn't sure if the rows with zero genes stood out enough.