### PR TITLE
Refactor the metagenotype management page

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7070,9 +7070,8 @@ var metagenotypeGenotypePicker =
       controller: function ($scope) {
 
         $scope.data = {
-          genotypes: null,
-          singleAllele: [],
-          multiAllele: [],
+          singleAlleleGenotypes: [],
+          multiAlleleGenotypes: [],
           wildType: [],
           typeLabel: 'Host',
           genotypeType: 'host',
@@ -7085,17 +7084,6 @@ var metagenotypeGenotypePicker =
             organismType.toLowerCase() +
             '_genotype_manage';
         }
-
-        $scope.readGenotypes = function () {
-          CursGenotypeList.cursGenotypeList({
-            include_allele: 1
-          }).then(function (results) {
-            $scope.data.genotypes = results;
-          }).catch(function () {
-            toaster.pop('error', "couldn't read the genotype list from the server");
-            $scope.data.waitingForServer = false;
-          });
-        };
 
         $scope.setSingleAllele = function () {
           if ($scope.data.selectedOrganism == null) {
@@ -7144,7 +7132,6 @@ var metagenotypeGenotypePicker =
           } else {
             defaultGenotype = $scope.data.wildType;
           }
-          $scope.$emit($scope.data.genotypeType + ' selected', defaultGenotype);
         };
 
         $scope.setFilters = function () {
@@ -7161,16 +7148,6 @@ var metagenotypeGenotypePicker =
         $scope.data.isHost = !$scope.isPathogen;
 
         $scope.data.genotypeShortcutUrl = setGenotypeShortcut($scope.data.genotypeType);
-
-        Metagenotype.pickerOrganismCallbacks[$scope.data.genotypeType] = function (organism) {
-          $scope.data.selectedOrganism = organism;
-          $scope.setFilters();
-          $scope.setWildtypeOrganism();
-        };
-
-        $scope.data.pickerCallback = Metagenotype.pickerOrganismSelectors[$scope.data.genotypeType];
-
-        $scope.readGenotypes();
 
         StrainsService.getAllSessionStrains();
       },

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7329,6 +7329,22 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
 
       StrainsService.getAllSessionStrains();
 
+      function loadOrganisms() {
+        Curs.list('organism').then(function (response) {
+          var organisms = response.data;
+          $scope.pathogenOrganisms = filterOrganisms(organisms, 'pathogen');
+          $scope.hostOrganisms = filterOrganisms(organisms, 'host');
+        });
+      }
+
+      function loadGenotypes() {
+        CursGenotypeList.cursGenotypeList({
+          include_allele: 1
+        }).then(function (genotypes) {
+          $scope.taxonGenotypeMap = makeTaxonGenotypeMap(genotypes);
+        });
+      }
+
       function makeTaxonGenotypeMap(genotypes) {
         var getGenotypeTaxonId = function (genotype) {
           return genotype.organism.taxonid;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7048,8 +7048,8 @@ var metagenotypeGenotypePicker =
   function (CantoGlobals, CursGenotypeList, toaster, Metagenotype, StrainsService) {
     return {
       scope: {
-        isPathogen: '=',
-        genotypeModel: '=',
+        isPathogen: '<',
+        genotypes: '<'
       },
       restrict: 'E',
       replace: true,
@@ -7263,9 +7263,7 @@ var metagenotypeManage = function (CantoGlobals, CursGenotypeList, Metagenotype,
     replace: true,
     templateUrl: app_static_path + 'ng_templates/metagenotype_manage.html',
     controller: function ($scope) {
-      $scope.pathogenModel = null;
       $scope.selectedPathogen = null;
-      $scope.hostModel = null;
       $scope.selectedHost = null;
       $scope.genotypeUrl = CantoGlobals.curs_root_uri;
       $scope.makeInvalid = true;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7263,8 +7263,17 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
     replace: true,
     templateUrl: app_static_path + 'ng_templates/metagenotype_manage.html',
     controller: function ($scope) {
+
+      $scope.pathogenOrganisms = null;
       $scope.selectedPathogen = null;
+      $scope.selectedPathogenGenotypes = null;
+
+      $scope.hostOrganisms = null;
       $scope.selectedHost = null;
+      $scope.selectedHostGenotypes = null;
+
+      $scope.taxonGenotypeMap = null;
+
       $scope.genotypeUrl = CantoGlobals.curs_root_uri;
       $scope.makeInvalid = true;
       $scope.display = (!CantoGlobals.read_only_curs);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7062,6 +7062,7 @@ var metagenotypeGenotypePicker =
     return {
       scope: {
         isHost: '<',
+        selectedOrganism: '<',
         genotypes: '<'
       },
       restrict: 'E',
@@ -7077,6 +7078,14 @@ var metagenotypeGenotypePicker =
           wildType: [],
         };
 
+        if ($scope.isHost) {
+          $scope.$watch('selectedOrganism', function (newVal, oldVal) {
+            if (newVal !== oldVal) {
+              $scope.setWildtypeOrganism();
+            }
+          });
+        }
+
         function setGenotypeShortcut(organismType) {
           return CantoGlobals.curs_root_uri + '/' +
             organismType.toLowerCase() +
@@ -7084,7 +7093,7 @@ var metagenotypeGenotypePicker =
         }
 
         $scope.setWildtypeOrganism = function () {
-          StrainsService.getSessionStrains($scope.data.selectedOrganism.taxonid)
+          StrainsService.getSessionStrains($scope.selectedOrganism.taxonid)
             .then(function (strains) {
               $scope.data.wildType = [];
 
@@ -7110,7 +7119,9 @@ var metagenotypeGenotypePicker =
           $scope.setDefaultGenotype();
         };
 
-        StrainsService.getAllSessionStrains();
+        if ($scope.isHost) {
+          StrainsService.getAllSessionStrains();
+        }
       },
     };
   };
@@ -7239,7 +7250,9 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
       $scope.onHostSelected = function (organism) {
         var taxonId = organism.taxonid;
         $scope.selectedHost = organism;
-        $scope.selectedHostGenotypes = $scope.taxonGenotypeMap[taxonId];
+        $scope.selectedHostGenotypes = taxonId in $scope.taxonGenotypeMap
+          ? $scope.taxonGenotypeMap[taxonId]
+          : {'single': [], 'multi': []}
       };
 
       $scope.toGenotype = function () {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7085,11 +7085,11 @@ var metagenotypeGenotypePicker =
             '_genotype_manage';
         }
 
-        $scope.setSingleAllele = function () {
+        $scope.setSingleAlleleGenotypes = function () {
           if ($scope.data.selectedOrganism == null) {
-            $scope.data.singleAllele = [];
+            $scope.data.singleAlleleGenotypes = [];
           } else {
-            $scope.data.singleAllele = $scope.data.genotypes.filter(function (e) {
+            $scope.data.singleAlleleGenotypes = $scope.data.genotypes.filter(function (e) {
               return (
                 (e.organism.taxonid === $scope.data.selectedOrganism.taxonid) &&
                 (e.alleles.length === 1)
@@ -7098,11 +7098,11 @@ var metagenotypeGenotypePicker =
           }
         };
 
-        $scope.setMultiAllele = function () {
+        $scope.setMultiAlleleGenotypes = function () {
           if ($scope.data.selectedOrganism == null) {
-            $scope.data.multiAllele = [];
+            $scope.data.multiAlleleGenotypes = [];
           } else {
-            $scope.data.multiAllele = $scope.data.genotypes.filter(function (e) {
+            $scope.data.multiAlleleGenotypes = $scope.data.genotypes.filter(function (e) {
               return (
                 (e.organism.taxonid === $scope.data.selectedOrganism.taxonid) &&
                 (e.alleles.length > 1)
@@ -7125,18 +7125,18 @@ var metagenotypeGenotypePicker =
 
         $scope.setDefaultGenotype = function () {
           var defaultGenotype = null;
-          if ($scope.data.singleAllele.length > 0) {
-            defaultGenotype = $scope.data.singleAllele[0];
-          } else if ($scope.data.multiAllele.length > 0) {
-            defaultGenotype = $scope.data.multiAllele[0];
+          if ($scope.data.singleAlleleGenotypes.length > 0) {
+            defaultGenotype = $scope.data.singleAlleleGenotypes[0];
+          } else if ($scope.data.multiAlleleGenotypes.length > 0) {
+            defaultGenotype = $scope.data.multiAlleleGenotypes[0];
           } else {
             defaultGenotype = $scope.data.wildType;
           }
         };
 
         $scope.setFilters = function () {
-          $scope.setSingleAllele();
-          $scope.setMultiAllele();
+          $scope.setSingleAlleleGenotypes();
+          $scope.setMultiAlleleGenotypes();
           $scope.setDefaultGenotype();
         };
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7037,17 +7037,24 @@ var wildGenotypeRow =
     return {
       restrict: 'A',
       scope: {
-        strain: '=',
-        showCheckBoxActions: '=',
-        genotypeModel: '=',
+        strain: '<',
+        showCheckBoxActions: '<',
+        onStrainSelect: '&'
       },
       replace: true,
       templateUrl: CantoGlobals.app_static_path + 'ng_templates/wild_genotype_row.html',
       controller: function ($scope) {
-        $scope.isSelected = function () {
-          $scope.$emit('host selected', $scope.strain);
+
+        $scope.data = {
+          selectedStrain: null
         };
-      },
+
+        $scope.strainSelected = function(strain) {
+          $scope.onStrainSelect({
+            strain: strain
+          });
+        };
+      }
     };
   };
 
@@ -7058,14 +7065,20 @@ var wildGenotypeView =
   function () {
     return {
       scope: {
-        wildType: '=',
-        genotypeModel: '=',
-        organism: '=',
-        showCheckBoxActions: '=',
+        strains: '<',
+        showCheckBoxActions: '<',
+        onStrainSelect: '&'
       },
       restrict: 'E',
       replace: true,
       templateUrl: app_static_path + 'ng_templates/wild_genotype_view.html',
+      controller: function ($scope) {
+        $scope.onStrainChange = function (strain) {
+          $scope.onStrainSelect({
+            strain: strain
+          });
+        };
+      }
     };
   };
 
@@ -7079,7 +7092,8 @@ var metagenotypeGenotypePicker =
         isHost: '<',
         selectedOrganism: '<',
         genotypes: '<',
-        onGenotypeSelect: '&'
+        onGenotypeSelect: '&',
+        onStrainSelect: '&'
       },
       restrict: 'E',
       replace: true,
@@ -7091,13 +7105,13 @@ var metagenotypeGenotypePicker =
         $scope.genotypeShortcutUrl = setGenotypeShortcut($scope.organismType);
 
         $scope.data = {
-          wildType: [],
+          wildTypeStrains: [],
         };
 
         if ($scope.isHost) {
           $scope.$watch('selectedOrganism', function (newVal, oldVal) {
             if (newVal !== oldVal) {
-              $scope.setWildtypeOrganism();
+              $scope.loadWildTypeStrains();
             }
           });
         }
@@ -7108,15 +7122,10 @@ var metagenotypeGenotypePicker =
             '_genotype_manage';
         }
 
-        $scope.setWildtypeOrganism = function () {
+        $scope.loadWildTypeStrains = function () {
           StrainsService.getSessionStrains($scope.selectedOrganism.taxonid)
             .then(function (strains) {
-              $scope.data.wildType = [];
-
-              strains.map(function (strain) {
-                strain.genotype_id = (0 - strain.strain_id);
-                $scope.data.wildType.push(strain);
-              });
+              $scope.data.wildTypeStrains = strains;
             });
         };
 
@@ -7146,6 +7155,12 @@ var metagenotypeGenotypePicker =
             genotype: genotype
           });
         }
+
+        $scope.onStrainChange = function (strain) {
+          $scope.onStrainSelect({
+            strain: strain
+          });
+        };
 
         if ($scope.isHost) {
           StrainsService.getAllSessionStrains();
@@ -7263,6 +7278,7 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
       $scope.selectedHost = null;
       $scope.selectedHostGenotypes = null;
       $scope.selectedGenotypeHost = null;
+      $scope.selectedHostStrain = null;
 
       $scope.taxonGenotypeMap = null;
 
@@ -7291,6 +7307,10 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
 
       $scope.onHostGenotypeSelect = function (genotype) {
         $scope.selectedGenotypeHost = genotype;
+      };
+
+      $scope.onHostStrainSelect = function (strain) {
+        $scope.selectedHostStrain = strain;
       };
 
       $scope.toGenotype = function () {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7328,6 +7328,14 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
       };
 
       StrainsService.getAllSessionStrains();
+
+      function makeTaxonGenotypeMap(genotypes) {
+        var getGenotypeTaxonId = function (genotype) {
+          return genotype.organism.taxonid;
+        };
+        return indexArray(genotypes, getGenotypeTaxonId);
+      }
+
     }
   };
 };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6976,6 +6976,7 @@ var genotypeSimpleListRowCtrl =
       restrict: 'A',
       scope: {
         genotype: '<',
+        isHost: '<',
         showCheckBoxActions: '<',
         onGenotypeSelect: '&'
       },
@@ -6984,6 +6985,8 @@ var genotypeSimpleListRowCtrl =
       controller: function ($scope) {
         $scope.curs_root_uri = CantoGlobals.curs_root_uri;
         $scope.read_only_curs = CantoGlobals.read_only_curs;
+
+        $scope.inputNameValue = ($scope.isHost ? 'host' : 'pathogen') + '_genotype';
 
         $scope.genotype.alleles = $scope.genotype.alleles || [];
         $scope.firstAllele = $scope.genotype.alleles[0];
@@ -7010,6 +7013,7 @@ var genotypeSimpleListViewCtrl =
     return {
       scope: {
         genotypeList: '=',
+        isHost: '<',
         showCheckBoxActions: '=',
         genotypeModel: '=',
         onGenotypeSelect: '&'
@@ -7044,6 +7048,8 @@ var wildGenotypeRow =
       replace: true,
       templateUrl: CantoGlobals.app_static_path + 'ng_templates/wild_genotype_row.html',
       controller: function ($scope) {
+
+        $scope.inputNameValue = 'host_genotype';
 
         $scope.data = {
           selectedStrain: null

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7282,17 +7282,18 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
         pathogen: false
       };
 
-      $scope.$on('pathogen selected', function (event, selectedPathogen) {
-        $scope.pathogenModel = selectedPathogen.genotype_id;
-        $scope.selectedPathogen = selectedPathogen;
-      });
 
-      $scope.$on('host selected', function (event, selectedHost) {
-        $scope.hostModel = selectedHost.genotype_id;
-        $scope.selectedHost = selectedHost;
-      });
+      $scope.onPathogenSelected = function (organism) {
+        var taxonId = organism.taxonid;
+        $scope.selectedPathogen = organism;
+        $scope.selectedPathogenGenotypes = $scope.taxonGenotypeMap[taxonId];
+      };
 
-      $scope.isPickerSet = Metagenotype.isPickerSet;
+      $scope.onHostSelected = function (organism) {
+        var taxonId = organism.taxonid;
+        $scope.selectedHost = organism;
+        $scope.selectedHostGenotypes = $scope.taxonGenotypeMap[taxonId];
+      };
 
       $scope.toGenotype = function () {
         window.location.href = $scope.genotypeUrl +

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7256,7 +7256,7 @@ var metagenotypeListView = function (Metagenotype) {
 canto.directive('metagenotypeListView', ['Metagenotype', metagenotypeListView]);
 
 
-var metagenotypeManage = function (CantoGlobals, CursGenotypeList, Metagenotype, StrainsService) {
+var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagenotype, StrainsService) {
   return {
     scope: {},
     restrict: 'E',

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7291,7 +7291,6 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
       $scope.genotypeUrl = CantoGlobals.curs_root_uri;
       $scope.makeInvalid = true;
       $scope.display = (!CantoGlobals.read_only_curs);
-      $scope.isPickerSet = ($scope.selectedPathogen && $scope.selectedHost);
 
       $scope.onPathogenSelected = function (organism) {
         var taxonId = organism.taxonid;
@@ -7327,6 +7326,14 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
       $scope.toGenotype = function () {
         window.location.href = $scope.genotypeUrl +
           (CantoGlobals.read_only_curs ? '/ro' : '');
+      };
+
+      $scope.isMetagenotypeInvalid = function () {
+        return ! (
+          $scope.selectedGenotypePathogen && (
+            $scope.selectedGenotypeHost || $scope.selectedHostStrain
+          )
+        );
       };
 
       $scope.createMetagenotype = function () {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -68,6 +68,19 @@ function arrayRemoveOne(array, item) {
   }
 }
 
+function indexArray(array, keyFunction) {
+	var indexObject = {};
+	var i, key;
+	for (i = 0; i < array.length; i += 1) {
+		key = keyFunction(array[i]);
+		if (indexObject.hasOwnProperty(key) === false) {
+			indexObject[key] = [];
+		}
+		indexObject[key].push(array[i]);
+	}
+	return indexObject;
+}
+
 function copyObject(src, dest, keysFilter) {
   Object.getOwnPropertyNames(src).forEach(function (key) {
     if (key.indexOf('$$') === 0) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7296,6 +7296,7 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
       $scope.onPathogenSelected = function (organism) {
         var taxonId = organism.taxonid;
         $scope.selectedPathogen = organism;
+        $scope.selectedGenotypePathogen = null;
         $scope.selectedPathogenGenotypes = $scope.taxonGenotypeMap[taxonId];
       };
 
@@ -7306,6 +7307,8 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
       $scope.onHostSelected = function (organism) {
         var taxonId = organism.taxonid;
         $scope.selectedHost = organism;
+        $scope.selectedGenotypeHost = null;
+        $scope.selectedHostStrain = null;
         $scope.selectedHostGenotypes = taxonId in $scope.taxonGenotypeMap
           ? $scope.taxonGenotypeMap[taxonId]
           : {'single': [], 'multi': []}
@@ -7313,10 +7316,12 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
 
       $scope.onHostGenotypeSelect = function (genotype) {
         $scope.selectedGenotypeHost = genotype;
+        $scope.selectedHostStrain = null;
       };
 
       $scope.onHostStrainSelect = function (strain) {
         $scope.selectedHostStrain = strain;
+        $scope.selectedGenotypeHost = null;
       };
 
       $scope.toGenotype = function () {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7327,7 +7327,13 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
         }
       };
 
-      StrainsService.getAllSessionStrains();
+      onInit();
+
+      function onInit() {
+        loadOrganisms();
+        loadGenotypes();
+        StrainsService.getAllSessionStrains();
+      }
 
       function loadOrganisms() {
         Curs.list('organism').then(function (response) {
@@ -7356,7 +7362,7 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
   };
 };
 
-canto.directive('metagenotypeManage', ['CantoGlobals', 'CursGenotypeList', 'Metagenotype', 'StrainsService', metagenotypeManage]);
+canto.directive('metagenotypeManage', ['CantoGlobals', 'Curs', 'CursGenotypeList', 'Metagenotype', 'StrainsService', metagenotypeManage]);
 
 
 canto.service('StrainsService', function (CantoService, Curs, $q, toaster) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -587,14 +587,13 @@ canto.service('CursGenotypeList', function ($q, Curs) {
   };
 });
 
-
 canto.service('Metagenotype', function ($rootScope, $http, toaster, Curs) {
 
-  var vm = this;
-  vm.list = [];
+  var svc = this;
+  svc.list = [];
 
-  vm.create = function (data) {
-    var storePromise = vm.store(data);
+  svc.create = function (data) {
+    var storePromise = svc.store(data);
 
     storePromise.then(function successCallback(response) {
       switch (response.data.status) {
@@ -608,7 +607,7 @@ canto.service('Metagenotype', function ($rootScope, $http, toaster, Curs) {
 
         case 'success':
           toaster.pop('success', 'This metagenotype has been created');
-          vm.load();
+          svc.load();
           break;
       }
     }, function errorCallback() {
@@ -617,7 +616,7 @@ canto.service('Metagenotype', function ($rootScope, $http, toaster, Curs) {
 
   };
 
-  vm.store = function (data) {
+  svc.store = function (data) {
     var url = curs_root_uri + '/feature/metagenotype/store';
 
     return $http({
@@ -627,13 +626,13 @@ canto.service('Metagenotype', function ($rootScope, $http, toaster, Curs) {
     });
   };
 
-  vm.delete = function (id) {
+  svc.delete = function (id) {
     loadingStart();
 
     Curs.delete('metagenotype', id)
       .then(function () {
         toaster.pop('success', 'The metagenotype has been deleted');
-        vm.load();
+        svc.load();
 
       }).catch(function (message) {
         if (message.match('metagenotype .* has annotations')) {
@@ -647,19 +646,18 @@ canto.service('Metagenotype', function ($rootScope, $http, toaster, Curs) {
       });
   };
 
-  vm.load = function () {
+  svc.load = function () {
     var options = {
       include_allele: 1,
     };
 
     Curs.list('metagenotype', [options])
       .then(function (res) {
-        vm.list = res.data;
-        $rootScope.$broadcast('metagenotype:updated', vm.list);
+        svc.list = res.data;
+        $rootScope.$broadcast('metagenotype:updated', svc.list);
       });
   };
 });
-
 
 canto.service('CursAlleleList', function ($q, Curs) {
   this.alleleList = function (genePrimaryIdentifier, searchTerm) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6975,9 +6975,9 @@ var genotypeSimpleListRowCtrl =
     return {
       restrict: 'A',
       scope: {
-        genotype: '=',
-        showCheckBoxActions: '=',
-        genotypeModel: '=',
+        genotype: '<',
+        showCheckBoxActions: '<',
+        onGenotypeSelect: '&'
       },
       replace: true,
       templateUrl: CantoGlobals.app_static_path + 'ng_templates/genotype_simple_list_row.html',
@@ -6989,11 +6989,16 @@ var genotypeSimpleListRowCtrl =
         $scope.firstAllele = $scope.genotype.alleles[0];
         $scope.otherAlleles = $scope.genotype.alleles.slice(1);
 
-        $scope.isSelected = function () {
-          var pathogen_or_host = $scope.genotype.organism.pathogen_or_host;
-          $scope.$emit(pathogen_or_host + ' selected', $scope.genotype);
+        $scope.data = {
+          selectedGenotype: null
         };
-      },
+
+        $scope.genotypeSelected = function (genotype) {
+          $scope.onGenotypeSelect({
+            genotype: genotype
+          });
+        };
+      }
     };
   };
 
@@ -7007,10 +7012,20 @@ var genotypeSimpleListViewCtrl =
         genotypeList: '=',
         showCheckBoxActions: '=',
         genotypeModel: '=',
+        onGenotypeSelect: '&'
       },
       restrict: 'E',
       replace: true,
       templateUrl: app_static_path + 'ng_templates/genotype_simple_list_view.html',
+      controller: function ($scope) {
+
+        $scope.onGenotypeChange = function (genotype) {
+          $scope.onGenotypeSelect({
+            genotype: genotype
+          });
+        }
+
+      }
     };
   };
 
@@ -7063,7 +7078,8 @@ var metagenotypeGenotypePicker =
       scope: {
         isHost: '<',
         selectedOrganism: '<',
-        genotypes: '<'
+        genotypes: '<',
+        onGenotypeSelect: '&'
       },
       restrict: 'E',
       replace: true,
@@ -7118,6 +7134,18 @@ var metagenotypeGenotypePicker =
         $scope.setFilters = function () {
           $scope.setDefaultGenotype();
         };
+
+        $scope.onGenotypeChangeSingle = function (genotype) {
+          $scope.onGenotypeSelect({
+            genotype: genotype
+          });
+        }
+
+        $scope.onGenotypeChangeMulti = function (genotype) {
+          $scope.onGenotypeSelect({
+            genotype: genotype
+          });
+        }
 
         if ($scope.isHost) {
           StrainsService.getAllSessionStrains();
@@ -7229,10 +7257,12 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
       $scope.pathogenOrganisms = null;
       $scope.selectedPathogen = null;
       $scope.selectedPathogenGenotypes = null;
+      $scope.selectedGenotypePathogen = null;
 
       $scope.hostOrganisms = null;
       $scope.selectedHost = null;
       $scope.selectedHostGenotypes = null;
+      $scope.selectedGenotypeHost = null;
 
       $scope.taxonGenotypeMap = null;
 
@@ -7247,12 +7277,20 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
         $scope.selectedPathogenGenotypes = $scope.taxonGenotypeMap[taxonId];
       };
 
+      $scope.onPathogenGenotypeSelect = function (genotype) {
+        $scope.selectedGenotypePathogen = genotype;
+      };
+
       $scope.onHostSelected = function (organism) {
         var taxonId = organism.taxonid;
         $scope.selectedHost = organism;
         $scope.selectedHostGenotypes = taxonId in $scope.taxonGenotypeMap
           ? $scope.taxonGenotypeMap[taxonId]
           : {'single': [], 'multi': []}
+      };
+
+      $scope.onHostGenotypeSelect = function (genotype) {
+        $scope.selectedGenotypeHost = genotype;
       };
 
       $scope.toGenotype = function () {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7070,8 +7070,6 @@ var metagenotypeGenotypePicker =
       controller: function ($scope) {
 
         $scope.data = {
-          singleAlleleGenotypes: [],
-          multiAlleleGenotypes: [],
           wildType: [],
           typeLabel: 'Host',
           genotypeType: 'host',
@@ -7084,32 +7082,6 @@ var metagenotypeGenotypePicker =
             organismType.toLowerCase() +
             '_genotype_manage';
         }
-
-        $scope.setSingleAlleleGenotypes = function () {
-          if ($scope.data.selectedOrganism == null) {
-            $scope.data.singleAlleleGenotypes = [];
-          } else {
-            $scope.data.singleAlleleGenotypes = $scope.data.genotypes.filter(function (e) {
-              return (
-                (e.organism.taxonid === $scope.data.selectedOrganism.taxonid) &&
-                (e.alleles.length === 1)
-              );
-            });
-          }
-        };
-
-        $scope.setMultiAlleleGenotypes = function () {
-          if ($scope.data.selectedOrganism == null) {
-            $scope.data.multiAlleleGenotypes = [];
-          } else {
-            $scope.data.multiAlleleGenotypes = $scope.data.genotypes.filter(function (e) {
-              return (
-                (e.organism.taxonid === $scope.data.selectedOrganism.taxonid) &&
-                (e.alleles.length > 1)
-              );
-            });
-          }
-        };
 
         $scope.setWildtypeOrganism = function () {
           StrainsService.getSessionStrains($scope.data.selectedOrganism.taxonid)
@@ -7135,8 +7107,6 @@ var metagenotypeGenotypePicker =
         };
 
         $scope.setFilters = function () {
-          $scope.setSingleAlleleGenotypes();
-          $scope.setMultiAlleleGenotypes();
           $scope.setDefaultGenotype();
         };
 
@@ -7332,7 +7302,35 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
         var getGenotypeTaxonId = function (genotype) {
           return genotype.organism.taxonid;
         };
-        return indexArray(genotypes, getGenotypeTaxonId);
+        var taxonGenotypeMap = indexArray(genotypes, getGenotypeTaxonId);
+        return splitGenotypeMapByAlleleCount(taxonGenotypeMap);
+      }
+
+      function splitGenotypeMapByAlleleCount(genotypeMap) {
+      	var newMap = {};
+      	var genotypes, taxonId;
+      	for (taxonId in genotypeMap) {
+      		if (genotypeMap.hasOwnProperty(taxonId)) {
+      			genotypes = genotypeMap[taxonId];
+      			newMap[taxonId] = splitGenotypesByAlleleCount(genotypes);
+      		}
+      	}
+      	return newMap;
+      }
+
+      function splitGenotypesByAlleleCount(genotypes) {
+      	var splitObject = {
+      		'single': [],
+      		'multi': []
+      	};
+      	genotypes.forEach(function (g) {
+      		if (isSingleAlleleGenotype(g)) {
+      			splitObject['single'].push(g);
+      		} else {
+      			splitObject['multi'].push(g);
+      		}
+      	});
+      	return splitObject;
       }
 
     }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7061,7 +7061,7 @@ var metagenotypeGenotypePicker =
   function (CantoGlobals, CursGenotypeList, toaster, Metagenotype, StrainsService) {
     return {
       scope: {
-        isPathogen: '<',
+        isHost: '<',
         genotypes: '<'
       },
       restrict: 'E',
@@ -7069,12 +7069,12 @@ var metagenotypeGenotypePicker =
       templateUrl: app_static_path + 'ng_templates/metagenotype_genotype_picker.html',
       controller: function ($scope) {
 
+        $scope.organismType = $scope.isHost ? 'host' : 'pathogen';
+        $scope.organismLabel = capitalizeFirstLetter($scope.organismType);
+        $scope.genotypeShortcutUrl = setGenotypeShortcut($scope.organismType);
+
         $scope.data = {
           wildType: [],
-          typeLabel: 'Host',
-          genotypeType: 'host',
-          isHost: false,
-          genotypeShortcutUrl: null
         };
 
         function setGenotypeShortcut(organismType) {
@@ -7109,15 +7109,6 @@ var metagenotypeGenotypePicker =
         $scope.setFilters = function () {
           $scope.setDefaultGenotype();
         };
-
-        if ($scope.isPathogen) {
-          $scope.data.typeLabel = 'Pathogen';
-          $scope.data.genotypeType = 'pathogen';
-        }
-
-        $scope.data.isHost = !$scope.isPathogen;
-
-        $scope.data.genotypeShortcutUrl = setGenotypeShortcut($scope.data.genotypeType);
 
         StrainsService.getAllSessionStrains();
       },

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -69,16 +69,16 @@ function arrayRemoveOne(array, item) {
 }
 
 function indexArray(array, keyFunction) {
-	var indexObject = {};
-	var i, key;
-	for (i = 0; i < array.length; i += 1) {
-		key = keyFunction(array[i]);
-		if (indexObject.hasOwnProperty(key) === false) {
-			indexObject[key] = [];
-		}
-		indexObject[key].push(array[i]);
-	}
-	return indexObject;
+  var indexObject = {};
+  var i, key;
+  for (i = 0; i < array.length; i += 1) {
+    key = keyFunction(array[i]);
+    if (indexObject.hasOwnProperty(key) === false) {
+      indexObject[key] = [];
+    }
+    indexObject[key].push(array[i]);
+  }
+  return indexObject;
 }
 
 function copyObject(src, dest, keysFilter) {
@@ -7396,30 +7396,30 @@ var metagenotypeManage = function ($q, CantoGlobals, Curs, CursGenotypeList, Met
       }
 
       function splitGenotypeMapByAlleleCount(genotypeMap) {
-      	var newMap = {};
-      	var genotypes, taxonId;
-      	for (taxonId in genotypeMap) {
-      		if (genotypeMap.hasOwnProperty(taxonId)) {
-      			genotypes = genotypeMap[taxonId];
-      			newMap[taxonId] = splitGenotypesByAlleleCount(genotypes);
-      		}
-      	}
-      	return newMap;
+        var newMap = {};
+        var genotypes, taxonId;
+        for (taxonId in genotypeMap) {
+          if (genotypeMap.hasOwnProperty(taxonId)) {
+            genotypes = genotypeMap[taxonId];
+            newMap[taxonId] = splitGenotypesByAlleleCount(genotypes);
+          }
+        }
+        return newMap;
       }
 
       function splitGenotypesByAlleleCount(genotypes) {
-      	var splitObject = {
-      		'single': [],
-      		'multi': []
-      	};
-      	genotypes.forEach(function (g) {
-      		if (isSingleAlleleGenotype(g)) {
-      			splitObject['single'].push(g);
-      		} else {
-      			splitObject['multi'].push(g);
-      		}
-      	});
-      	return splitObject;
+        var splitObject = {
+          'single': [],
+          'multi': []
+        };
+        genotypes.forEach(function (g) {
+          if (isSingleAlleleGenotype(g)) {
+            splitObject['single'].push(g);
+          } else {
+            splitObject['multi'].push(g);
+          }
+        });
+        return splitObject;
       }
 
       function createNormalMetagenotype() {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -593,35 +593,6 @@ canto.service('Metagenotype', function ($rootScope, $http, toaster, Curs) {
   var vm = this;
   vm.list = [];
 
-  vm.pickerSet = {
-    host: false,
-    pathogen: false,
-  };
-
-  vm.isPickerSet = function () {
-    return (vm.pickerSet.host && vm.pickerSet.pathogen);
-  };
-
-  vm.pickerOrganismCallbacks = {
-    host: null,
-    pathogen: null,
-  };
-
-  vm.pickerOrganismSelectors = {
-    host: function (organism) {
-      vm.pickerOrganismCallbacks.host(organism);
-      if (organism) {
-        vm.pickerSet.host = true;
-      }
-    },
-    pathogen: function (organism) {
-      vm.pickerOrganismCallbacks.pathogen(organism);
-      if (organism) {
-        vm.pickerSet.pathogen = true;
-      }
-    },
-  };
-
   vm.create = function (data) {
     var storePromise = vm.store(data);
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7319,20 +7319,12 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
       };
 
       $scope.createMetagenotype = function () {
-        var data = {};
+        var wildTypeGenotypeExists = !! $scope.selectedHostStrain;
 
-        data.pathogen_genotype_id = $scope.pathogenModel;
-        if ($scope.hostModel < 0) {
-          var strain_id = ($scope.hostModel * -1);
-          var strainPromise = StrainsService.getStrainById(strain_id);
-          strainPromise.then(function(strain) {
-            data.host_taxon_id = strain.taxon_id;
-            data.host_strain_name = strain.strain_name;
-            Metagenotype.create(data);
-          });
+        if (wildTypeGenotypeExists) {
+          createWildTypeMetagenotype();
         } else {
-          data.host_genotype_id = $scope.hostModel;
-          Metagenotype.create(data);
+          createNormalMetagenotype();
         }
       };
 
@@ -7393,6 +7385,26 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
       		}
       	});
       	return splitObject;
+      }
+
+      function createNormalMetagenotype() {
+        var pathogenGenotypeId = $scope.selectedGenotypePathogen.genotype_id;
+        var hostGenotypeId = $scope.selectedGenotypeHost.genotype_id;
+        Metagenotype.create({
+          pathogen_genotype_id: pathogenGenotypeId,
+          host_genotype_id: hostGenotypeId
+        });
+      }
+
+      function createWildTypeMetagenotype() {
+        var pathogenGenotypeId = $scope.selectedGenotypePathogen.genotype_id;
+        var hostStrainTaxonId = $scope.selectedHostStrain.taxon_id;
+        var hostStrainName = $scope.selectedHostStrain.strain_name;
+        Metagenotype.create({
+          pathogen_genotype_id: pathogenGenotypeId,
+          host_taxon_id: hostStrainTaxonId,
+          host_strain_name: hostStrainName
+        });
       }
 
     }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7277,11 +7277,7 @@ var metagenotypeManage = function (CantoGlobals, Curs, CursGenotypeList, Metagen
       $scope.genotypeUrl = CantoGlobals.curs_root_uri;
       $scope.makeInvalid = true;
       $scope.display = (!CantoGlobals.read_only_curs);
-      $scope.organismPicker = {
-        host: false,
-        pathogen: false
-      };
-
+      $scope.isPickerSet = ($scope.selectedPathogen && $scope.selectedHost);
 
       $scope.onPathogenSelected = function (organism) {
         var taxonId = organism.taxonid;

--- a/root/static/ng_templates/genotype_simple_list_row.html
+++ b/root/static/ng_templates/genotype_simple_list_row.html
@@ -3,7 +3,7 @@
         <td ng-if="showCheckBoxActions" class="curs-genotype-checkbox-column" rowspan="{{genotype.alleles.length}}">
             <input
               type="radio"
-              name="genotype"
+              name="{{inputNameValue}}"
               ng-model="data.selectedGenotype"
               ng-click="genotypeSelected(genotype)"
               value="{{genotype}}" />

--- a/root/static/ng_templates/genotype_simple_list_row.html
+++ b/root/static/ng_templates/genotype_simple_list_row.html
@@ -1,7 +1,12 @@
-<tbody ng-class="{ selected: ($parent.genotypeModel === genotype.genotype_id) }">
+<tbody>
     <tr>
         <td ng-if="showCheckBoxActions" class="curs-genotype-checkbox-column" rowspan="{{genotype.alleles.length}}">
-            <input type="radio" ng-model="$parent.genotypeModel" ng-change="isSelected()" value="{{genotype.genotype_id}}" />
+            <input
+              type="radio"
+              name="genotype"
+              ng-model="data.selectedGenotype"
+              ng-click="genotypeSelected(genotype)"
+              value="{{genotype}}" />
         </td>
         <td>
             <a href="{{curs_root_uri + '/feature/gene/view/' + firstAllele.gene_id + (read_only_curs ? '/ro' : '')}}">{{firstAllele.gene_display_name}}</a>

--- a/root/static/ng_templates/genotype_simple_list_view.html
+++ b/root/static/ng_templates/genotype_simple_list_view.html
@@ -16,6 +16,7 @@
       <tbody
         genotype-simple-list-row
         ng-repeat="currentGenotype in genotypeList track by currentGenotype.id_or_identifier"
+        is-host="isHost"
         show-check-box-actions="showCheckBoxActions"
         genotype="currentGenotype"
         on-genotype-select="onGenotypeChange(genotype)"

--- a/root/static/ng_templates/genotype_simple_list_view.html
+++ b/root/static/ng_templates/genotype_simple_list_view.html
@@ -18,7 +18,7 @@
         ng-repeat="currentGenotype in genotypeList track by currentGenotype.id_or_identifier"
         show-check-box-actions="showCheckBoxActions"
         genotype="currentGenotype"
-        genotype-model="genotypeModel">
+        on-genotype-select="onGenotypeChange(genotype)"
       </tbody>
     </table>
   </div>

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -1,6 +1,5 @@
 <div>
 <div ng-if="selectedOrganism">
-    <div class="curs-box-title" style="margin-bottom: 10px;">{{organismLabel}} Genotypes</div>
     <div>
         <p class="metagenotype-genotype-shortcut">
           <a href="{{genotypeShortcutUrl}}">Create a new {{organismType}} genotype...</a>

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -4,26 +4,26 @@
         <p class="metagenotype-genotype-shortcut">
           <a href="{{data.genotypeShortcutUrl}}">Create a new {{data.genotypeType}} genotype...</a>
         </p>
-        <div ng-if="data.selectedOrganism">
+        <div ng-if="genotypes.single.length > 0 || genotypes.multi.length > 0">
             <div class="curs-box-title">Single allele genotypes</div>
-            <div ng-show="data.singleAllele.length == 0">
+            <div ng-show="genotypes.single.length === 0">
                 <p>No Single allele genotypes created</p>
             </div>
-            <div ng-if="data.singleAllele.length > 0">
+            <div ng-if="genotypes.single.length > 0">
                 <genotype-simple-list-view
-                    genotype-list="data.singleAllele"
+                    genotype-list="genotypes.single"
                     show-check-box-actions="true"
                     genotype-model="genotypeModel">
                 </genotype-simple-list-view>
             </div>
 
             <div class="curs-box-title">Multi-allele genotypes</div>
-            <div ng-show="data.multiAllele.length == 0">
+            <div ng-show="genotypes.multi.length === 0">
                 <p>No Multi-allele genotypes created</p>
             </div>
-            <div ng-show="data.multiAllele.length > 0">
+            <div ng-show="genotypes.multi.length > 0">
                 <genotype-simple-list-view
-                    genotype-list="data.multiAllele"
+                    genotype-list="genotypes.multi"
                     show-check-box-actions="true"
                     genotype-model="genotypeModel">
                 </genotype-simple-list-view>

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -14,7 +14,7 @@
                 <genotype-simple-list-view
                     genotype-list="genotypes.single"
                     show-check-box-actions="true"
-                    genotype-model="genotypeModel">
+                    on-genotype-select="onGenotypeChangeSingle(genotype)">
                 </genotype-simple-list-view>
             </div>
 
@@ -26,7 +26,7 @@
                 <genotype-simple-list-view
                     genotype-list="genotypes.multi"
                     show-check-box-actions="true"
-                    genotype-model="genotypeModel">
+                    on-genotype-select="onGenotypeChangeMulti(genotype)">
                 </genotype-simple-list-view>
             </div>
 

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -1,11 +1,6 @@
 <div>
     <div class="curs-box-title" style="margin-bottom: 10px;">{{data.typeLabel}} Genotypes</div>
     <div>
-        <organism-selector
-            hide-label="true"
-            genotype-type="data.genotypeType"
-            organism-selected="data.pickerCallback(organism)">
-        </organism-selector>
         <p class="metagenotype-genotype-shortcut">
           <a href="{{data.genotypeShortcutUrl}}">Create a new {{data.genotypeType}} genotype...</a>
         </p>

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -12,6 +12,7 @@
             <div ng-if="genotypes.single.length > 0">
                 <genotype-simple-list-view
                     genotype-list="genotypes.single"
+                    is-host="isHost"
                     show-check-box-actions="true"
                     on-genotype-select="onGenotypeChangeSingle(genotype)">
                 </genotype-simple-list-view>
@@ -24,6 +25,7 @@
             <div ng-show="genotypes.multi.length > 0">
                 <genotype-simple-list-view
                     genotype-list="genotypes.multi"
+                    is-host="isHost"
                     show-check-box-actions="true"
                     on-genotype-select="onGenotypeChangeMulti(genotype)">
                 </genotype-simple-list-view>

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -33,9 +33,9 @@
             <div ng-if="isHost">
                 <div class="curs-box-title">Wildtype genotype</div>
                 <wild-genotype-view
-                    wild-type="data.wildType"
+                    strains="data.wildTypeStrains"
                     show-check-box-actions="true"
-                    genotype-model="genotypeModel">
+                    on-strain-select="onStrainChange(strain)">
                 </wild-genotype-view>
             </div>
         </div>

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -1,10 +1,11 @@
 <div>
+<div ng-if="selectedOrganism">
     <div class="curs-box-title" style="margin-bottom: 10px;">{{organismLabel}} Genotypes</div>
     <div>
         <p class="metagenotype-genotype-shortcut">
           <a href="{{genotypeShortcutUrl}}">Create a new {{organismType}} genotype...</a>
         </p>
-        <div ng-if="genotypes.single.length > 0 || genotypes.multi.length > 0">
+        <div>
             <div class="curs-box-title">Single allele genotypes</div>
             <div ng-show="genotypes.single.length === 0">
                 <p>No Single allele genotypes created</p>
@@ -39,4 +40,5 @@
             </div>
         </div>
     </div>
+</div>
 </div>

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -1,8 +1,8 @@
 <div>
-    <div class="curs-box-title" style="margin-bottom: 10px;">{{data.typeLabel}} Genotypes</div>
+    <div class="curs-box-title" style="margin-bottom: 10px;">{{organismLabel}} Genotypes</div>
     <div>
         <p class="metagenotype-genotype-shortcut">
-          <a href="{{data.genotypeShortcutUrl}}">Create a new {{data.genotypeType}} genotype...</a>
+          <a href="{{genotypeShortcutUrl}}">Create a new {{organismType}} genotype...</a>
         </p>
         <div ng-if="genotypes.single.length > 0 || genotypes.multi.length > 0">
             <div class="curs-box-title">Single allele genotypes</div>
@@ -29,7 +29,7 @@
                 </genotype-simple-list-view>
             </div>
 
-            <div ng-if="data.isHost">
+            <div ng-if="isHost">
                 <div class="curs-box-title">Wildtype genotype</div>
                 <wild-genotype-view
                     wild-type="data.wildType"

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -22,6 +22,7 @@
                 selected-organism="selectedHost"
                 genotypes="selectedHostGenotypes"
                 on-genotype-select="onHostGenotypeSelect(genotype)"
+                on-strain-select="onHostStrainSelect(strain)"
             </metagenotype-genotype-picker>
         </div>
     </div>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -6,7 +6,7 @@
                 organism-selected="onPathogenSelected(organism)">
             </organism-selector-new>
             <metagenotype-genotype-picker
-                is-pathogen="true"
+                is-host="false"
                 genotypes="selectedPathogenGenotypes"
             </metagenotype-genotype-picker>
         </div>
@@ -16,7 +16,7 @@
                 organism-selected="onHostSelected(organism)">
             </organism-selector-new>
             <metagenotype-genotype-picker
-                is-pathogen="false"
+                is-host="true"
                 genotypes="selectedHostGenotypes"
             </metagenotype-genotype-picker>
         </div>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -9,6 +9,7 @@
                 is-host="false"
                 selected-organism="selectedPathogen"
                 genotypes="selectedPathogenGenotypes"
+                on-genotype-select="onPathogenGenotypeSelect(genotype)"
             </metagenotype-genotype-picker>
         </div>
         <div class="col-md-6">
@@ -20,6 +21,7 @@
                 is-host="true"
                 selected-organism="selectedHost"
                 genotypes="selectedHostGenotypes"
+                on-genotype-select="onHostGenotypeSelect(genotype)"
             </metagenotype-genotype-picker>
         </div>
     </div>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -7,6 +7,7 @@
             </organism-selector-new>
             <metagenotype-genotype-picker
                 is-host="false"
+                selected-organism="selectedPathogen"
                 genotypes="selectedPathogenGenotypes"
             </metagenotype-genotype-picker>
         </div>
@@ -17,6 +18,7 @@
             </organism-selector-new>
             <metagenotype-genotype-picker
                 is-host="true"
+                selected-organism="selectedHost"
                 genotypes="selectedHostGenotypes"
             </metagenotype-genotype-picker>
         </div>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -7,8 +7,7 @@
             </organism-selector-new>
             <metagenotype-genotype-picker
                 is-pathogen="true"
-                genotype-model="pathogenModel"
-                selected-organism="pathogenSelectedOrganism">
+                genotypes="selectedPathogenGenotypes"
             </metagenotype-genotype-picker>
         </div>
         <div class="col-md-6">
@@ -18,8 +17,7 @@
             </organism-selector-new>
             <metagenotype-genotype-picker
                 is-pathogen="false"
-                genotype-model="hostModel"
-                selected-organism="hostSelectedOrganism">
+                genotypes="selectedHostGenotypes"
             </metagenotype-genotype-picker>
         </div>
     </div>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -36,7 +36,7 @@
             ng-click="createMetagenotype()"
             type="button"
             class="btn btn-primary curs-back-button"
-            ng-disabled="isPickerSet() == false"
+            ng-disabled="isMetagenotypeInvalid()"
             ng-if="display">
             Make metagenotype --&gt;
         </button>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -1,6 +1,10 @@
 <div id="curs-genotype-manage" class="genotype-list ng-cloak container">
     <div class="row" ng-if="display">
         <div class="col-md-6">
+            <organism-selector-new
+                organisms="pathogenOrganisms"
+                organism-selected="onPathogenSelected(organism)">
+            </organism-selector-new>
             <metagenotype-genotype-picker
                 is-pathogen="true"
                 genotype-model="pathogenModel"
@@ -8,6 +12,10 @@
             </metagenotype-genotype-picker>
         </div>
         <div class="col-md-6">
+            <organism-selector-new
+                organisms="hostOrganisms"
+                organism-selected="onHostSelected(organism)">
+            </organism-selector-new>
             <metagenotype-genotype-picker
                 is-pathogen="false"
                 genotype-model="hostModel"

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -1,6 +1,7 @@
 <div id="curs-genotype-manage" class="genotype-list ng-cloak container">
     <div class="row" ng-if="display">
         <div class="col-md-6">
+            <div class="curs-box-title" style="margin-bottom: 10px;">Pathogen Genotypes</div>
             <organism-selector-new
                 organisms="pathogenOrganisms"
                 organism-selected="onPathogenSelected(organism)">
@@ -13,6 +14,7 @@
             </metagenotype-genotype-picker>
         </div>
         <div class="col-md-6">
+            <div class="curs-box-title" style="margin-bottom: 10px;">Host Genotypes</div>
             <organism-selector-new
                 organisms="hostOrganisms"
                 organism-selected="onHostSelected(organism)">

--- a/root/static/ng_templates/wild_genotype_row.html
+++ b/root/static/ng_templates/wild_genotype_row.html
@@ -1,7 +1,7 @@
 <tbody>
   <tr>
       <td ng-if="showCheckBoxActions" class="curs-genotype-checkbox-column">
-          <input type="radio" ng-model="data.selectedStrain" ng-click="strainSelected(strain)" value="{{strain}}" />
+          <input type="radio" name="{{inputNameValue}}" ng-model="data.selectedStrain" ng-click="strainSelected(strain)" value="{{strain}}" />
       </td>
       <td>
           {{strain.strain_name}}

--- a/root/static/ng_templates/wild_genotype_row.html
+++ b/root/static/ng_templates/wild_genotype_row.html
@@ -1,7 +1,7 @@
-<tbody ng-class="{ selected: ($parent.genotypeModel === strain.genotype_id) }">
+<tbody>
   <tr>
       <td ng-if="showCheckBoxActions" class="curs-genotype-checkbox-column">
-          <input type="radio" ng-model="$parent.genotypeModel" ng-change="isSelected()" value="{{strain.genotype_id}}" />
+          <input type="radio" ng-model="data.selectedStrain" ng-click="strainSelected(strain)" value="{{strain}}" />
       </td>
       <td>
           {{strain.strain_name}}

--- a/root/static/ng_templates/wild_genotype_view.html
+++ b/root/static/ng_templates/wild_genotype_view.html
@@ -11,7 +11,7 @@
       </thead>
       <tbody
         wild-genotype-row
-        ng-repeat="strain in strains track by strain.genotype_id"
+        ng-repeat="strain in strains track by strain.strain_name"
         show-check-box-actions="showCheckBoxActions"
         strain="strain"
         on-strain-select="onStrainChange(strain)"

--- a/root/static/ng_templates/wild_genotype_view.html
+++ b/root/static/ng_templates/wild_genotype_view.html
@@ -1,5 +1,5 @@
 <div class="curs-genotype-list-view">
-  <div ng-if="(wildType.length > 0)">
+  <div ng-if="(strains.length > 0)">
     <table class="curs-genotype-list">
       <thead>
         <tr>
@@ -11,10 +11,10 @@
       </thead>
       <tbody
         wild-genotype-row
-        ng-repeat="strain in wildType track by strain.genotype_id"
+        ng-repeat="strain in strains track by strain.genotype_id"
         show-check-box-actions="showCheckBoxActions"
         strain="strain"
-        genotype-model="genotypeModel">
+        on-strain-select="onStrainChange(strain)"
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
(Fixes #1837)

This pull request refactors the metagenotype page to allow it to interact properly with other components. The refactoring tries to make the code more consistent with the rest of the application, particularly with regards to the refactoring of the Genotype Management page.

Notable changes include:

- Passing more data as objects (rather than passing object properties), through one-way bindings.

- Reducing nesting of components, to reduce the depth of callback binding chains.

- Removing state management from the `Metagenotype` service and transferring this responsibility to the `MetagenotypeManage` controller (might not be an ideal solution long-term).

- Delegating more control of state and data to the overall page controller `MetagenotypeManage`.

- Numerous fixes to page controls, such as the disabling logic on the metagenotype creation button, and selection of custom and unknown strains in the wild-type genotype strain selector.

These changes shouldn't need testing in any other mode, since the components and pages are only used for pathogen&ndash;host mode. I've done manual testing of the critical functionality on the page, and I didn't notice any bugs, but the page may need some more comprehensive testing just to ensure that nothing subtle is going wrong.