### PR TITLE
Check strain is set when making allele

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3241,11 +3241,22 @@ var alleleEditDialogCtrl =
       return !!$scope.alleleData.primary_identifier;
     };
 
+    $scope.isValidStrain = function () {
+      if ($scope.strainData.showStrainPicker) {
+        return $scope.strainData.selectedStrain;
+      } else {
+        return true;
+      }
+    };
+
     $scope.isValid = function () {
       return $scope.isValidExpression() &&
-        ($scope.isExistingAllele() ||
+        (
+          $scope.isExistingAllele() ||
           $scope.isValidType() && $scope.isValidName() &&
-          $scope.isValidDescription());
+          $scope.isValidDescription()
+        ) &&
+        $scope.isValidStrain();
     };
 
     $scope.ok = function () {


### PR DESCRIPTION
(Fixes #1847)

When creating alleles on the Genotype Management page by using the 'Other genotype...' button, the code never actually checked if the strain was set before allowing the allele to be created. This fixes that. The check always returns `true` in the case that strains aren't enabled, so this change doesn't break anything for Canto's other modes.