### PR TITLE
Unconditionally enable metagenotype link button

### DIFF
--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -88,8 +88,7 @@
                 &lt;-- Back to summary
             </button>
             <span ng-if="pathogen_host_mode">
-            <button ng-click="toMetagenotype()" type="button" class="btn btn-primary curs-back-button"
-                    ng-disabled="!data.showMetagenotypeButton">
+            <button ng-click="toMetagenotype()" type="button" class="btn btn-primary curs-back-button">
                 Meta-genotype management --&gt;
             </button>
             </span>


### PR DESCRIPTION
(Workaround for #1804)

This pull request is a temporary fix for the fact that the button linking to the Metagenotype Management page (on the Genotype Management page) never enables correctly – the fix here just keeps the button enabled all the time.