### PR TITLE
Show genotype background in metagenotype page tables

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7332,6 +7332,7 @@ var metagenotypeListRow = function (CantoGlobals, Metagenotype, AnnotationTypeCo
   return {
     scope: {
       metagenotype: '=',
+      showBackground: '<'
     },
     restrict: 'A',
     replace: true,
@@ -7392,8 +7393,11 @@ var metagenotypeListView = function (Metagenotype) {
     templateUrl: app_static_path + 'ng_templates/metagenotype_list_view.html',
     controller: function ($scope) {
       $scope.metagenotypes = [];
+      $scope.showBackground = {};
+
       $scope.$on('metagenotype:updated', function (event, data) {
         $scope.metagenotypes = data;
+        $scope.showBackground = getBackgroundColumnSettings($scope.metagenotypes);
       });
 
       $scope.$on('metagenotype list changed', function () {
@@ -7401,6 +7405,23 @@ var metagenotypeListView = function (Metagenotype) {
       });
 
       Metagenotype.load();
+
+      function getBackgroundColumnSettings(metagenotypes) {
+        var backgroundFinder = function (organismType) {
+          return function (mg) {
+            var genotype = mg[organismType + '_genotype'];
+            return (
+              genotype.organism.pathogen_or_host === organismType &&
+              genotype.background !== null
+            );
+          };
+        };
+        return {
+          'pathogen': arrayContains(metagenotypes, backgroundFinder('pathogen')),
+          'host': arrayContains(metagenotypes, backgroundFinder('host')),
+        };
+      }
+
     }
   };
 };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7127,6 +7127,7 @@ var genotypeSimpleListRowCtrl =
         genotype: '<',
         isHost: '<',
         showCheckBoxActions: '<',
+        showBackground: '<',
         onGenotypeSelect: '&'
       },
       replace: true,
@@ -7171,6 +7172,9 @@ var genotypeSimpleListViewCtrl =
       replace: true,
       templateUrl: app_static_path + 'ng_templates/genotype_simple_list_view.html',
       controller: function ($scope) {
+        $scope.showBackground = false;
+
+        $scope.$watch('genotypeList', updateShowBackground);
 
         $scope.onGenotypeChange = function (genotype) {
           $scope.onGenotypeSelect({
@@ -7178,6 +7182,12 @@ var genotypeSimpleListViewCtrl =
           });
         };
 
+        function updateShowBackground() {
+          function hasBackground(genotype) {
+            return genotype.background !== null;
+          }
+          $scope.showBackground = arrayContains($scope.genotypeList, hasBackground);
+        }
       }
     };
   };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7184,7 +7184,7 @@ var genotypeSimpleListViewCtrl =
 
         function updateShowBackground() {
           function hasBackground(genotype) {
-            return genotype.background !== null;
+            return !! genotype.background;
           }
           $scope.showBackground = arrayContains($scope.genotypeList, hasBackground);
         }
@@ -7422,7 +7422,7 @@ var metagenotypeListView = function (Metagenotype) {
             var genotype = mg[organismType + '_genotype'];
             return (
               genotype.organism.pathogen_or_host === organismType &&
-              genotype.background !== null
+              !! genotype.background
             );
           };
         };

--- a/root/static/ng_templates/genotype_simple_list_row.html
+++ b/root/static/ng_templates/genotype_simple_list_row.html
@@ -20,6 +20,9 @@
         <td rowspan="{{genotype.alleles.length}}">
             <span ng-bind-html="genotype.strain_name | formatExpression | toTrusted"></span>
         </td>
+        <td rowspan="{{genotype.alleles.length}}" ng-show="showBackground">
+          <span ng-bind-html="genotype.background | wrapAtSpaces | encodeAlleleSymbols | toTrusted"></span>
+        </td>
     </tr>
     <tr ng-repeat="currentAllele in otherAlleles track by $index">
         <td>

--- a/root/static/ng_templates/genotype_simple_list_view.html
+++ b/root/static/ng_templates/genotype_simple_list_view.html
@@ -4,13 +4,14 @@
       <thead>
         <tr>
           <th ng-if="showCheckBoxActions" class="curs-genotype-checkbox-column" rowspan="2">&nbsp;</th>
