### PR TITLE
Filter gene list by organism on Genotype Edit page

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3405,6 +3405,10 @@ var genotypeEdit =
             var genes = results;
             genes = setGeneNames(genes);
 
+            var currentTaxonId = $scope.data.taxonId;
+            if (currentTaxonId) {
+              genes = filterGenesByOrganism(genes, currentTaxonId);
+            }
             $scope.genes = genes;
           }).error(function () {
             toaster.pop('error', 'failed to get gene list from server');
@@ -3453,7 +3457,6 @@ var genotypeEdit =
         reload();
 
         function reload() {
-          $scope.getGenesFromServer();
 
           if ($scope.genotypeId) {
             if ($scope.editOrDuplicate == 'edit') {
@@ -3472,6 +3475,8 @@ var genotypeEdit =
                 getStrainsFromServer($scope.data.taxonId);
               });
           }
+
+          $scope.getGenesFromServer();
         }
 
         $scope.env = {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3421,6 +3421,12 @@ var genotypeEdit =
           });
         }
 
+        function filterGenesByOrganism(genes, taxonId) {
+          return $.grep(genes, function (gene) {
+            return gene.organism.taxonid == taxonId;
+          });
+        }
+
         $scope.reset = function () {
           $scope.alleles = [];
           $scope.genes = [];

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3402,12 +3402,10 @@ var genotypeEdit =
 
         $scope.getGenesFromServer = function () {
           Curs.list('gene').success(function (results) {
-            $scope.genes = results;
+            var genes = results;
+            genes = setGeneNames(genes);
 
-            $.map($scope.genes,
-              function (gene) {
-                gene.display_name = gene.primary_name || gene.primary_identifier;
-              });
+            $scope.genes = genes;
           }).error(function () {
             toaster.pop('error', 'failed to get gene list from server');
           });
@@ -3425,6 +3423,13 @@ var genotypeEdit =
           return $.grep(genes, function (gene) {
             return gene.organism.taxonid == taxonId;
           });
+        }
+
+        function setGeneNames(genes) {
+          $.map(genes, function (gene) {
+            gene.display_name = gene.primary_name || gene.primary_identifier;
+          });
+          return genes;
         }
 
         $scope.reset = function () {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3472,11 +3472,12 @@ var genotypeEdit =
                 $scope.data.strainName = genotypeDetails.strain_name;
                 $scope.data.organismName = genotypeDetails.organism.scientific_name;
 
+                $scope.getGenesFromServer();
                 getStrainsFromServer($scope.data.taxonId);
               });
+          } else {
+            $scope.getGenesFromServer();
           }
-
-          $scope.getGenesFromServer();
         }
 
         $scope.env = {


### PR DESCRIPTION
(Fixes #1732)

Previously, the `genotypeEdit` controller didn't perform any filtering of the genes passed to the gene list, so the list displayed genes for all organisms in the curation session:

![1732-gene-list-before](https://user-images.githubusercontent.com/37659591/52052734-3bf3fa80-254f-11e9-8cd5-e2aebfb7fab2.PNG)

(The genes CPD_WHEAT and ENO don't belong to _Fusarium graminearum_.)

After this change, the list only displays genes for the organism corresponding to the genotype being edited:

![1732-gene-list-after](https://user-images.githubusercontent.com/37659591/52052771-5af28c80-254f-11e9-8acf-fdabd2d696c4.PNG)

- - -

This adds a new function, `filterGenesByOrganism(genes, taxonId)` to the `genotypeEdit` controller.  If there is no taxon ID set (i.e. because `genotypeId` is null and `genotypeDetails` aren't set), the filtering is skipped by `$scope.getGenesFromServer`. I had to move the call to `$scope.getGenesFromServer` to take place after the fetching of `genotypeDetails`, since it now depends on the taxon ID being there.

I was concerned about a possible race condition developing, given that the taxon ID and the gene list are both fetched asynchronously. I've tried to mitigate this in https://github.com/pombase/canto/commit/2dbf8bc48e9567b0b9f5ca7d90163bd31ddcc0be, but I'm not sure if there's a better solution.

I also factored out the setting of `gene.display_name` into its own function, `setGeneNames(genes)`, to simplify the body of `$scope.getGenesFromServer`.

@kimrutherford This might need testing in single organism mode, but I don't foresee any major problems, since it should behave correctly even when there's no taxon ID (the gene list is still correct without filtering when there's only one organism).