### PR TITLE
Fix strain picker displaying nothing on page load

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7668,7 +7668,7 @@ var strainPicker = function () {
         newStrain: '',
         strains: null,
         sessionStrains: null,
-        strainSelector: 'Add experimental strains for this organism'
+        strainSelector: ''
       };
 
       CantoService.lookup('strains', [$scope.taxonId]).then(function (data) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7675,7 +7675,6 @@ var strainPicker = function () {
         $scope.data.strains = data;
       });
 
-
       $scope.getSessionStrains = function () {
         StrainsService.getSessionStrains($scope.taxonId)
           .then(function (sessionStrains) {
@@ -7686,7 +7685,7 @@ var strainPicker = function () {
       $scope.getSessionStrains();
 
       $scope.changed = function () {
-        if ($scope.data.strainSelector !== 'Type a new strain') {
+        if ($scope.data.strainSelector && notActionOption()) {
           StrainsService.addSessionStrain($scope.taxonId, $scope.data.strainSelector)
             .then($scope.getSessionStrains);
         }
@@ -7705,6 +7704,13 @@ var strainPicker = function () {
         StrainsService.addSessionStrain($scope.taxonId, $scope.data.newStrain)
           .then($scope.getSessionStrains);
       };
+
+      function notActionOption() {
+        return (
+          $scope.data.strainSelector !== 'Type a new strain' &&
+          $scope.data.strainSelector !== 'Add experimental strains for this organism'
+        );
+      }
     },
   };
 };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7685,7 +7685,7 @@ var strainPicker = function () {
       $scope.getSessionStrains();
 
       $scope.changed = function () {
-        if ($scope.data.strainSelector && notActionOption()) {
+        if ($scope.data.strainSelector && ($scope.data.strainSelector !== 'Type a new strain')) {
           StrainsService.addSessionStrain($scope.taxonId, $scope.data.strainSelector)
             .then($scope.getSessionStrains);
         }
@@ -7705,12 +7705,6 @@ var strainPicker = function () {
           .then($scope.getSessionStrains);
       };
 
-      function notActionOption() {
-        return (
-          $scope.data.strainSelector !== 'Type a new strain' &&
-          $scope.data.strainSelector !== 'Add experimental strains for this organism'
-        );
-      }
     },
   };
 };

--- a/root/static/ng_templates/strainPicker.html
+++ b/root/static/ng_templates/strainPicker.html
@@ -9,7 +9,7 @@
     <div style="width:280px;">
         <select ng-model="data.strainSelector" ng-change="changed()">
             <optgroup>
-                <option>Add experimental strains for this organism</option>
+                <option value="">Add experimental strains for this organism</option>
             </optgroup>
             <optgroup label="-----------------------------">
                 <option>Type a new strain</option>

--- a/root/static/ng_templates/strainPicker.html
+++ b/root/static/ng_templates/strainPicker.html
@@ -9,7 +9,7 @@
     <div style="width:280px;">
         <select ng-model="data.strainSelector" ng-change="changed()">
             <optgroup>
-                <option disabled>Add experimental strains for this organism</option>
+                <option>Add experimental strains for this organism</option>
             </optgroup>
             <optgroup label="-----------------------------">
                 <option>Type a new strain</option>


### PR DESCRIPTION
Fixes #1881 

It's possible that there's been some changes in the `ngModel` logic for AngularJS that prevents it selecting a disabled `<option>` element when used with a `<select>`. This was causing the strain picker on the gene confirmation page to default to an empty value, since its default `<option>` is given the `disabled` attribute in the template:

![empty-strain-picker](https://user-images.githubusercontent.com/37659591/58099648-faf22580-7bd3-11e9-9b98-052d5c3cb30e.PNG)

This change removes the `disabled` attribute as a quick fix, and has the controller check that the drop-down's selection isn't a 'special' option that represents an action (e.g. 'Type a strain' or the default descriptive 'Add a strain...' option).

@kimrutherford This fix is brittle, since it relies on values that are hard-coded into the template staying in sync with values hard-coded into the controller. If you don't think that's a problem then I'll leave it as is, but I think a better solution might be to either:

- **a)** store all the option text as (scope) variables in the controller and then bind them to the template, or

- **b)** use the `ng-options` directive to render the list instead, since this can set the `disabled` attribute as part of the expression. I expect this would require reshaping the data in the controller (see https://github.com/pombase/canto/issues/1881#issuecomment-494373625 for more caveats).