### PR TITLE
Make quick deletion strain picker conditional

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4091,6 +4091,10 @@ var GenotypeGeneListCtrl =
           });
         };
 
+        $scope.quickDeletion = $scope.multiOrganismMode
+          ? $scope.deleteSelectStrainPicker
+          : $scope.makeDeletionAllele
+
         $scope.deletionButtonTitle = function (gene_id) {
           if ($scope.hasDeletionHash[gene_id]) {
             return 'A deletion genotype already exists for this gene';

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -26,7 +26,7 @@
           <td>
             <button class="btn btn-primary btn-xs"
                     title="{{deletionButtonTitle(gene.gene_id)}}"
-                    ng-click="deleteSelectStrainPicker(gene.gene_id)">
+                    ng-click="quickDeletion(gene.gene_id)">
                 Deletion</button>
           </td>
           <td>


### PR DESCRIPTION
Fixes #1771 

This pull request adds a dispatch function to `GenotypeGeneListCtrl`, that assigns a function to the `ng-click` directive on the quick deletion button (on the Genotype Management page), based on the value of `$scope.multiOrganismMode`.

@kimrutherford let me know if you're not keen on the dynamic function assignment to the new `$scope.quickDeletion` variable, or if you'd prefer to not use a ternary expression. I admit the code is a bit esoteric:

```js
$scope.quickDeletion = $scope.multiOrganismMode
  ? $scope.deleteSelectStrainPicker
  : $scope.makeDeletionAllele
```

I did this in the interest of efficiency, so the function doesn't have to keep checking what mode it's in every time the 'Deletion' button is clicked. If you'd prefer a more conventional function that simply calls the correct function, I can amend it. This solution might be a bit brittle because it depends on the function signature of both methods being the same.