### PR TITLE
Add a strains_mode

### DIFF
--- a/canto.yaml
+++ b/canto.yaml
@@ -30,8 +30,8 @@ app_version: v1279
 schema_version: 26
 
 ## Set this to create a Canto instance for a particular organism.  If not set,
-## all gene lookups with match genes from any organism (and will return the
-## organism).
+## Canto will be in multi-organism mode and the multi_organism_mode will be set.
+## In multi-organism mode all gene lookups with match genes from any organism.
 #instance_organism:
 #  taxonid: 4896
 
@@ -40,6 +40,9 @@ schema_version: 26
 ## see also: Canto::Role::TaxonIDLookup
 # organism_taxon_id:
 #   'Schizosaccharomyces pombe': 4896
+
+## set to 1 to enable strains for genotypes
+strains_mode: 0
 
 # the path that the home link goes to
 instance_front_path: /docs/instance_front

--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -163,6 +163,7 @@ sub top : Chained('/') PathPart('curs') CaptureArgs(1)
 
   $st->{instance_organism} = $config->{instance_organism};
   $st->{multi_organism_mode} = !defined $st->{instance_organism};
+  $st->{strains_mode} = $config->{strains_mode};
   $st->{pathogen_host_mode} = $config->{pathogen_host_mode};
 
   my $with_gene_evidence_codes =

--- a/root/curs/autohandler
+++ b/root/curs/autohandler
@@ -16,6 +16,7 @@ var with_gene_evidence_codes = <% $with_gene_evidence_codes_js |n %>;
 var annotation_type_config = <% $annotation_type_config_js |n %>;
 var curs_session_state = '<% $curs_session_state |n %>';
 var multi_organism_mode = '<% $multi_organism_mode %>';
+var strains_mode = '<% $strains_mode %>';
 var pathogen_host_mode = '<% $pathogen_host_mode %>';
 var alleles_have_expression = <% $alleles_have_expression ? 'true' : 'false' %>;
 </script>
@@ -64,6 +65,7 @@ my $annotation_type_config = $st->{annotation_type_config};
 my $annotation_type_config_js = Data::JavaScript::Anon->anon_dump($annotation_type_config);
 
 my $multi_organism_mode = $st->{multi_organism_mode} || 0;
+my $strains_mode = $st->{strains_mode} || 0;
 my $pathogen_host_mode = $st->{pathogen_host_mode} || 0;
 my $alleles_have_expression = $c->config()->{alleles_have_expression} || 0;
 </%init>

--- a/root/curs/gene_list_edit_table.mhtml
+++ b/root/curs/gene_list_edit_table.mhtml
@@ -11,7 +11,7 @@
           <% $col_name %>
         </th>
 %     }
