### PR TITLE
Use flexbox layout on genotype management page

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1559,3 +1559,15 @@ a:not([href]) {
   resize: vertical;
   min-height: 60px;
 }
+
+.curs-gm-container {
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+.curs-gm-gene-col {
+  margin-left: 3px;
+}
+.curs-gm-genotype-col {
+  margin-left: 30px;
+}

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -29,9 +29,9 @@
             Add, view and edit genotypes
         </div>
         <div class="curs-box-body">
-            <div class="row">
+            <div class="row curs-gm-container">
                 <div ng-if="!read_only_curs">
-                    <div class="col-sm-3 col-md-3">
+                    <div class="curs-gm-gene-col">
                         <organism-selector
                           ng-if="data.multiOrganismMode && data.splitGenotypesByOrganism"
                           organisms="data.organisms"
@@ -54,7 +54,7 @@
                     </div>
                 </div>
 
-                <div class="col-sm-9 col-md-9">
+                <div class="curs-gm-genotype-col">
                     <div class="ng-cloak">
                         <div ng-show="data.waitingForServer">
                             <img ng-src="{{app_static_path + '/images/spinner.gif'}}" />


### PR DESCRIPTION
(Fixes #1508)

Previously we were using Bootstrap columns to lay out the genotype management page, but using fixed widths didn't cooperate with the automatic layout on tables: typically the gene list column would overflow into the genotype list column once the gene names got too long. Using a flexbox layout seems to fix this:

![genomgmt-flexbox](https://user-images.githubusercontent.com/37659591/57302191-8cd93900-70d2-11e9-940e-a56f340df3d7.PNG)

The changes introduce a few new CSS classes to explicitly tag the flex container and the columns on the genotype management page:

* `curs-gm-container`
* `curs-gm-gene-col`
* `curs-gm-genotype-col`

`gm` is just shorthand for 'genotype management'. If you'd prefer any of these classes to be named differently, please let me know.

Note I've left the Bootstrap `row` class in the markup, although I'm not sure if we necessarily need it anymore.

- - -

This change still needs testing in Firefox and Internet Explorer 11 &ndash; the latter in particular is the most buggy with regards to flexbox implementation, but it doesn't seem like the known issues should affect us, based on this list: https://github.com/philipwalton/flexbugs

