### PR TITLE
Add organism and strain columns to annotation tables

### DIFF
--- a/root/static/ng_templates/annotation_table.html
+++ b/root/static/ng_templates/annotation_table.html
@@ -29,7 +29,7 @@
           <thead>
             <tr>
               <th ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">Organism</th>
-              <th ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">Strain</th>
+              <th ng-if="multiOrganismMode && annotationType.feature_type === 'genotype'">Strain</th>
               <th ng-if="annotationType.feature_type == 'genotype'">Genes</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_background">Background</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_name">Genotype name</th>

--- a/root/static/ng_templates/annotation_table.html
+++ b/root/static/ng_templates/annotation_table.html
@@ -28,6 +28,8 @@
         <table ng-switch-when="ontology" class="list">
           <thead>
             <tr>
+              <th ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">Organism</th>
+              <th ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">Strain</th>
               <th ng-if="annotationType.feature_type == 'genotype'">Genes</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_background">Background</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_name">Genotype name</th>

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -1,4 +1,10 @@
 <tr ng-class="{ 'curs-row-checked' : sessionState == 'APPROVAL_IN_PROGRESS' && checked == 'yes' }">
+  <td ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">
+    {{annotation.organism.scientific_name}}
+  </td>
+  <td ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">
+    {{annotation.strain_name}}
+  </td>
   <td ng-if="annotationType.feature_type == 'genotype'">
     <div style="white-space: nowrap" ng-repeat="allele in annotation.alleles">
       {{allele.gene_display_name}}

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -2,7 +2,7 @@
   <td ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">
     {{annotation.organism.scientific_name}}
   </td>
-  <td ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">
+  <td ng-if="multiOrganismMode && annotationType.feature_type === 'genotype'">
     {{annotation.strain_name}}
   </td>
   <td ng-if="annotationType.feature_type == 'genotype'">
@@ -52,7 +52,7 @@
         </div>
       </a>
       <span ng-if="!addLinks()">
-        <div style="white-space: nowrap" ng-repeat="allele in annotation.alleles"> 
+        <div style="white-space: nowrap" ng-repeat="allele in annotation.alleles">
           <initially-hidden-text text="{{allele.long_display_name | encodeAlleleSymbols | toTrusted}}"
                                  preview-char-count="50"
                                  break-on-comma="true"
@@ -141,4 +141,3 @@
     </div>
   </td>
 </tr>
-


### PR DESCRIPTION
(Fixes #1715)

This PR adds an organism column to wild-type annotations (GO annotations), and an organism and strain column to phenotype annotations. This should allow users to distinguish annotations that have the same gene name, but are for different organisms. The strain name currently only shows for annotations with a genotype feature, but it may need to show for certain gene feature annotations in future (the cases are still undecided).

![1750-organism-strain-columns](https://user-images.githubusercontent.com/37659591/51671271-7514f380-1fc0-11e9-837c-8a4221a3f134.PNG)