### PR TITLE
Change how hidden genotype columns are calculated

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4776,6 +4776,8 @@ var genotypeListViewCtrl =
           name: true,
         };
 
+        $scope.hiddenColumnsCount = Object.keys($scope.columnsToHide).length;
+
         $scope.checkedGenotypeIds = function () {
           var retVal = [];
           $.map($scope.genotypeList, function (genotype) {
@@ -4862,6 +4864,7 @@ var genotypeListViewCtrl =
                   $scope.columnsToHide.name = false;
                 }
               });
+            $scope.hiddenColumnsCount = getHiddenColumnsCount();
           }, true);
       },
     };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4755,6 +4755,18 @@ var genotypeListViewCtrl =
           return 'normal';
         }
 
+        function getHiddenColumnsCount() {
+          var key;
+          var count = 0;
+          for (key in $scope.columnsToHide) {
+            if ($scope.columnsToHide.hasOwnProperty(key)
+                && $scope.columnsToHide[key] === true) {
+              count += 1;
+            }
+          }
+          return count;
+        }
+
         $scope.organismType = getOrganismType($scope.genotypeList);
 
         $scope.checkBoxChecked = {};

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4774,6 +4774,7 @@ var genotypeListViewCtrl =
         $scope.columnsToHide = {
           background: true,
           name: true,
+          strain: true
         };
 
         $scope.hiddenColumnsCount = Object.keys($scope.columnsToHide).length;
@@ -4854,6 +4855,7 @@ var genotypeListViewCtrl =
             $scope.columnsToHide = {
               background: true,
               name: true,
+              strain: true,
             };
             $.map($scope.genotypeList,
               function (genotype) {
@@ -4862,6 +4864,9 @@ var genotypeListViewCtrl =
                 }
                 if (genotype.name) {
                   $scope.columnsToHide.name = false;
+                }
+                if (genotype.strain_name) {
+                  $scope.columnsToHide.strain = false;
                 }
               });
             $scope.hiddenColumnsCount = getHiddenColumnsCount();

--- a/root/static/ng_templates/genotype_list_row.html
+++ b/root/static/ng_templates/genotype_list_row.html
@@ -6,6 +6,9 @@
     <input ng-show="showCheckBoxActions" name="select-annotation" type="Checkbox" ng-model="$parent.checkBoxIsChecked"/>
   </td>
   <td>
+    <span ng-bind-html="genotype.name | wrapAtSpaces | encodeAlleleSymbols | toTrusted"></span>
+  </td>
+  <td>
     <a href="{{curs_root_uri + '/feature/gene/view/' + firstAllele.gene_id + (read_only_curs ? '/ro' : '')}}">{{firstAllele.gene_display_name}}</a>
   </td>
   <td>

--- a/root/static/ng_templates/genotype_list_row.html
+++ b/root/static/ng_templates/genotype_list_row.html
@@ -14,7 +14,7 @@
   <td>
     <span ng-bind-html="firstAllele.expression | formatExpression | toTrusted"></span>
   </td>
-  <td rowspan="{{genotype.alleles.length}}" ng-show="multi_organism_mode">{{ strain }}</td>
+  <td rowspan="{{genotype.alleles.length}}" ng-hide="columnsToHide.strain">{{ strain }}</td>
   <td rowspan="{{genotype.alleles.length}}" ng-hide="columnsToHide.background">
     <span ng-bind-html="genotype.background | wrapAtSpaces | encodeAlleleSymbols | toTrusted"></span>
   </td>

--- a/root/static/ng_templates/genotype_list_row.html
+++ b/root/static/ng_templates/genotype_list_row.html
@@ -5,7 +5,7 @@
       rowspan="{{genotype.alleles.length}}">
     <input ng-show="showCheckBoxActions" name="select-annotation" type="Checkbox" ng-model="$parent.checkBoxIsChecked"/>
   </td>
-  <td>
+  <td ng-hide="columnsToHide.name">
     <span ng-bind-html="genotype.name | wrapAtSpaces | encodeAlleleSymbols | toTrusted"></span>
   </td>
   <td>

--- a/root/static/ng_templates/genotype_list_view.html
+++ b/root/static/ng_templates/genotype_list_view.html
@@ -16,6 +16,9 @@ Annotations
       </tr>
       <tr>
         <th>
+          Name
+        </th>
+        <th>
           Genes
         </th>
         <th>

--- a/root/static/ng_templates/genotype_list_view.html
+++ b/root/static/ng_templates/genotype_list_view.html
@@ -24,7 +24,7 @@ Annotations
         <th>
           Expression
         </th>
-        <th ng-show="multi_organism_mode">
+        <th ng-hide="columnsToHide.strain">
           Strain
         </th>
         <th rowspan="2" ng-hide="columnsToHide.background">

--- a/root/static/ng_templates/genotype_list_view.html
+++ b/root/static/ng_templates/genotype_list_view.html
@@ -7,7 +7,7 @@
           &nbsp;
         </th>
         <th style="border-bottom: 1px solid grey"
-            colspan="{{columnsToHide.background ? 4 : 5}}">
+            colspan="{{6 - hiddenColumnsCount}}">
 Genotype
         </th>
         <th rowspan="2">

--- a/root/static/ng_templates/genotype_list_view.html
+++ b/root/static/ng_templates/genotype_list_view.html
@@ -15,7 +15,7 @@ Annotations
         </th>
       </tr>
       <tr>
-        <th>
+        <th ng-hide="columnsToHide.name">
           Name
         </th>
         <th>


### PR DESCRIPTION
(Fixes #1773)

The way in which columns were hidden in the genotype list (on the Genotype Management page and elsewhere) wasn't using consistent logic to hide its columns, and didn't cope well with the changes introduced by pathogen&ndash;host mode when I tested the list in single organism mode. The header table cells tended to go out of alignment with the table body cells, due to a `colspan` on the header being incorrectly calculated.

My changes add the 'strain' column to the list of `columnsToHide`, and the `colspan` is adjusted based on `$scope.hiddenColumnsCount` (a new variable), which is the sum of values in `columnsToHide` that equal true. I've added a function to the `$watch` on `genotypeListViewCtrl` that recalculates `$scope.hiddenColumnsCount` after `$scope.columnsToHide` changes, so I don't think there's any risk of the counts going out of step, but it might not be too good for performance.

I also ran into another bug as part of the changes, which was caused by the 'Name' column (`genotype.name`) not being present in the template code, but still present in the controller code. Because I'm now calculating the `colspan` based on the maximum number of columns minus `$scope.hiddenColumnsCount`, I decided to add the 'Name' column back in to prevent the columns becoming misaligned again.

@kimrutherford I suspect there was a valid reason to hide the 'Name' column, possibly to save screen space, so please let me know if you want me to remove all the code concerning the 'Name' column, rather than adding it back in.

I've tested these changes on the Genotype Management page in single organism mode, but haven't checked them properly in pathogen&ndash;host mode, or multi-organism mode, or on other pages where the genotype list might appear.