### PR TITLE
Resize finish textarea to suit laptop screens

### DIFF
--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -2064,6 +2064,9 @@ sub finish_form : Chained('top') Args(0)
         type => 'Textarea',
         cols => 80,
         rows => 3,
+        attributes => {
+          class => 'curs-final-comments-field'
+        },
         default => $self->get_metadata($schema, MESSAGE_FOR_CURATORS_KEY) // '',
       },
       map {

--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -2060,7 +2060,10 @@ sub finish_form : Chained('top') Args(0)
 
   my @all_elements = (
       {
-        name => $finish_textarea, type => 'Textarea', cols => 80, rows => 20,
+        name => $finish_textarea,
+        type => 'Textarea',
+        cols => 80,
+        rows => 3,
         default => $self->get_metadata($schema, MESSAGE_FOR_CURATORS_KEY) // '',
       },
       map {

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1550,3 +1550,8 @@ a:not([href]) {
 .metagenotype-list-strain {
   display: inline-block;
 }
+
+.curs-final-comments-field {
+  resize: vertical;
+  min-height: 60px;
+}


### PR DESCRIPTION
(Fixes #1784)

This change reduces the default height of the comments text box on the 'Finish Curation' page, so that the 'Finish' and 'Back' buttons are still visible on shorter screens (like laptops):

![1784-short-textarea](https://user-images.githubusercontent.com/37659591/53889267-0ba3ee00-401e-11e9-8db6-183c0111b9d6.PNG)

I've also set a `min-height` on the `textarea` element to prevent users from collapsing the text area to the point that it's almost invisible, and I've restricted resizing the text area to allow only vertical resizing, since horizontal resizing tends to interfere with usability if the user accidentally forces horizontal scrolling by resizing too far. @kimrutherford If you'd prefer some horizontal resizing, I think I can set a `max-width` instead to prevent the text area flowing off the side of the screen.