-          <th style="border-bottom: 1px solid grey" colspan="4">Genotype</th>
+          <th style="border-bottom: 1px solid grey" colspan="{{showBackground ? 5 : 4}}">Genotype</th>
         </tr>
         <tr>
           <th>Genes</th>
           <th>Alleles</th>
           <th>Expression</th>
           <th>Strain</th>
+          <th ng-show="showBackground">Background</th>
         </tr>
       </thead>
       <tbody
@@ -20,6 +21,7 @@
         show-check-box-actions="showCheckBoxActions"
         genotype="currentGenotype"
         on-genotype-select="onGenotypeChange(genotype)"
+        show-background="showBackground"
       </tbody>
     </table>
   </div>

--- a/root/static/ng_templates/metagenotype_list_row.html
+++ b/root/static/ng_templates/metagenotype_list_row.html
@@ -5,11 +5,13 @@
           <span class="metagenotype-list-strain">{{ getStrainName('pathogen') }}</span>
         </td>
         <td>{{ metagenotype.pathogen_genotype.display_name }}</td>
+        <td ng-if="showBackground.pathogen">{{ metagenotype.pathogen_genotype.background }}</td>
         <td>
           <b>{{ getOrganismName('host') }}</b>
           <span class="metagenotype-list-strain">{{ getStrainName('host') }}</span>
         </td>
         <td>{{ metagenotype.host_genotype.display_name }}</td>
+        <td ng-if="showBackground.host">{{ metagenotype.host_genotype.background }}</td>
         <td>{{ metagenotype.annotation_count }}</td>
         <td class="table-row-actions">
             <div ng-repeat="annotationType in matchingAnnotationTypes">

--- a/root/static/ng_templates/metagenotype_list_view.html
+++ b/root/static/ng_templates/metagenotype_list_view.html
@@ -6,21 +6,24 @@
                 <table class="curs-genotype-list">
                     <thead>
                         <tr>
-                            <th colspan="2">Pathogen</th>
-                            <th colspan="2">Host</th>
+                            <th colspan="{{showBackground.pathogen ? 3 : 2}}">Pathogen</th>
+                            <th colspan="{{showBackground.host ? 3 : 2}}">Host</th>
                             <th></th>
                         </tr>
                         <tr>
                             <th>Organism</th>
                             <th>Genotype</th>
+                            <th ng-if="showBackground.pathogen">Background</th>
                             <th>Organism</th>
                             <th>Genotype</th>
+                            <th ng-if="showBackground.host">Background</th>
                             <th>Annotations</th>
                         </tr>
                     </thead>
                     <tbody
                     metagenotype-list-row
                     ng-repeat="meta in metagenotypes track by meta.metagenotype_id"
+                    show-background="showBackground"
                     metagenotype="meta">
                   </tbody>
                 </table>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -41,5 +41,7 @@
             Make metagenotype --&gt;
         </button>
     </div>
-    <metagenotype-list-view></metagenotype-list-view>
+    <div class="row">
+      <metagenotype-list-view></metagenotype-list-view>
+    </div>
 </div>


### PR DESCRIPTION
Fixes #1873 

The genotype and metagenotype tables on the Metagenotype Management page weren't displaying a column for the genotype background under any circumstances. The background was sometimes needed to distinguish metagenotypes that differed only by their background. This provides a quick fix to that.

The fix definitely isn't ideal, since it causes more divergence between the Genotype Management and Metagenotype Management pages &ndash; the latter already uses a different directive for its genotype tables, called `genotypeSimpleListView` &ndash; my changes are particular to the Metagenotype Management version of the directive, just because it was faster and easier to get implemented. I'm planning to merge the directives on both pages at some point (see #1714), but I haven't figured out a good way to do this yet.

Besides the above problems, the solution seems to work well &ndash; for each table, the background columns are only shown if at least one genotype or metagenotype in that table has a background.

**Note** that the solution uses boolean conversion `!!` on the background field, rather than `null` checking, since editing the background of a genotype to the empty string `""` doesn't set the background back to `null`. I'm not sure if that's meant to be intended behaviour.

- - -

![metagenotype-genotype-background](https://user-images.githubusercontent.com/37659591/58250012-46cdd780-7d58-11e9-9542-a77fe2ec7d09.PNG)

![metagenotype-background](https://user-images.githubusercontent.com/37659591/58250017-49303180-7d58-11e9-9fc4-28a4529bfc78.PNG)
