### PR TITLE
Include hidden organism selector in single organism mode

### DIFF
--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -1,6 +1,6 @@
 <div class="curs-genotype-gene-list">
   <organism-selector
-    ng-if="multiOrganismMode"
+    ng-show="multiOrganismMode"
     label="Organism"
     organism-selected="organismUpdated(organism)"
     genotype-type="genotypeType"


### PR DESCRIPTION
(Fixes #1790)

In order to support the selection of multiple organisms for PHI-Canto, we made the decision to have genes as a property of the organism. We also chose to have `organismSelectorCtrl` in charge of reloading the list of organisms; `GenotypeGeneListCtrl` simply gets the genes from the last organism selected by the organism selector.

Unfortunately, `organismSelectorCtrl` is never loaded in single organism mode, thanks to `ng-if` restricting it to multi-organism mode. This means that the gene list doesn't automatically reload in single organism mode. **This PR is a quick fix that changes the `ng-if` to `ng-show`**, so the organism selector can still make its logic available without being visible.

In future, I think a better solution would be to store the organism list in a component higher in the hierarchy, or through a generic data model service (for example, `GenotypeManageModelService`). The organism selector could then use service calls to notify when the organism changes. This avoids the problem of having long chains of callback bindings.