### PR TITLE
Allow editing strain of genotype, and refactor strain selector

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1536,6 +1536,10 @@ a:not([href]) {
   display: inline-block;
 }
 
+.strain-selector__select--genotype-edit {
+  padding: 3.5px 0;
+}
+
 .metagenotype-genotype-shortcut {
   padding-top: 20px;
 }

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1532,6 +1532,10 @@ a:not([href]) {
   width: 100%;
 }
 
+.strain-selector__container {
+  display: inline-block;
+}
+
 .metagenotype-genotype-shortcut {
   padding-top: 20px;
 }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3005,6 +3005,10 @@ var alleleEditDialogCtrl =
       getStrains: StrainsService.getSessionStrains,
     };
 
+    $scope.strainSelected = function (strain) {
+      $scope.strainData.selectedStrain = strain;
+    };
+
     $scope.env = {
     };
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3837,6 +3837,36 @@ canto.directive('organismSelector', [
   organismSelector
 ]);
 
+var strainSelector = function (CantoGlobals) {
+  return {
+    scope: {
+      strainNames: '<',
+      strainSelected: '&'
+    },
+    restrict: 'E',
+    templateUrl: app_static_path + 'ng_templates/strain_selector.html',
+    controller: strainSelectorCtrl
+  };
+};
+
+var strainSelectorCtrl = function ($scope, CantoGlobals) {
+
+  $scope.app_static_path = CantoGlobals.app_static_path;
+
+  $scope.data = {
+    selectedStrain: null
+  };
+
+  $scope.strainChanged = function () {
+    $scope.strainSelected({
+      strainName: $scope.data.selectedStrain
+    });
+  };
+
+};
+
+canto.directive('strainSelector', ['CantoGlobals', strainSelector]);
+
 var GenotypeGeneListCtrl =
   function($uibModal, $http, Curs, CursGenotypeList, CantoGlobals,
            CantoConfig, toaster) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -165,6 +165,13 @@ function getGenotypeManagePath(organismMode) {
   return paths.normal;
 }
 
