### PR TITLE
Implement refactored organism selector on Genotype Management page

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4034,6 +4034,7 @@ var genotypeManageCtrl =
           editingGenotype: false,
           editGenotypeId: null,
           multiOrganismMode: false,
+          hostOrganismExists: false,
           showMetagenotypeButton: true,
           showNoGenotypeNotice: true
         };
@@ -4052,6 +4053,9 @@ var genotypeManageCtrl =
         var readOrganisms = function () {
           Curs.list('organism').then(function (response) {
             var organisms = response.data;
+            $scope.data.hostOrganismExists = arrayContains(organisms, function (org) {
+              return org.pathogen_or_host === 'host';
+            });
             $scope.data.organisms = filterOrganisms(organisms, $scope.genotypeType);
           }).catch(function () {
             toaster.pop('error', "couldn't read the organism list from the server");

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4040,7 +4040,7 @@ var genotypeManageCtrl =
         $scope.metagenotypeUrl = CantoGlobals.curs_root_uri + '/metagenotype_manage';
 
         $scope.data = {
-          organisms = [],
+          organisms: [],
           genotypeMap: {},
           singleAlleleGenotypes: [],
           multiAlleleGenotypes: [],
@@ -4196,7 +4196,7 @@ var genotypeManageCtrl =
           return genotypeMap;
         };
 
-        $scope.readOrganisms();
+        readOrganisms();
         $scope.readGenotypes();
 
       },

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4035,6 +4035,7 @@ var genotypeManageCtrl =
           editGenotypeId: null,
           multiOrganismMode: false,
           hostOrganismExists: false,
+          pathogenGenotypeExists: false,
           isMetagenotypeLinkDisabled: true,
           showNoGenotypeNotice: true
         };
@@ -4110,7 +4111,8 @@ var genotypeManageCtrl =
           }).then(function (results) {
             setGenotypes(results);
             $scope.data.waitingForServer = false;
-            $scope.data.isMetagenotypeLinkDisabled = ($scope.data.genotypeMap.length === 0);
+            $scope.data.pathogenGenotypeExists = findPathogenGenotype(results);
+            $scope.data.isMetagenotypeLinkDisabled = getMetagenotypeLinkState();
             CursGenotypeList.onListChange($scope.readGenotypesCallback);
           }).catch(function () {
             toaster.pop('error', "couldn't read the genotype list from the server");
@@ -4196,7 +4198,21 @@ var genotypeManageCtrl =
         			return organism['pathogen_or_host'] === type;
         		};
         	};
