### PR TITLE
Fix confirmation button on edit organisms page

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7477,7 +7477,7 @@ var editOrganisms = function () {
       $scope.getPathogens = EditOrganismsSvc.getPathogenOrganisms;
       $scope.getHosts = EditOrganismsSvc.getHostOrganisms;
 
-      $scope.getContiueUrlDisabled = function () {
+      $scope.isContinueUrlDisabled = function () {
         if ($scope.getPathogens().length == 0 &&
           $scope.getHosts().length == 0) {
           return true;
@@ -7518,7 +7518,7 @@ var editOrganisms = function () {
       $scope.addGenesUrl = curs_root_uri + '/gene_upload/';
 
       $scope.getContinueButtonTitle = function () {
-        if ($scope.getContiueUrlDisabled()) {
+        if ($scope.isContinueUrlDisabled()) {
           return 'Please indicate what strains were used for all organisms!';
         } else {
           return 'Continue';

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7523,6 +7523,10 @@ var editOrganisms = function () {
           return 'Continue';
         }
       };
+
+      $scope.goToSummaryPage = function () {
+        $window.location.href = $scope.continueUrl;
+      };
     }
   };
 };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7519,7 +7519,7 @@ var editOrganisms = function () {
 
       $scope.getContinueButtonTitle = function () {
         if ($scope.isContinueUrlDisabled()) {
-          return 'Please indicate what strains were used for all organisms!';
+          return 'Please specify which strains were used for all organisms.';
         } else {
           return 'Continue';
         }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7476,6 +7476,8 @@ var editOrganisms = function () {
     controller: function ($scope, EditOrganismsSvc, StrainsService) {
       $scope.getPathogens = EditOrganismsSvc.getPathogenOrganisms;
       $scope.getHosts = EditOrganismsSvc.getHostOrganisms;
+      $scope.continueUrl = curs_root_uri;
+      $scope.addGenesUrl = curs_root_uri + '/gene_upload/';
 
       $scope.isContinueUrlDisabled = function () {
         if ($scope.getPathogens().length == 0 &&
@@ -7513,9 +7515,6 @@ var editOrganisms = function () {
 
         return false;
       };
-
-      $scope.continueUrl = curs_root_uri;
-      $scope.addGenesUrl = curs_root_uri + '/gene_upload/';
 
       $scope.getContinueButtonTitle = function () {
         if ($scope.isContinueUrlDisabled()) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7473,7 +7473,7 @@ var editOrganisms = function () {
     restrict: 'E',
     replace: true,
     templateUrl: app_static_path + 'ng_templates/edit_organisms.html',
-    controller: function ($scope, EditOrganismsSvc, StrainsService) {
+    controller: function ($scope, $window, EditOrganismsSvc, StrainsService) {
       $scope.getPathogens = EditOrganismsSvc.getPathogenOrganisms;
       $scope.getHosts = EditOrganismsSvc.getHostOrganisms;
       $scope.continueUrl = curs_root_uri;
@@ -7527,4 +7527,4 @@ var editOrganisms = function () {
   };
 };
 
-canto.directive('editOrganisms', ['EditOrganismsSvc', 'StrainsService', editOrganisms]);
+canto.directive('editOrganisms', ['$window', 'EditOrganismsSvc', 'StrainsService', editOrganisms]);

--- a/root/static/ng_templates/edit_organisms.html
+++ b/root/static/ng_templates/edit_organisms.html
@@ -3,6 +3,6 @@
   <edit-organisms-table title="Host genes" organisms="getHosts"></edit-organisms-table>
   <div class="submit">
     <a href="{{addGenesUrl}}" class="btn btn-primary">Add more genes and organisms</a>&nbsp;
-    <a href="{{continueUrl}}" ng-disabled="isContinueUrlDisabled()" class="btn btn-primary" title="{{ getContinueButtonTitle() }}">Continue</a>
+    <button href="{{continueUrl}}" ng-disabled="isContinueUrlDisabled()" class="btn btn-primary" title="{{ getContinueButtonTitle() }}">Continue</a>
   </div>
 </div>

--- a/root/static/ng_templates/edit_organisms.html
+++ b/root/static/ng_templates/edit_organisms.html
@@ -3,6 +3,6 @@
   <edit-organisms-table title="Host genes" organisms="getHosts"></edit-organisms-table>
   <div class="submit">
     <a href="{{addGenesUrl}}" class="btn btn-primary">Add more genes and organisms</a>&nbsp;
-    <button href="{{continueUrl}}" ng-disabled="isContinueUrlDisabled()" class="btn btn-primary" title="{{ getContinueButtonTitle() }}">Continue</a>
+    <button ng-click="goToSummaryPage()" ng-disabled="isContinueUrlDisabled()" class="btn btn-primary" title="{{ getContinueButtonTitle() }}">Continue</a>
   </div>
 </div>

--- a/root/static/ng_templates/edit_organisms.html
+++ b/root/static/ng_templates/edit_organisms.html
@@ -3,6 +3,6 @@
   <edit-organisms-table title="Host genes" organisms="getHosts"></edit-organisms-table>
   <div class="submit">
     <a href="{{addGenesUrl}}" class="btn btn-primary">Add more genes and organisms</a>&nbsp;
-    <a href="{{continueUrl}}" ng-disabled="getContiueUrlDisabled()" class="btn btn-primary" title="{{ getContinueButtonTitle() }}">Continue</a>
+    <a href="{{continueUrl}}" ng-disabled="isContinueUrlDisabled()" class="btn btn-primary" title="{{ getContinueButtonTitle() }}">Continue</a>
   </div>
 </div>


### PR DESCRIPTION
(Fixes #1762)

This fixes a bug with the 'Continue' link on the 'Gene and host organism list' page (template `edit_organisms.html`). The bug was due to the `ng-disabled` directive being applied to a link that was _styled_ like a button (rather than being applied to a real `<button>` element), and links do not support the `disabled` attribute.

I've changed the link to a button so that the disabled state is properly supported – click events do not fire from an element in the disabled state, so checks aren't needed in the controller to prevent redirection. @kimrutherford If you'd prefer the element to stay as a link, I think it should be possible to override the redirection on the link to do nothing if the state of organisms and strains is invalid.