+function filterStrainsByTaxonId(strains, taxonId) {
+  var taxonIdNum = parseInt(taxonId, 10);
+  return $.grep(strains, function (strain) {
+    return strain.taxon_id === taxonIdNum;
+  });
+}
+
 canto.filter('breakExtensions', function() {
   return function(text) {
     if (text) {
@@ -3366,13 +3373,6 @@ var genotypeEdit =
             toaster.pop('error', 'failed to get gene list from server');
           });
         };
-
-        function filterStrainsByTaxonId(strains, taxonId) {
-          var taxonIdNum = parseInt(taxonId, 10);
-          return $.grep(strains, function (strain) {
-            return strain.taxon_id === taxonIdNum;
-          });
-        }
 
         function getStrainNamesFromServer (taxonId) {
           Curs.list('strain').success(function (strains) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2989,7 +2989,7 @@ canto.directive('alleleNameComplete', ['CursAlleleList', 'toaster', alleleNameCo
 
 
 var alleleEditDialogCtrl =
-  function($scope, $uibModalInstance, toaster, CantoConfig, args, StrainsService, CantoGlobals) {
+  function($scope, $uibModalInstance, toaster, CantoConfig, args, Curs, CantoGlobals) {
     $scope.alleleData = {};
     copyObject(args.allele, $scope.alleleData);
     $scope.taxonId = args.taxonId;
@@ -3002,8 +3002,10 @@ var alleleEditDialogCtrl =
     $scope.strainData = {
       selectedStrain: null,
       showStrainPicker: CantoGlobals.multi_organism_mode && $scope.taxonId,
-      getStrains: StrainsService.getSessionStrains,
+      strains: null
     };
+
+    getStrainNamesFromServer($scope.taxonId);
 
     $scope.strainSelected = function (strain) {
       $scope.strainData.selectedStrain = strain;
@@ -3111,10 +3113,18 @@ var alleleEditDialogCtrl =
     $scope.cancel = function () {
       $uibModalInstance.dismiss('cancel');
     };
+
+    function getStrainNamesFromServer(taxonId) {
+      Curs.list('strain').success(function (strains) {
+        $scope.strainData.strains = filterStrainsByTaxonId(strains, taxonId);
+      }).error(function() {
+        toaster.pop('error', 'failed to get strain list from server');
+      });
+    }
   };
 
 canto.controller('AlleleEditDialogCtrl',
-                 ['$scope', '$uibModalInstance', 'toaster', 'CantoConfig', 'args', 'StrainsService', 'CantoGlobals',
+                 ['$scope', '$uibModalInstance', 'toaster', 'CantoConfig', 'args', 'Curs', 'CantoGlobals',
                  alleleEditDialogCtrl]);
 
 var termSuggestDialogCtrl =

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3382,12 +3382,8 @@ var genotypeEdit =
         }
 
         $scope.reset = function() {
-          $scope.alleles = [
-          ];
-
-          $scope.genes = [
-          ];
-
+          $scope.alleles = [];
+          $scope.genes = [];
           $scope.strains = [];
 
           $scope.getGenesFromServer();
@@ -3397,7 +3393,9 @@ var genotypeEdit =
             annotationCount: 0,
             genotypeName: null,
             genotypeBackground: null,
-            selectedStrainName: null
+            selectedStrainName: null,
+            strainName: null,
+            taxonId: null
           };
 
           $scope.wildTypeCheckPasses = true;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3390,6 +3390,8 @@ var genotypeEdit =
           $scope.genes = [
           ];
 
+          $scope.strains = [];
+
           $scope.getGenesFromServer();
 
           $scope.data = {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6999,7 +6999,7 @@ var strainPickerDialogCtrl =
     };
 
     $scope.isValid = function() {
-      return ($scope.strainData.strain !== 'choose a strain ...');
+      return !! $scope.strainData.strain;
     };
 
     $scope.ok = function () {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3391,7 +3391,7 @@ var genotypeEdit =
           $scope.strains = [];
 
           $scope.getGenesFromServer();
-          getStrainNamesFromServer(5518);
+          getStrainNamesFromServer($scope.taxonId);
 
           $scope.data = {
             annotationCount: 0,

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3386,9 +3386,6 @@ var genotypeEdit =
           $scope.genes = [];
           $scope.strains = [];
 
-          $scope.getGenesFromServer();
-          getStrainNamesFromServer($scope.taxonId);
-
           $scope.data = {
             annotationCount: 0,
             genotypeName: null,
@@ -3402,20 +3399,27 @@ var genotypeEdit =
         };
 
         $scope.reset();
+        reload();
 
-        if ($scope.genotypeId) {
-          if ($scope.editOrDuplicate == 'edit') {
-            $scope.data.genotype_id = $scope.genotypeId;
+        function reload() {
+          $scope.getGenesFromServer();
+
+          if ($scope.genotypeId) {
+            if ($scope.editOrDuplicate == 'edit') {
+              $scope.data.genotype_id = $scope.genotypeId;
+            }
+            Curs.details('genotype', ['by_id', $scope.genotypeId])
+              .success(function(genotypeDetails) {
+                $scope.alleles = genotypeDetails.alleles;
+                $scope.data.genotypeName = genotypeDetails.name;
+                $scope.data.genotypeBackground = genotypeDetails.background;
+                $scope.data.annotationCount = genotypeDetails.annotation_count;
+                $scope.data.taxonId = genotypeDetails.organism.taxonid;
+                $scope.data.strainName = genotypeDetails.strain_name;
+
+                getStrainNamesFromServer($scope.data.taxonId);
+              });
           }
-          Curs.details('genotype', ['by_id', $scope.genotypeId])
-            .success(function(genotypeDetails) {
-              $scope.alleles = genotypeDetails.alleles;
-              $scope.data.genotypeName = genotypeDetails.name;
-              $scope.data.genotypeBackground = genotypeDetails.background;
-              $scope.data.annotationCount = genotypeDetails.annotation_count;
-              $scope.data.taxonId = genotypeDetails.organism.taxonid;
-              $scope.data.strainName = genotypeDetails.strain_name;
-            });
         }
 
         $scope.env = {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6991,7 +6991,11 @@ var strainPickerDialogCtrl =
     $scope.taxonId = $scope.$resolve.args.taxonId;
     $scope.strainData = {};
 
-    $scope.strains = StrainsService.getSessionStrains;
+    $scope.strains = StrainsService.getSessionStrains($scope.taxonId);
+
+    $scope.strainSelected = function (strain) {
+      $scope.strainData.strain = strain;
+    };
 
     $scope.isValid = function() {
       return ($scope.strainData.strain !== 'choose a strain ...');

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6990,7 +6990,9 @@ var strainPickerDialogCtrl =
   function($scope, $uibModalInstance, StrainsService) {
 
     $scope.taxonId = $scope.$resolve.args.taxonId;
-    $scope.strainData = {};
+    $scope.strainData = {
+      strain: null
+    };
 
     $scope.strains = StrainsService.getSessionStrains($scope.taxonId);
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3348,8 +3348,10 @@ var genotypeEdit =
         $scope.app_static_path = CantoGlobals.app_static_path;
         $scope.multi_organism_mode = CantoGlobals.multi_organism_mode;
 
-        $scope.strainSelected = function (strainName) {
-          $scope.data.selectedStrainName = strainName;
+        $scope.strainSelected = function (strain) {
+          $scope.data.selectedStrainName = strain
+            ? strain.strain_name
+            : null;
         };
 
         $scope.getGenesFromServer = function() {
@@ -3371,17 +3373,9 @@ var genotypeEdit =
           });
         }
 
-        function extractStrainNames(strains) {
-          return $.map(strains, function (strain) {
-            return strain.strain_name;
-          });
-        }
-
         function getStrainNamesFromServer (taxonId) {
           Curs.list('strain').success(function (strains) {
-            $scope.strains = extractStrainNames(
-              filterStrainsByTaxonId(strains, taxonId)
-            );
+            $scope.strains = filterStrainsByTaxonId(strains, taxonId);
           }).error(function() {
             toaster.pop('error', 'failed to get strain list from server');
           });
@@ -3845,7 +3839,7 @@ canto.directive('organismSelector', [
 var strainSelector = function (CantoGlobals) {
   return {
     scope: {
-      strainNames: '<',
+      strains: '<',
       strainSelected: '&'
     },
     restrict: 'E',
@@ -3864,7 +3858,7 @@ var strainSelectorCtrl = function ($scope, CantoGlobals) {
 
   $scope.strainChanged = function () {
     $scope.strainSelected({
-      strainName: $scope.data.selectedStrain
+      strain: $scope.data.selectedStrain
     });
   };
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6987,9 +6987,9 @@ canto.directive('strainPicker', ['StrainsService', 'CantoService', strainPicker]
 
 
 var strainPickerDialogCtrl =
-  function($scope, $uibModalInstance, StrainsService) {
+  function($scope, $uibModalInstance, args, StrainsService) {
 
-    $scope.taxonId = $scope.$resolve.args.taxonId;
+    $scope.taxonId = args.taxonId;
     $scope.strainData = {
       strain: null
     };
@@ -7013,7 +7013,7 @@ var strainPickerDialogCtrl =
     };
   };
 
-canto.controller('strainPickerDialogCtrl', ['$scope', '$uibModalInstance', 'StrainsService', strainPickerDialogCtrl]);
+canto.controller('strainPickerDialogCtrl', ['$scope', '$uibModalInstance', 'args', 'StrainsService', strainPickerDialogCtrl]);
 
 
 function selectStrainPicker($uibModal, taxonId)

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3487,10 +3487,16 @@ var genotypeEdit =
         };
 
         $scope.store = function() {
-          var result =
-            storeGenotypeHelper(toaster, $http, $scope.data.genotype_id,
-                            $scope.data.genotypeName, $scope.data.genotypeBackground,
-                            $scope.alleles);
+          var result = storeGenotypeHelper(
+            toaster,
+            $http,
+            $scope.data.genotype_id,
+            $scope.data.genotypeName,
+            $scope.data.genotypeBackground,
+            $scope.alleles,
+            undefined,
+            $scope.data.selectedStrainName
+          );
 
           result.success(function(data) {
             if (data.status === "success") {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6996,14 +6996,14 @@ canto.directive('strainPicker', ['StrainsService', 'CantoService', strainPicker]
 
 
 var strainPickerDialogCtrl =
-  function($scope, $uibModalInstance, args, StrainsService) {
+  function($scope, $uibModalInstance, args, Curs) {
 
     $scope.taxonId = args.taxonId;
     $scope.strainData = {
       strain: null
     };
 
-    $scope.strains = StrainsService.getSessionStrains($scope.taxonId);
+    getStrainNamesFromServer($scope.taxonId);
 
     $scope.strainSelected = function (strain) {
       $scope.strainData.strain = strain;
@@ -7020,9 +7020,17 @@ var strainPickerDialogCtrl =
     $scope.cancel = function () {
       $uibModalInstance.dismiss('cancel');
     };
+
+    function getStrainNamesFromServer(taxonId) {
+      Curs.list('strain').success(function (strains) {
+        $scope.strains = filterStrainsByTaxonId(strains, taxonId);
+      }).error(function() {
+        toaster.pop('error', 'failed to get strain list from server');
+      });
+    }
   };
 
-canto.controller('strainPickerDialogCtrl', ['$scope', '$uibModalInstance', 'args', 'StrainsService', strainPickerDialogCtrl]);
+canto.controller('strainPickerDialogCtrl', ['$scope', '$uibModalInstance', 'args', 'Curs', strainPickerDialogCtrl]);
 
 
 function selectStrainPicker($uibModal, taxonId)

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3391,6 +3391,7 @@ var genotypeEdit =
           $scope.strains = [];
 
           $scope.getGenesFromServer();
+          getStrainNamesFromServer(5518);
 
           $scope.data = {
             annotationCount: 0,

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3361,6 +3361,28 @@ var genotypeEdit =
           });
         };
 
+        function filterStrainsByTaxonId(strains, taxonId) {
+          return $.grep(strains, function (strain) {
+            return strain.taxon_id === taxonId;
+          });
+        }
+
+        function extractStrainNames(strains) {
+          return $.map(strains, function (strain) {
+            return strain.strain_name;
+          });
+        }
+
+        function getStrainNamesFromServer (taxonId) {
+          Curs.list('strain').success(function (strains) {
+            $scope.strains = extractStrainNames(
+              filterStrainsByTaxonId(strains, taxonId)
+            );
+          }).error(function() {
+            toaster.pop('error', 'failed to get strain list from server');
+          });
+        }
+
         $scope.reset = function() {
           $scope.alleles = [
           ];

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3368,8 +3368,9 @@ var genotypeEdit =
         };
 
         function filterStrainsByTaxonId(strains, taxonId) {
+          var taxonIdNum = parseInt(taxonId, 10);
           return $.grep(strains, function (strain) {
-            return strain.taxon_id === taxonId;
+            return strain.taxon_id === taxonIdNum;
           });
         }
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3348,6 +3348,10 @@ var genotypeEdit =
         $scope.app_static_path = CantoGlobals.app_static_path;
         $scope.multi_organism_mode = CantoGlobals.multi_organism_mode;
 
+        $scope.strainSelected = function (strainName) {
+          $scope.data.selectedStrainName = strainName;
+        };
+
         $scope.getGenesFromServer = function() {
           Curs.list('gene').success(function(results) {
             $scope.genes = results;
@@ -3398,6 +3402,7 @@ var genotypeEdit =
             annotationCount: 0,
             genotypeName: null,
             genotypeBackground: null,
+            selectedStrainName: null
           };
 
           $scope.wildTypeCheckPasses = true;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3005,7 +3005,7 @@ var alleleEditDialogCtrl =
       strains: null
     };
 
-    getStrainNamesFromServer($scope.taxonId);
+    getStrainsFromServer($scope.taxonId);
 
     $scope.strainSelected = function (strain) {
       $scope.strainData.selectedStrain = strain;
@@ -3114,7 +3114,7 @@ var alleleEditDialogCtrl =
       $uibModalInstance.dismiss('cancel');
     };
 
-    function getStrainNamesFromServer(taxonId) {
+    function getStrainsFromServer(taxonId) {
       Curs.list('strain').success(function (strains) {
         $scope.strainData.strains = filterStrainsByTaxonId(strains, taxonId);
       }).error(function() {
@@ -3388,7 +3388,7 @@ var genotypeEdit =
           });
         };
 
-        function getStrainNamesFromServer (taxonId) {
+        function getStrainsFromServer(taxonId) {
           Curs.list('strain').success(function (strains) {
             $scope.strains = filterStrainsByTaxonId(strains, taxonId);
           }).error(function() {
@@ -3432,7 +3432,7 @@ var genotypeEdit =
                 $scope.data.taxonId = genotypeDetails.organism.taxonid;
                 $scope.data.strainName = genotypeDetails.strain_name;
 
-                getStrainNamesFromServer($scope.data.taxonId);
+                getStrainsFromServer($scope.data.taxonId);
               });
           }
         }
@@ -7017,7 +7017,7 @@ var strainPickerDialogCtrl =
       strain: null
     };
 
-    getStrainNamesFromServer($scope.taxonId);
+    getStrainsFromServer($scope.taxonId);
 
     $scope.strainSelected = function (strain) {
       $scope.strainData.strain = strain;
@@ -7035,7 +7035,7 @@ var strainPickerDialogCtrl =
       $uibModalInstance.dismiss('cancel');
     };
 
-    function getStrainNamesFromServer(taxonId) {
+    function getStrainsFromServer(taxonId) {
       Curs.list('strain').success(function (strains) {
         $scope.strains = filterStrainsByTaxonId(strains, taxonId);
       }).error(function() {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3864,7 +3864,8 @@ var strainSelector = function (CantoGlobals) {
   return {
     scope: {
       strains: '<',
-      strainSelected: '&'
+      strainSelected: '&',
+      styleClass: '@?'
     },
     restrict: 'E',
     templateUrl: app_static_path + 'ng_templates/strain_selector.html',
@@ -3877,7 +3878,8 @@ var strainSelectorCtrl = function ($scope, CantoGlobals) {
   $scope.app_static_path = CantoGlobals.app_static_path;
 
   $scope.data = {
-    selectedStrain: null
+    selectedStrain: null,
+    styleClass: computeStyleClass($scope.styleClass)
   };
 
   $scope.strainChanged = function () {
@@ -3885,6 +3887,10 @@ var strainSelectorCtrl = function ($scope, CantoGlobals) {
       strain: $scope.data.selectedStrain
     });
   };
+
+  function computeStyleClass(className) {
+    return className === undefined ? 'form-control' : className;
+  }
 
 };
 

--- a/root/static/ng_templates/allele_edit.html
+++ b/root/static/ng_templates/allele_edit.html
@@ -30,13 +30,10 @@
         <tr ng-if="strainData.showStrainPicker" class="curs-allele-type-select">
           <td>Strain used</td>
           <td>
-              <select
-                  class="form-control"
-                  ng-model="strainData.selectedStrain"
-                  name="curs-allele-type"
-                  ng-options="st.strain_name for st in strainData.getStrains(taxonId) track by st.strain_name">
-                  <option value="">Choose a strain ...</option>
-              </select>
+              <strain-selector
+                strains="strainData.getStrains(taxonId)"
+                strain-selected="strainSelected(strain)">
+              </strain-selector>
           </td>
       </tr>
 

--- a/root/static/ng_templates/allele_edit.html
+++ b/root/static/ng_templates/allele_edit.html
@@ -31,7 +31,7 @@
           <td>Strain used</td>
           <td>
               <strain-selector
-                strains="strainData.getStrains(taxonId)"
+                strains="strainData.strains"
                 strain-selected="strainSelected(strain)">
               </strain-selector>
           </td>

--- a/root/static/ng_templates/genotype_edit.html
+++ b/root/static/ng_templates/genotype_edit.html
@@ -18,7 +18,8 @@
         <div>
           Strain: <strain-selector
             strains="strains"
-            strain-selected="strainSelected(strain)">
+            strain-selected="strainSelected(strain)"
+            style-class="strain-selector__select--genotype-edit">
           </strain-selector>
         </div>
       </div>

--- a/root/static/ng_templates/genotype_edit.html
+++ b/root/static/ng_templates/genotype_edit.html
@@ -15,7 +15,7 @@
                              ng-model="data.genotypeBackground" />
           <help-icon key="genotype_edit_background_input"></help-icon>
         </div>
-        <div>
+        <div ng-if="multi_organism_mode">
           Strain: <strain-selector
             strains="strains"
             strain-selected="strainSelected(strain)"

--- a/root/static/ng_templates/genotype_edit.html
+++ b/root/static/ng_templates/genotype_edit.html
@@ -17,8 +17,8 @@
         </div>
         <div>
           Strain: <strain-selector
-            strain-names="strains"
-            strain-selected="strainSelected(strainName)">
+            strains="strains"
+            strain-selected="strainSelected(strain)">
           </strain-selector>
         </div>
       </div>

--- a/root/static/ng_templates/genotype_edit.html
+++ b/root/static/ng_templates/genotype_edit.html
@@ -15,6 +15,12 @@
                              ng-model="data.genotypeBackground" />
           <help-icon key="genotype_edit_background_input"></help-icon>
         </div>
+        <div>
+          Strain: <strain-selector
+            strain-names="strains"
+            strain-selected="strainSelected(strainName)">
+          </strain-selector>
+        </div>
       </div>
       <div class="col-sm-5 col-md-5">
         <div ng-show="editOrDuplicate == 'edit' && data.annotationCount > 0"

--- a/root/static/ng_templates/select_strain_picker.html
+++ b/root/static/ng_templates/select_strain_picker.html
@@ -11,13 +11,10 @@
                         <tr class="curs-allele-type-select">
                             <td>Available Strains for this curation</td>
                             <td>
-                                <select
-                                    class="form-control"
-                                    ng-model="strainData.strain"
-                                    name="curs-allele-type"
-                                    ng-options="st.strain_name for st in strains(taxonId) track by st.strain_name">
-                                    <option value="">Choose a strain ...</option>
-                                </select>
+                                <strain-selector
+                                    strains="strains"
+                                    strain-selected="strainSelected(strain)">
+                                </strain-selector>
                             </td>
                         </tr>
                     </table>

--- a/root/static/ng_templates/strain_selector.html
+++ b/root/static/ng_templates/strain_selector.html
@@ -1,5 +1,6 @@
-<div>
+<div class="strain-selector__container">
   <select
+      ng-class="form-control"
       ng-model="data.selectedStrain"
       ng-change="strainChanged()"
       name="curs-allele-type"

--- a/root/static/ng_templates/strain_selector.html
+++ b/root/static/ng_templates/strain_selector.html
@@ -1,6 +1,5 @@
 <div>
   <select
-      class="form-control"
       ng-model="data.selectedStrain"
       ng-change="strainChanged()"
       name="curs-allele-type"

--- a/root/static/ng_templates/strain_selector.html
+++ b/root/static/ng_templates/strain_selector.html
@@ -3,7 +3,7 @@
       ng-model="data.selectedStrain"
       ng-change="strainChanged()"
       name="curs-allele-type"
-      ng-options="s for s in strainNames">
+      ng-options="s.strain_name for s in strains track by s.strain_name">
     <option value="">Choose a strain ...</option>
   </select>
 </div>

--- a/root/static/ng_templates/strain_selector.html
+++ b/root/static/ng_templates/strain_selector.html
@@ -1,0 +1,10 @@
+<div>
+  <select
+      class="form-control"
+      ng-model="data.selectedStrain"
+      ng-change="strainChanged()"
+      name="curs-allele-type"
+      ng-options="s for s in strainNames">
+    <option value="">Choose a strain ...</option>
+  </select>
+</div>

--- a/root/static/ng_templates/strain_selector.html
+++ b/root/static/ng_templates/strain_selector.html
@@ -1,6 +1,6 @@
 <div class="strain-selector__container">
   <select
-      ng-class="form-control"
+      ng-class="data.styleClass"
       ng-model="data.selectedStrain"
       ng-change="strainChanged()"
       name="curs-allele-type"


### PR DESCRIPTION
(Fixes #1701)

This pull request allows editing the strain of a genotype on the genotype edit page, and extracts the strain selector into its own directive &ndash; it was previously hard-coded into the allele creation modals on the genotype management page. Here's how the new selector looks:

![1701-genotype-edit-strain-selector](https://user-images.githubusercontent.com/37659591/51325294-86ac4780-1a64-11e9-8f49-9136752764ad.PNG)

@kimrutherford The main problem I had implementing this was getting the selector to cooperate with the `StrainsService`. I considered changing the internals of the service, but that risks affecting many more directives than the ones I was focusing on, so eventually I decided to switch the relevant directives back to using the `Curs` service &ndash; specifically, `Curs.list('strain')` &ndash; and performed the filtering of strains (by taxon ID) in the controllers. I only intend for this to be a workaround until we can figure out a more permanent fix to the `StrainsService`. Please let me know if you want further explanation / justification.

I've also added the ability for the strain selector to be styled according to its context, by optionally passing in a style class name to the directive (as a text binding). I thought this was necessary since Canto's modals use the bootstrap-style `form-control` classes, whereas the fields on the _genotype edit_ page use minimal styling. I've set `form-control` as the default, and I've specified other styling rules where necessary, so the selector always looks consistent with its context. (It's possible that I could've used CSS descendant selectors to achieve the same result, but this seemed more complicated at the time.)