-        };
+        }
+
+        function findPathogenGenotype(genotypes) {
+          return arrayContains(genotypes, function (g) {
+            return g.organism.pathogen_or_host === 'pathogen';
+          });
+        }
+
+        function getMetagenotypeLinkState() {
+          var DISABLED = true, ENABLED = false;
+          if ($scope.data.pathogenGenotypeExists && $scope.data.hostOrganismExists) {
+            return ENABLED;
+          }
+          return DISABLED;
+        }
 
         readOrganisms();
         $scope.readGenotypes();

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3905,7 +3905,7 @@ var GenotypeGeneListCtrl =
         $scope.selectedStrain = '';
 
         $scope.deleteSelectStrainPicker = function (gene_id) {
-          var deleteInstance = selectStrainPicker($uibModal, $scope.data.selectedOrganism.taxonid);
+          var deleteInstance = selectStrainPicker($uibModal, $scope.getSelectedOrganism().taxonid);
 
           deleteInstance.result.then(function (strain) {
             $scope.selectedStrain = strain.strain.strain_name;
@@ -3939,8 +3939,8 @@ var GenotypeGeneListCtrl =
           };
 
           var storePromise =
-            CursGenotypeList.storeGenotype(toaster, $http, undefined, undefined, undefined, [deletionAllele],
-              $scope.data.selectedOrganism.taxonid, $scope.selectedStrain, undefined);
+          CursGenotypeList.storeGenotype(toaster, $http, undefined, undefined, undefined, [deletionAllele],
+              $scope.getSelectedOrganism().taxonid, $scope.selectedStrain, undefined);
 
           storePromise.then(function (result) {
             if (result.data.status === "existing") {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -180,6 +180,20 @@ function getGenotypeManagePath(organismMode) {
   return paths.normal;
 }
 
+function filterOrganisms(organisms, genotypeType) {
+  if (genotypeType !== 'host' && genotypeType !== 'pathogen') {
+    return organisms;
+  }
+  var byOrganismType = buildOrganismFilter(genotypeType);
+  return organisms.filter(byOrganismType);
+
+  function buildOrganismFilter(type) {
+    return function (organism) {
+      return organism.pathogen_or_host === type;
+    };
+  }
+}
+
 function filterStrainsByTaxonId(strains, taxonId) {
   var taxonIdNum = parseInt(taxonId, 10);
   return $.grep(strains, function (strain) {
@@ -4177,20 +4191,6 @@ var genotypeManageCtrl =
           $.each(genotypes, addToGenotypeMap);
           return genotypeMap;
         };
-
-        function filterOrganisms(organisms, genotypeType) {
-        	if (genotypeType !== 'host' && genotypeType !== 'pathogen') {
-        		return organisms;
-        	}
-        	var byOrganismType = buildOrganismFilter(genotypeType);
-        	return organisms.filter(byOrganismType);
-
-        	function buildOrganismFilter(type) {
-        		return function (organism) {
-        			return organism['pathogen_or_host'] === type;
-        		};
-        	};
-        }
 
         function findPathogenGenotype(genotypes) {
           return arrayContains(genotypes, function (g) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3835,6 +3835,7 @@ var GenotypeGeneListCtrl =
 
         $scope.curs_root_uri = CantoGlobals.curs_root_uri;
         $scope.read_only_curs = CantoGlobals.read_only_curs;
+        $scope.multiOrganismMode = CantoGlobals.multi_organism_mode;
 
         $scope.hasDeletionHash = {};
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -51,6 +51,16 @@ function countKeys(o) {
   return size;
 }
 
+function arrayContains(array, predicate) {
+  var i, len = array.length;
+  for (i = 0; i < len; i += 1) {
+    if (predicate(array[i]) === true) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function arrayRemoveOne(array, item) {
   var i = array.indexOf(item);
   if (i >= 0) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3835,7 +3835,8 @@ var GenotypeGeneListCtrl =
     return {
       scope: {
         genotypes: '=',
-        selectedOrganism: '<'
+        selectedOrganism: '<',
+        genotypeType: '<'
       },
       restrict: 'E',
       replace: true,

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3793,6 +3793,14 @@ var organismSelectorCtrl = function ($scope, CantoGlobals) {
       organism: $scope.data.selectedOrganism
     });
   };
+
+  $scope.$watch('organisms', function () {
+    if ($scope.organisms && $scope.organisms.length === 1) {
+      $scope.organismSelected({
+        organism: $scope.organisms[0]
+      });
+    }
+  });
 };
 
 canto.directive('organismSelector', organismSelector);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4048,6 +4048,7 @@ var genotypeManageCtrl =
         $scope.metagenotypeUrl = CantoGlobals.curs_root_uri + '/metagenotype_manage';
 
         $scope.data = {
+          organisms = [],
           genotypeMap: {},
           singleAlleleGenotypes: [],
           multiAlleleGenotypes: [],
@@ -4070,6 +4071,16 @@ var genotypeManageCtrl =
         $scope.organismUpdated = function (organism) {
           $scope.data.selectedOrganism = organism;
           updateGenotypeLists();
+        };
+
+        var readOrganisms = function () {
+          Curs.list('organism').then(function (response) {
+            var organisms = response.data;
+            $scope.data.organisms = organisms;
+          }).catch(function () {
+            toaster.pop('error', "couldn't read the organism list from the server");
+            $scope.data.waitingForServer = false;
+          });
         };
 
         function hashChangedHandler() {
@@ -4193,6 +4204,7 @@ var genotypeManageCtrl =
           return genotypeMap;
         };
 
+        $scope.readOrganisms();
         $scope.readGenotypes();
 
       },

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -256,6 +256,15 @@ canto.filter('featureChooserFilter', function () {
   };
 });
 
+canto.filter('renameGenotypeType', function () {
+  return function (type) {
+    if (type === 'pathogen' || type === 'host') {
+      return capitalizeFirstLetter(type);
+    }
+    return 'Organism';
+  };
+});
+
 canto.config(function ($logProvider) {
   $logProvider.debugEnabled(true);
 });

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3766,7 +3766,7 @@ var organismSelector = function () {
   };
 };
 
-var organismSelectorCtrl = function ($scope, Curs, toaster, CantoGlobals) {
+var organismSelectorCtrl = function ($scope, CantoGlobals) {
 
   $scope.app_static_path = CantoGlobals.app_static_path;
 
@@ -3781,9 +3781,7 @@ var organismSelectorCtrl = function ($scope, Curs, toaster, CantoGlobals) {
   };
 };
 
-canto.directive('organismSelector', [
-  organismSelector
-]);
+canto.directive('organismSelector', organismSelector);
 
 var strainSelector = function () {
   return {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4052,7 +4052,7 @@ var genotypeManageCtrl =
         var readOrganisms = function () {
           Curs.list('organism').then(function (response) {
             var organisms = response.data;
-            $scope.data.organisms = organisms;
+            $scope.data.organisms = filterOrganisms(organisms, $scope.genotypeType);
           }).catch(function () {
             toaster.pop('error', "couldn't read the organism list from the server");
             $scope.data.waitingForServer = false;
@@ -4178,6 +4178,20 @@ var genotypeManageCtrl =
           };
           $.each(genotypes, addToGenotypeMap);
           return genotypeMap;
+        };
+
+        function filterOrganisms(organisms, genotypeType) {
+        	if (genotypeType !== 'host' && genotypeType !== 'pathogen') {
+        		return organisms;
+        	}
+        	var byOrganismType = buildOrganismFilter(genotypeType);
+        	return organisms.filter(byOrganismType);
+
+        	function buildOrganismFilter(type) {
+        		return function (organism) {
+        			return organism['pathogen_or_host'] === type;
+        		};
+        	};
         };
 
         readOrganisms();

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3825,46 +3825,25 @@ var GenotypeGeneListCtrl =
     return {
       scope: {
         genotypes: '=',
-        multiOrganismMode: '=',
-        label: '@',
-        genotypeType: '<',
-        lastAddedGene: '<',
-        onOrganismSelect: '&'
+        selectedOrganism: '<'
       },
       restrict: 'E',
       replace: true,
       templateUrl: app_static_path + 'ng_templates/genotype_gene_list.html',
       controller: function ($scope) {
-        $scope.data = {
-          selectedOrganism: {}
-        };
 
         $scope.curs_root_uri = CantoGlobals.curs_root_uri;
         $scope.read_only_curs = CantoGlobals.read_only_curs;
 
         $scope.hasDeletionHash = {};
 
-        if (!$scope.multiOrganismMode) {
-          Curs.list('organism')
-            .then(function (organisms) {
-              $scope.organismUpdated(organisms.data[0]);
-            });
-        }
-
         $scope.$watch('genotypes',
           function () {
             $scope.makeHasDeletionHash();
           }, true);
 
-        $scope.organismUpdated = function (organism) {
-          $scope.data.selectedOrganism = organism;
-          $scope.onOrganismSelect({
-            organism: organism
-          });
-        };
-
         $scope.getSelectedOrganism = function () {
-          return $scope.data.selectedOrganism;
+          return $scope.selectedOrganism;
         };
 
         $scope.hasDeletionGenotype = function(gene_id) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3771,8 +3771,9 @@ var organismSelector = function () {
   return {
     scope: {
       organismSelected: '&',
-      organisms: '<',
-      label: '@'
+      genotypeType: '<',
+      lastAddedGene: '<',
+      hideLabel: '=',
     },
     restrict: 'E',
     templateUrl: app_static_path + 'ng_templates/organism_selector.html',
@@ -3780,7 +3781,208 @@ var organismSelector = function () {
   };
 };
 
-var organismSelectorCtrl = function ($scope, CantoGlobals) {
+var organismSelectorCtrl = function ($scope, Curs, toaster, CantoGlobals) {
+
+  $scope.app_static_path = CantoGlobals.app_static_path;
+
+  $scope.data = {
+    selectedOrganism: null,
+    organisms: null,
+    defaultOrganism: null
+  };
+
+  $scope.$watch('lastAddedGene', function () {
+    if ($scope.lastAddedGene) {
+      reloadOrganisms(
+        $scope.data.selectedOrganism,
+        $scope.genotypeType,
+        $scope.lastAddedGene
+      );
+    }
+  });
+
+  $scope.organismChanged = function () {
+    $scope.organismSelected({
+      organism: $scope.data.selectedOrganism
+    });
+  };
+
+  var onInit = function () {
+    $scope.data.hideLabel = $scope.hideLabel || false;
+    reloadOrganisms(
+      $scope.data.selectedOrganism,
+      $scope.genotypeType,
+      $scope.lastAddedGene
+    );
+    setLabelText($scope.genotypeType);
+  };
+
+  var setLabelText = function (genotypeType) {
+    var calculateLabelText = function (genotypeType) {
+      return genotypeType === 'host' || genotypeType === 'pathogen' ?
+        capitalizeFirstLetter(genotypeType) :
+        'Organism';
+    };
+    $scope.label = calculateLabelText(genotypeType);
+  };
+
+  var filterOrganisms = function (organisms, genotypeType) {
+    if (genotypeType !== 'host' && genotypeType !== 'pathogen') {
+      return organisms;
+    }
+    var buildOrganismFilter = function (type) {
+      return function (organism) {
+        return organism['pathogen_or_host'] === type;
+      };
+    };
+    var byOrganismType = buildOrganismFilter(genotypeType);
+    return organisms.filter(byOrganismType);
+  };
+
+  var getOrganisms = function () {
+    return Curs.list('organism');
+  };
+
+  var setOrganisms = function (organisms) {
+    $scope.data.organisms = organisms;
+  };
+
+  var reloadSelectedOrganism = function (previousOrganism, organisms, lastAddedGene) {
+    var selectedOrganism;
+    // if lastAddedGene is undefined, then the page has just been loaded,
+    // so no organism should be selected.
+    if (lastAddedGene === undefined) {
+      selectedOrganism = null;
+    } else {
+      selectedOrganism = getNewSelectedOrganism(
+        previousOrganism, organisms, lastAddedGene
+      );
+    }
+    $scope.data.selectedOrganism = selectedOrganism;
+    $scope.organismSelected({
+      organism: $scope.data.selectedOrganism
+    });
+  };
+
+  var reloadOrganisms = function (oldSelectedOrganism, genotypeType, lastAddedGene) {
+    getOrganisms().success(function (organisms) {
+      var filteredOrganisms = filterOrganisms(organisms, genotypeType);
+      var defaultOrganism = getDefaultOrganism(filteredOrganisms);
+      setOrganisms(filteredOrganisms);
+      if (defaultOrganism) {
+        setDefaultOrganism(defaultOrganism);
+      } else {
+        reloadSelectedOrganism(
+          oldSelectedOrganism,
+          filteredOrganisms,
+          lastAddedGene
+        );
+      }
+    }).error(function () {
+      toaster.pop('error', 'failed to get organism list from server');
+    });
+  };
+
+  var getNewSelectedOrganism = function (previousOrganism, organisms, lastAddedGene) {
+    var newOrganism = null;
+
+    var refreshPreviousOrganism = function (previousOrganism, organisms) {
+      var finder = function (key, value) {
+        return function (obj) {
+          return obj[key] === value;
+        };
+      };
+      var previousTaxonId = previousOrganism.taxonid;
+      var newSelectedOrganism = $.grep(
+        organisms,
+        finder('taxonid', previousTaxonId)
+      )[0];
+      return newSelectedOrganism;
+    };
+
+    var findOrganismWithLastAddedGene = function (organisms, geneId) {
+      var i, j, organism, genes, gene;
+
+      // simple 'for' loops are helpful here: we can break out of the
+      // loop as soon as the gene is found, since the gene ID is unique.
+      for (i = 0; i < organisms.length; i += 1) {
+        organism = organisms[i];
+        genes = organism.genes;
+        for (j = 0; j < genes.length; j += 1) {
+          gene = genes[j];
+          if (gene.gene_id === geneId) {
+            return organism;
+          }
+        }
+      }
+      return null;
+    };
+
+    var excluding = function (previousOrganism) {
+      return function (organism) {
+        return organism.taxonid !== previousOrganism.taxonid;
+      };
+    };
+
+    if (previousOrganism) {
+      // check the previously selected organism first, assuming the user is
+      // more likely to add genes for the selected organism.
+      var newPreviousOrganism = refreshPreviousOrganism(
+        previousOrganism,
+        organisms
+      );
+      newOrganism = findOrganismWithLastAddedGene(
+        [newPreviousOrganism],
+        lastAddedGene
+      );
+    }
+    if (!newOrganism) {
+      var remainingOrganisms = previousOrganism ?
+        organisms.filter(excluding(previousOrganism)) :
+        organisms;
+      newOrganism = findOrganismWithLastAddedGene(
+        remainingOrganisms,
+        lastAddedGene
+      );
+    }
+    return newOrganism;
+  };
+
+  var getDefaultOrganism = function (organisms) {
+    return organisms.length === 1 ? organisms[0] : null;
+  };
+
+  var setDefaultOrganism = function (defaultOrganism) {
+    $scope.data.defaultOrganism = defaultOrganism;
+    // we must check for null, or the default organism will always be set
+    if (defaultOrganism) {
+      $scope.organismSelected({
+        organism: defaultOrganism
+      });
+    }
+  };
+
+  onInit();
+};
+
+canto.directive('organismSelector', [
+  organismSelector
+]);
+
+var organismSelectorNew = function () {
+  return {
+    scope: {
+      organismSelected: '&',
+      organisms: '<',
+      label: '@'
+    },
+    restrict: 'E',
+    templateUrl: app_static_path + 'ng_templates/organism_selector_new.html',
+    controller: organismSelectorNewCtrl,
+  };
+};
+
+var organismSelectorNewCtrl = function ($scope, CantoGlobals) {
 
   $scope.app_static_path = CantoGlobals.app_static_path;
 
@@ -3803,7 +4005,7 @@ var organismSelectorCtrl = function ($scope, CantoGlobals) {
   });
 };
 
-canto.directive('organismSelector', organismSelector);
+canto.directive('organismSelectorNew', organismSelectorNew);
 
 var strainSelector = function () {
   return {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4035,7 +4035,7 @@ var genotypeManageCtrl =
           editGenotypeId: null,
           multiOrganismMode: false,
           hostOrganismExists: false,
-          showMetagenotypeButton: true,
+          isMetagenotypeLinkDisabled: true,
           showNoGenotypeNotice: true
         };
 
@@ -4110,7 +4110,7 @@ var genotypeManageCtrl =
           }).then(function (results) {
             setGenotypes(results);
             $scope.data.waitingForServer = false;
-            $scope.data.showMetagenotypeButton = ($scope.data.genotypeMap.length >= 1);
+            $scope.data.isMetagenotypeLinkDisabled = ($scope.data.genotypeMap.length === 0);
             CursGenotypeList.onListChange($scope.readGenotypesCallback);
           }).catch(function () {
             toaster.pop('error', "couldn't read the genotype list from the server");

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3758,7 +3758,7 @@ var organismSelector = function () {
     scope: {
       organismSelected: '&',
       organisms: '<',
-      hideLabel: '='
+      label: '@'
     },
     restrict: 'E',
     templateUrl: app_static_path + 'ng_templates/organism_selector.html',
@@ -3780,22 +3780,6 @@ var organismSelectorCtrl = function ($scope, Curs, toaster, CantoGlobals) {
       organism: $scope.data.selectedOrganism
     });
   };
-
-  var onInit = function () {
-    $scope.data.hideLabel = $scope.hideLabel || false;
-    setLabelText($scope.genotypeType);
-  };
-
-  var setLabelText = function (genotypeType) {
-    var calculateLabelText = function (genotypeType) {
-      return genotypeType === 'host' || genotypeType === 'pathogen' ?
-        capitalizeFirstLetter(genotypeType) :
-        'Organism';
-    };
-    $scope.label = calculateLabelText(genotypeType);
-  };
-
-  onInit();
 };
 
 canto.directive('organismSelector', [

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3771,8 +3771,7 @@ var organismSelectorCtrl = function ($scope, Curs, toaster, CantoGlobals) {
   $scope.app_static_path = CantoGlobals.app_static_path;
 
   $scope.data = {
-    selectedOrganism: null,
-    defaultOrganism: null
+    selectedOrganism: null
   };
 
   $scope.organismChanged = function () {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3972,9 +3972,7 @@ var GenotypeGenesPanelCtrl =
 
     return {
       scope: {
-        genotypes: '=',
-        multiOrganismMode: '=',
-        lastAddedGene: '<'
+        multiOrganismMode: '='
       },
       restrict: 'E',
       replace: true,
@@ -3985,9 +3983,6 @@ var GenotypeGenesPanelCtrl =
 
         $scope.openSingleGeneAddDialog = function () {
           var modal = openSingleGeneAddDialog($uibModal);
-          modal.result.then(function (geneObj) {
-            $scope.lastAddedGene = geneObj.new_gene_id;
-          });
         };
       }
     };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3995,9 +3995,7 @@ var GenotypeGenesPanelCtrl =
       scope: {
         genotypes: '=',
         multiOrganismMode: '=',
-        genotypeType: '<',
-        lastAddedGene: '<',
-        onOrganismSelect: '&',
+        lastAddedGene: '<'
       },
       restrict: 'E',
       replace: true,
@@ -4010,12 +4008,6 @@ var GenotypeGenesPanelCtrl =
           var modal = openSingleGeneAddDialog($uibModal);
           modal.result.then(function (geneObj) {
             $scope.lastAddedGene = geneObj.new_gene_id;
-          });
-        };
-
-        $scope.organismUpdated = function (organism) {
-          $scope.onOrganismSelect({
-            organism: organism
           });
         };
       }

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -1,11 +1,4 @@
 <div class="curs-genotype-gene-list">
-  <organism-selector
-    ng-show="multiOrganismMode"
-    label="Organism"
-    organism-selected="organismUpdated(organism)"
-    genotype-type="genotypeType"
-    last-added-gene="lastAddedGene">
-  </organism-selector>
   <div class="curs-genotype-edit-gene-list"
        ng-if="getSelectedOrganism()">
     <table class="list" ng-if="selectedOrganismGenes().length > 0">

--- a/root/static/ng_templates/genotype_genes_panel.html
+++ b/root/static/ng_templates/genotype_genes_panel.html
@@ -1,11 +1,4 @@
 <div>
-    <genotype-gene-list
-      genotypes="genotypes"
-      on-organism-select="organismUpdated(organism)"
-      multi-organism-mode="multiOrganismMode"
-      genotype-type="genotypeType"
-      last-added-gene="lastAddedGene">
-    </genotype-gene-list>
     <a ng-if="multiOrganismMode" href="confirm_genes">Delete or Edit genes and organisms list ...</a>
     <a ng-if="!multiOrganismMode" ng-click="openSingleGeneAddDialog()">Add another gene ...</a>
 </div>

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -39,7 +39,8 @@
                         </organism-selector>
                         <genotype-gene-list
                           genotypes="data.singleAlleleGenotypes"
-                          selected-organism="data.selectedOrganism">
+                          selected-organism="data.selectedOrganism"
+                          genotype-type="genotypeType">
                         </genotype-gene-list>
                         <genotype-genes-panel
                           multi-organism-mode="data.multiOrganismMode">

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -32,6 +32,11 @@
             <div class="row">
                 <div ng-if="!read_only_curs">
                     <div class="col-sm-3 col-md-3">
+                        <organism-selector
+                          ng-if="multiOrganismMode"
+                          organisms="data.organisms"
+                          organism-selected="organismUpdated(organism)">
+                        </organism-selector>
                         <genotype-genes-panel
                           on-organism-select="organismUpdated(organism)"
                           genotypes="data.singleAlleleGenotypes"

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -95,8 +95,9 @@
                 &lt;-- Back to summary
             </button>
             <span ng-if="pathogen_host_mode">
-            <button ng-click="toMetagenotype()" type="button" class="btn btn-primary curs-back-button">
-                Metagenotype management --&gt;
+            <button ng-click="toMetagenotype()" type="button" class="btn btn-primary curs-back-button"
+                    ng-disabled="data.isMetagenotypeLinkDisabled">
+                Meta-genotype management --&gt;
             </button>
             </span>
         </div>

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -38,7 +38,7 @@
                           organism-selected="organismUpdated(organism)">
                         </organism-selector>
                         <genotype-gene-list
-                          genotypes="genotypes"
+                          genotypes="data.singleAlleleGenotypes"
                           selected-organism="data.selectedOrganism">
                         </genotype-gene-list>
                         <genotype-genes-panel

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -33,7 +33,7 @@
                 <div ng-if="!read_only_curs">
                     <div class="col-sm-3 col-md-3">
                         <organism-selector
-                          ng-if="multiOrganismMode"
+                          ng-if="data.multiOrganismMode"
                           organisms="data.organisms"
                           organism-selected="organismUpdated(organism)">
                         </organism-selector>

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -37,8 +37,11 @@
                           organisms="data.organisms"
                           organism-selected="organismUpdated(organism)">
                         </organism-selector>
+                        <genotype-gene-list
+                          genotypes="genotypes"
+                          selected-organism="data.selectedOrganism">
+                        </genotype-gene-list>
                         <genotype-genes-panel
-                          genotypes="data.singleAlleleGenotypes"
                           multi-organism-mode="data.multiOrganismMode">
                         </genotype-genes-panel>
                     </div>

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -35,7 +35,8 @@
                         <organism-selector
                           ng-if="data.multiOrganismMode"
                           organisms="data.organisms"
-                          organism-selected="organismUpdated(organism)">
+                          organism-selected="organismUpdated(organism)"
+                          label="{{genotypeType | renameGenotypeType}}">
                         </organism-selector>
                         <genotype-gene-list
                           genotypes="data.singleAlleleGenotypes"

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -38,10 +38,9 @@
                           organism-selected="organismUpdated(organism)">
                         </organism-selector>
                         <genotype-genes-panel
-                          on-organism-select="organismUpdated(organism)"
                           genotypes="data.singleAlleleGenotypes"
-                          multi-organism-mode="data.multiOrganismMode"
-                          genotype-type="genotypeType" />
+                          multi-organism-mode="data.multiOrganismMode">
+                        </genotype-genes-panel>
                     </div>
                 </div>
 

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -32,12 +32,12 @@
             <div class="row">
                 <div ng-if="!read_only_curs">
                     <div class="col-sm-3 col-md-3">
-                        <organism-selector
+                        <organism-selector-new
                           ng-if="data.multiOrganismMode"
                           organisms="data.organisms"
                           organism-selected="organismUpdated(organism)"
                           label="{{genotypeType | renameGenotypeType}}">
-                        </organism-selector>
+                        </organism-selector-new>
                         <genotype-gene-list
                           genotypes="data.singleAlleleGenotypes"
                           selected-organism="data.selectedOrganism"

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -3,7 +3,7 @@
   Loading organisms...
 </div>
 <div class="curs-organism-selector" ng-if="organisms">
-  <p ng-hide="data.hideLabel" class="curs-organism-selector-label"><b>{{label}}</b></p>
+  <p ng-if="label" class="curs-organism-selector-label"><b>{{label}}</b></p>
   <select ng-if="organisms.length > 1"
       class="curs-organism-selector-select"
       name="select-organism"

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -3,7 +3,7 @@
   Loading organisms...
 </div>
 <div class="curs-organism-selector" ng-if="organisms">
-  <p ng-if="label" class="curs-organism-selector-label"><b>{{label}}</b></p>
+  <p ng-if="::label" class="curs-organism-selector-label"><b>{{::label}}</b></p>
   <select ng-if="organisms.length > 1"
       class="curs-organism-selector-select"
       name="select-organism"

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -1,16 +1,16 @@
-<div ng-if="!organisms">
+<div ng-if="!data.organisms">
   <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img>
   Loading organisms...
 </div>
-<div class="curs-organism-selector" ng-if="organisms">
-  <p ng-if="::label" class="curs-organism-selector-label"><b>{{::label}}</b></p>
-  <select ng-if="organisms.length > 1"
+<div class="curs-organism-selector" ng-if="data.organisms">
+  <p ng-hide="data.hideLabel" class="curs-organism-selector-label"><b>{{label}}</b></p>
+  <select ng-if="data.organisms.length > 1"
       class="curs-organism-selector-select"
       name="select-organism"
       ng-model="data.selectedOrganism"
       ng-change="organismChanged()"
-      ng-options="o as o.full_name for o in organisms track by o.taxonid">
+      ng-options="o as o.full_name for o in data.organisms track by o.taxonid">
     <option value="" disabled>Select an organism...</option>
   </select>
-  <span ng-if="organisms.length === 1">{{organisms[0].full_name}}</span>
+  <span ng-if="data.organisms.length === 1">{{data.defaultOrganism.full_name}}</span>
 </div>

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -1,16 +1,16 @@
-<div ng-if="!data.organisms">
+<div ng-if="!organisms">
   <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img>
   Loading organisms...
 </div>
-<div class="curs-organism-selector" ng-if="data.organisms">
+<div class="curs-organism-selector" ng-if="organisms">
   <p ng-hide="data.hideLabel" class="curs-organism-selector-label"><b>{{label}}</b></p>
-  <select ng-if="data.organisms.length > 1"
+  <select ng-if="organisms.length > 1"
       class="curs-organism-selector-select"
       name="select-organism"
       ng-model="data.selectedOrganism"
       ng-change="organismChanged()"
-      ng-options="o as o.full_name for o in data.organisms track by o.taxonid">
+      ng-options="o as o.full_name for o in organisms track by o.taxonid">
     <option value="" disabled>Select an organism...</option>
   </select>
-  <span ng-if="data.organisms.length === 1">{{data.defaultOrganism.full_name}}</span>
+  <span ng-if="organisms.length === 1">{{data.defaultOrganism.full_name}}</span>
 </div>

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -12,5 +12,5 @@
       ng-options="o as o.full_name for o in organisms track by o.taxonid">
     <option value="" disabled>Select an organism...</option>
   </select>
-  <span ng-if="organisms.length === 1">{{data.defaultOrganism.full_name}}</span>
+  <span ng-if="organisms.length === 1">{{organisms[0].full_name}}</span>
 </div>

--- a/root/static/ng_templates/organism_selector_new.html
+++ b/root/static/ng_templates/organism_selector_new.html
@@ -1,0 +1,16 @@
+<div ng-if="!organisms">
+  <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img>
+  Loading organisms...
+</div>
+<div class="curs-organism-selector" ng-if="organisms">
+  <p ng-if="::label" class="curs-organism-selector-label"><b>{{::label}}</b></p>
+  <select ng-if="organisms.length > 1"
+      class="curs-organism-selector-select"
+      name="select-organism"
+      ng-model="data.selectedOrganism"
+      ng-change="organismChanged()"
+      ng-options="o as o.full_name for o in organisms track by o.taxonid">
+    <option value="" disabled>Select an organism...</option>
+  </select>
+  <span ng-if="organisms.length === 1">{{organisms[0].full_name}}</span>
+</div>


### PR DESCRIPTION
(Partial fix for #1804)

There are a few issues pending for the Genotype Management page (for FlyBase) that are waiting for my refactoring of the organism selector to be finished (#1810, #1818). However, I don't think it's necessary to wait, since the organism selector already works correctly on the Genotype Management page: the problem is it's caused breaking changes to the Metagenotype Management page. Fortunately, FlyBase doesn't use Metagenotype Management page, and the changes to the organism selector were only really needed to enable a link to the Metagenotype Management page.

So for now, I'm suggesting we merge early by keeping _both_ versions of the organism selector (old and new): `genotypeManage` will use the new selector, and `metagenotypeManage` will use the old selector. This way, we can integrate my changes to stop them blocking us from integrating anything else into `master`.

My plan is to rename the `organismSelectorNew` directive and template to replace the (old) `organismSelector` once I've managed to integrate the new selector into the Metagenotype Management page &ndash; this shouldn't prevent us from making the changes that FlyBase need in the meantime. The changes to the Metagenotype Management can be handled on a new pull request.