### PR TITLE
Show organism name on genotype edit page

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -736,6 +736,10 @@ table td.curs-genotype-checkbox-column {
   color: grey;
 }
 
+.curs-genotype-edit__organism-label {
+  padding: 3px 0;
+}
+
 .curs-genotype-list .selected, .curs-genotype-details .selected {
   background-color: #eee !important;
   border: 2.5px solid #888;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3456,6 +3456,7 @@ var genotypeEdit =
                 $scope.data.annotationCount = genotypeDetails.annotation_count;
                 $scope.data.taxonId = genotypeDetails.organism.taxonid;
                 $scope.data.strainName = genotypeDetails.strain_name;
+                $scope.data.organismName = genotypeDetails.organism.scientific_name;
 
                 getStrainsFromServer($scope.data.taxonId);
               });

--- a/root/static/ng_templates/genotype_edit.html
+++ b/root/static/ng_templates/genotype_edit.html
@@ -15,6 +15,10 @@
                              ng-model="data.genotypeBackground" />
           <help-icon key="genotype_edit_background_input"></help-icon>
         </div>
+        <div ng-if="multi_organism_mode"
+             class="curs-genotype-edit__organism-label">
+          Organism: {{ data.organismName }}
+        </div>
         <div ng-if="multi_organism_mode">
           Strain: <strain-selector
             strains="strains"


### PR DESCRIPTION
(Fixes #1749)

This changes the Genotype Edit page to display the scientific name of the organism whose genotype is being edited. Based on feedback from other collaborators, it was decided to show the organism name above the strain picker. The organism name only displays in multi-organism mode.

![1749-organism-name](https://user-images.githubusercontent.com/37659591/51915635-82bce580-23d3-11e9-9627-87430026c217.PNG)