-%     if ($multi_organism_mode) {
+%     if ($strains_mode) {
         <th>
           Strains
         </th>
@@ -29,7 +29,7 @@
         <% $gene->{$col_name} |n %>
       </td>
 %     }
-%     if ($multi_organism_mode) {
+%     if ($strains_mode) {
       <td>
         <strain-picker taxon-id="<% $gene->{'taxonid'} %>"></strain-picker>
       </td>
@@ -48,7 +48,7 @@
   </table>
 
 <%init>
-my $multi_organism_mode = $c->stash()->{multi_organism_mode} || 0;
+my $strains_mode = $c->config()->{strains_mode} || 0;
 
 sub _has_annotations
 {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7589,7 +7589,7 @@ var editOrganismsGenesTable = function () {
 canto.directive('editOrganismsGenesTable', [editOrganismsGenesTable]);
 
 
-var editOrganismsTable = function (CantoGlobals) {
+var editOrganismsTable = function (EditOrganismsSvc, CantoGlobals) {
   return {
     scope: {
       title: '@',
@@ -7651,16 +7651,16 @@ var editOrganismsTable = function (CantoGlobals) {
 };
 
 canto.directive('editOrganismsTable',
-                ['EditOrganismsSvc', editOrganismsTable, 'CantoGlobals']);
+                ['EditOrganismsSvc', 'CantoGlobals', editOrganismsTable]);
 
 
-var editOrganisms = function () {
+var editOrganisms = function ($window, EditOrganismsSvc, StrainsService, CantoGlobals) {
   return {
     scope: {},
     restrict: 'E',
     replace: true,
     templateUrl: app_static_path + 'ng_templates/edit_organisms.html',
-    controller: function ($scope, $window, EditOrganismsSvc, StrainsService) {
+    controller: function ($scope) {
       $scope.getPathogens = EditOrganismsSvc.getPathogenOrganisms;
       $scope.getHosts = EditOrganismsSvc.getHostOrganisms;
       $scope.continueUrl = curs_root_uri;
@@ -7670,6 +7670,10 @@ var editOrganisms = function () {
         if ($scope.getPathogens().length == 0 &&
           $scope.getHosts().length == 0) {
           return true;
+        }
+
+        if (!CantoGlobals.strains_mode) {
+          return false;
         }
 
         if (StrainsService.sessionStrains.length == 0) {
@@ -7718,4 +7722,4 @@ var editOrganisms = function () {
   };
 };
 
-canto.directive('editOrganisms', ['$window', 'EditOrganismsSvc', 'StrainsService', editOrganisms]);
+canto.directive('editOrganisms', ['$window', 'EditOrganismsSvc', 'StrainsService', 'CantoGlobals', editOrganisms]);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -5808,6 +5808,7 @@ var annotationTableCtrl =
           genotype_background: true,
           term_suggestion: true,
           gene_product_form_id: true,
+          strain_name: true,
         };
 
         $scope.data = {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -664,6 +664,7 @@ canto.service('CantoGlobals', function ($window) {
   this.perPub5YearStatsData = $window.perPub5YearStatsData;
   this.htpPerPub5YearStatsData = $window.htpPerPub5YearStatsData;
   this.multi_organism_mode = $window.multi_organism_mode == 1;
+  this.strains_mode = $window.strains_mode == 1;
   this.pathogen_host_mode = $window.pathogen_host_mode;
   this.alleles_have_expression = $window.alleles_have_expression;
   this.organismsAndGenes = $window.organismsAndGenes;
@@ -3077,11 +3078,13 @@ var alleleEditDialogCtrl =
     $scope.alleleData.evidence = $scope.alleleData.evidence || '';
     $scope.strainData = {
       selectedStrain: null,
-      showStrainPicker: CantoGlobals.multi_organism_mode && $scope.taxonId,
+      showStrainPicker: CantoGlobals.strains_mode && $scope.taxonId,
       strains: null
     };
 
-    getStrainsFromServer($scope.taxonId);
+    if (CantoGlobals.strains_mode) {
+      getStrainsFromServer($scope.taxonId);
+    }
 
     $scope.showExpression = function () {
       return CantoGlobals.alleles_have_expression &&
@@ -3455,6 +3458,7 @@ var genotypeEdit =
       controller: function ($scope) {
         $scope.app_static_path = CantoGlobals.app_static_path;
         $scope.multi_organism_mode = CantoGlobals.multi_organism_mode;
+        $scope.strains_mode = CantoGlobals.strains_mode;
 
         $scope.strainSelected = function (strain) {
           $scope.data.selectedStrainName = strain ?
@@ -4179,7 +4183,7 @@ var GenotypeGeneListCtrl =
           });
         };
 
-        $scope.quickDeletion = $scope.multiOrganismMode ?
+        $scope.quickDeletion = CantoGlobals.strains_mode ?
           $scope.deleteSelectStrainPicker :
           $scope.makeDeletionAllele;
 
@@ -7585,7 +7589,7 @@ var editOrganismsGenesTable = function () {
 canto.directive('editOrganismsGenesTable', [editOrganismsGenesTable]);
 
 
-var editOrganismsTable = function () {
+var editOrganismsTable = function (CantoGlobals) {
   return {
     scope: {
       title: '@',
@@ -7595,6 +7599,10 @@ var editOrganismsTable = function () {
     replace: true,
     templateUrl: app_static_path + 'ng_templates/edit_organisms_table.html',
     controller: function ($scope, EditOrganismsSvc) {
+      $scope.data = {
+        strainsMode: CantoGlobals.strains_mode,
+      };
+
       $scope.firstGene = function (genes) {
         if (genes.length > 0) {
           return $scope.geneAttributes(genes[0]);
@@ -7642,7 +7650,8 @@ var editOrganismsTable = function () {
   };
 };
 
-canto.directive('editOrganismsTable', ['EditOrganismsSvc', editOrganismsTable]);
+canto.directive('editOrganismsTable',
+                ['EditOrganismsSvc', editOrganismsTable, 'CantoGlobals']);
 
 
 var editOrganisms = function () {

--- a/root/static/ng_templates/annotation_table.html
+++ b/root/static/ng_templates/annotation_table.html
@@ -29,7 +29,7 @@
           <thead>
             <tr>
               <th ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">Organism</th>
-              <th ng-if="multiOrganismMode && annotationType.feature_type === 'genotype'">Strain</th>
+              <th ng-if="multiOrganismMode && annotationType.feature_type === 'genotype'&& !data.hideColumns.strain_name">Strain</th>
               <th ng-if="annotationType.feature_type == 'genotype'">Genes</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_background">Background</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_name">Genotype name</th>

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -2,7 +2,7 @@
   <td ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">
     {{annotation.organism.scientific_name}}
   </td>
-  <td ng-if="multiOrganismMode && annotationType.feature_type === 'genotype'">
+  <td ng-if="multiOrganismMode && annotationType.feature_type === 'genotype' && !data.hideColumns.strain_name">
     {{annotation.strain_name}}
   </td>
   <td ng-if="annotationType.feature_type == 'genotype'">

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -56,7 +56,7 @@
             <span ng-class="{'gene-button-delete-text-disabled': g.disabled}">X</span></button>
           </td>
         </tr>
-        <tr><td colspan="6"><strain-picker taxon-id="{{ o.taxonid }}"></strain-picker></td></tr>
+        <tr ng-if="data.strainsMode"><td colspan="6"><strain-picker taxon-id="{{ o.taxonid }}"></strain-picker></td></tr>
       </tbody>
     </table>
   </div>

--- a/root/static/ng_templates/genotype_edit.html
+++ b/root/static/ng_templates/genotype_edit.html
@@ -25,7 +25,7 @@
              class="curs-genotype-edit__organism-label">
           Organism: {{ data.organismName }}
         </div>
-        <div ng-if="multi_organism_mode">
+        <div ng-if="strains_mode">
           Strain: <strain-selector
             strains="strains"
             strain-selected="strainSelected(strain)"


### PR DESCRIPTION
Hi @jseager7 

I've had a go at implementing a strains_mode (#1805).  I think I've fixed all the places that I can see where strains are required.  When you get a chance could you have a quick test and let me know if you spot bugs or any place I've missed?  If you have genotype with strains in your session but strains mode is disabled, the strain name will still appear in the genotype table.

You'll need to add this to your `canto_deploy.yaml` to activate strains mode:

```
strains_mode: 1
```

There's no rush to merge this so perhaps we should wait until after the conference even once any bugs are fixed.

