### PR TITLE
Simplify metagenotype shortcut link logic

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4410,7 +4410,7 @@ var genotypeManageCtrl =
             $scope.updateGenotypeLists();
             $scope.data.waitingForServer = false;
             $scope.data.pathogenGenotypeExists = findPathogenGenotype(results);
-            $scope.data.isMetagenotypeLinkDisabled = getMetagenotypeLinkState();
+            $scope.data.isMetagenotypeLinkDisabled = isMetagenotypeLinkDisabled();
             CursGenotypeList.onListChange($scope.readGenotypesCallback);
           }).catch(function () {
             toaster.pop('error', "couldn't read the genotype list from the server");
@@ -4482,12 +4482,8 @@ var genotypeManageCtrl =
           });
         }
 
-        function getMetagenotypeLinkState() {
-          var DISABLED = true, ENABLED = false;
-          if ($scope.data.pathogenGenotypeExists && $scope.data.hostOrganismExists) {
-            return ENABLED;
-          }
-          return DISABLED;
+        function isMetagenotypeLinkDisabled() {
+          return ! ($scope.data.pathogenGenotypeExists && $scope.data.hostOrganismExists);
         }
 
         readOrganisms();


### PR DESCRIPTION
On the Genotype Management page, the function that checked whether the shortcut to the Metagenotype Management page should be disabled was needlessly complicated, and only for the sake of avoiding a 'not' operator. I've changed the code to be simpler and more consistent.