### PR TITLE
Fix watch expression for loading wild-type strains

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7264,8 +7264,8 @@ var metagenotypeGenotypePicker =
         };
 
         if ($scope.isHost) {
-          $scope.$watch('selectedOrganism', function (newVal, oldVal) {
-            if (newVal !== oldVal) {
+          $scope.$watch('selectedOrganism', function () {
+            if ($scope.selectedOrganism) {
               $scope.loadWildTypeStrains();
             }
           });


### PR DESCRIPTION
Fixes #1882 

This amends the watch expression for loading wild-type strains on the Metagenotype Management page, such that the strains only load when the selected organism is truthy (which should mean that an organism has been selected).
