### PR TITLE
Add split_genotypes_by_organism option

### DIFF
--- a/canto.yaml
+++ b/canto.yaml
@@ -79,6 +79,10 @@ max_existing_annotations: 100
 # as a column in the genotype table on the genotype management page
 alleles_have_expression: 1
 
+# if 1, show the organism in a selector on the genotype management pages
+# and only show genes and genotypes for the selected organism
+split_genotypes_by_organism: 1
+
 # from_address - used as the "from" field is all outgoing messages
 # admin_address - the contact address of the admin curators, used to
 #                 alert about completed sessions and problems

--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -165,6 +165,7 @@ sub top : Chained('/') PathPart('curs') CaptureArgs(1)
   $st->{multi_organism_mode} = !defined $st->{instance_organism};
   $st->{strains_mode} = $config->{strains_mode};
   $st->{pathogen_host_mode} = $config->{pathogen_host_mode};
+  $st->{split_genotypes_by_organism} = $config->{split_genotypes_by_organism};
 
   my $with_gene_evidence_codes =
     { map { ( $_, 1 ) }

--- a/root/curs/autohandler
+++ b/root/curs/autohandler
@@ -16,6 +16,7 @@ var with_gene_evidence_codes = <% $with_gene_evidence_codes_js |n %>;
 var annotation_type_config = <% $annotation_type_config_js |n %>;
 var curs_session_state = '<% $curs_session_state |n %>';
 var multi_organism_mode = '<% $multi_organism_mode %>';
+var split_genotypes_by_organism = <% $split_genotypes_by_organism ? 'true' : 'false' %>;
 var strains_mode = '<% $strains_mode %>';
 var pathogen_host_mode = '<% $pathogen_host_mode %>';
 var alleles_have_expression = <% $alleles_have_expression ? 'true' : 'false' %>;
@@ -65,6 +66,7 @@ my $annotation_type_config = $st->{annotation_type_config};
 my $annotation_type_config_js = Data::JavaScript::Anon->anon_dump($annotation_type_config);
 
 my $multi_organism_mode = $st->{multi_organism_mode} || 0;
+my $split_genotypes_by_organism = $st->{split_genotypes_by_organism} || 0;
 my $strains_mode = $st->{strains_mode} || 0;
 my $pathogen_host_mode = $st->{pathogen_host_mode} || 0;
 my $alleles_have_expression = $c->config()->{alleles_have_expression} || 0;

--- a/root/docs/md/canto_admin/configuration_file.md
+++ b/root/docs/md/canto_admin/configuration_file.md
@@ -71,6 +71,10 @@ page.
 If 1, allow editing of the expression of alleles and show the expression
 as a column in the genotype table on the genotype management page.
 
+### split_genotypes_by_organism
+If 1, show the organism in a selector on the genotype management pages
+and only show genes and genotypes for the selected organism.
+
 ### db_initial_data
 Data needed to initialise a Canto instance.
 

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -1,7 +1,6 @@
 <div class="curs-genotype-gene-list">
-  <div class="curs-genotype-edit-gene-list"
-       ng-if="getSelectedOrganism()">
-    <table class="list" ng-if="selectedOrganismGenes().length > 0">
+  <div class="curs-genotype-edit-gene-list">
+    <table class="list" ng-if="genes.length > 0">
       <thead>
         <tr>
           <th>Gene</th>
@@ -9,7 +8,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="gene in selectedOrganismGenes()">
+        <tr ng-repeat="gene in genes">
           <td ng-if="gene.primary_name" title="{{gene.primary_name}} ({{gene.primary_identifier}})">
             <a href="{{curs_root_uri + '/feature/gene/view/' + gene.gene_id + (read_only_curs ? '/ro' : '')}}">{{gene.primary_name}}</a>
           </td>
@@ -30,9 +29,5 @@
         </tr>
       </tbody>
     </table>
-    <p class="curs-genotype-no-gene-notice"
-       ng-if="selectedOrganismGenes().length === 0">
-      No genes have been added for this organism.
-    </p>
   </div>
 </div>

--- a/root/static/ng_templates/genotype_genes_panel.html
+++ b/root/static/ng_templates/genotype_genes_panel.html
@@ -1,4 +1,4 @@
 <div>
-    <a ng-if="multiOrganismMode" href="confirm_genes">Delete or Edit genes and organisms list ...</a>
-    <a ng-if="!multiOrganismMode" ng-click="openSingleGeneAddDialog()">Add another gene ...</a>
+    <a ng-if="splitGenotypesByOrganism" href="confirm_genes">Delete or Edit genes and organisms list ...</a>
+    <a ng-if="!splitGenotypesByOrganism" ng-click="openSingleGeneAddDialog()">Add another gene ...</a>
 </div>

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -33,18 +33,22 @@
                 <div ng-if="!read_only_curs">
                     <div class="col-sm-3 col-md-3">
                         <organism-selector-new
-                          ng-if="data.multiOrganismMode"
+                          ng-if="data.multiOrganismMode && data.splitGenotypesByOrganism"
                           organisms="data.organisms"
                           organism-selected="organismUpdated(organism)"
                           label="{{genotypeType | renameGenotypeType}}">
                         </organism-selector-new>
                         <genotype-gene-list
                           genotypes="data.singleAlleleGenotypes"
-                          selected-organism="data.selectedOrganism"
+                          genes="data.visibleGenes"
                           genotype-type="genotypeType">
                         </genotype-gene-list>
+                        <p class="curs-genotype-no-gene-notice"
+                           ng-if="data.selectedOrganism && data.genes.length === 0">
+                          No genes have been added for this organism.
+                        </p>
                         <genotype-genes-panel
-                          multi-organism-mode="data.multiOrganismMode">
+                          split-genotypes-by-organism="data.splitGenotypesByOrganism">
                         </genotype-genes-panel>
                     </div>
                 </div>
@@ -82,7 +86,7 @@
                                 />
                             </div>
 
-                            <div ng-if="!readOnlyCurs" ng-show="data.showNoGenotypeNotice">
+                            <div ng-if="!readOnlyCurs" ng-show="showNoGenotypeNotice()">
                                 No genotypes in this session.  Try adding one.
                             </div>
                         </div>


### PR DESCRIPTION
I've added a new setting to optionally hide the organism selector on the genotype management page.  For now I've made a branch because I haven't tested the code in all the cases yet.

Sorry, there are quite a few lines changed. I think I haven't made the code worse.  :-)

The genotype management controller still looks the same from the outside (same attributes get passed in).  I had to move some logic from GenotypeGeneListCtrl to genotypeManageCtrl.  We now pass a gene list into GenotypeGeneListCtrl instead of `selectedOrganism`.

Refs pombase/canto#1818