### PR TITLE
Show organism and strain when editing genotype annotation

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4216,7 +4216,7 @@ var genotypeManageCtrl =
         $scope.app_static_path = CantoGlobals.app_static_path;
         $scope.read_only_curs = CantoGlobals.read_only_curs;
         $scope.curs_root_uri = CantoGlobals.curs_root_uri;
-        $scope.pathogen_host_mode = CantoGlobals.pathogen_host_mode == "1";
+        $scope.pathogen_host_mode = CantoGlobals.pathogen_host_mode;
         $scope.metagenotypeUrl = CantoGlobals.curs_root_uri + '/metagenotype_manage';
 
         $scope.data = {
@@ -4693,7 +4693,7 @@ var genotypeListRowLinksCtrl =
 
         $scope.curs_root_uri = CantoGlobals.curs_root_uri;
         $scope.read_only_curs = CantoGlobals.read_only_curs;
-        $scope.pathogen_host_mode = CantoGlobals.pathogen_host_mode !== "0";
+        $scope.pathogen_host_mode = CantoGlobals.pathogen_host_mode;
 
         $scope.matchingAnnotationTypes = [];
 
@@ -5068,7 +5068,7 @@ var genotypeListViewCtrl =
         }
 
         function getOrganismType(genotypes) {
-          if (CantoGlobals.pathogen_host_mode === "1") {
+          if (CantoGlobals.pathogen_host_mode) {
             var genotype = genotypes[0];
             if ('organism' in genotype) {
               var organism = genotype.organism;
@@ -5666,8 +5666,8 @@ var annotationEditDialogCtrl =
       showEvidence: true,
     };
 
-    $scope.showOrganismName = !! CantoGlobals.pathogen_host_mode;
-    $scope.showStrainName = !! CantoGlobals.strains_mode;
+    $scope.showOrganismName = CantoGlobals.pathogen_host_mode;
+    $scope.showStrainName = CantoGlobals.strains_mode;
 
     copyObject(args.annotation, $scope.annotation);
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -756,7 +756,7 @@ canto.service('CantoGlobals', function ($window) {
   this.split_genotypes_by_organism = $window.split_genotypes_by_organism == 1;
   this.show_genotype_management_genes_list = $window.show_genotype_management_genes_list;
   this.strains_mode = $window.strains_mode == 1;
-  this.pathogen_host_mode = $window.pathogen_host_mode;
+  this.pathogen_host_mode = $window.pathogen_host_mode == 1;
   this.alleles_have_expression = $window.alleles_have_expression;
   this.allow_single_wildtype_allele = $window.allow_single_wildtype_allele;
   this.diploid_mode = $window.diploid_mode;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -5666,6 +5666,9 @@ var annotationEditDialogCtrl =
       showEvidence: true,
     };
 
+    $scope.showOrganismName = !! CantoGlobals.pathogen_host_mode;
+    $scope.showStrainName = !! CantoGlobals.strains_mode;
+
     copyObject(args.annotation, $scope.annotation);
 
     $scope.isValidFeature = function () {

--- a/root/static/ng_templates/annotation_edit.html
+++ b/root/static/ng_templates/annotation_edit.html
@@ -12,6 +12,14 @@
     <div class="curs-dialog-body-contents" ng-switch="annotationType.category">
     <table ng-switch-when="ontology" class="curs-definition-table">
 
+      <tr ng-if="showOrganismName">
+        <td class="title">Organism</td>
+        <td>
+          <b>{{annotation.organism.scientific_name}}</b>
+          <span ng-if="showStrainName">({{annotation.strain_name}})</span>
+        </td>
+      </tr>
+
       <tr ng-if="annotationType.feature_type === 'gene'"
           ng-class="{ 'has-error': !isValidFeature() }">
         <td class="title">


### PR DESCRIPTION
Fixes #1767 

Previously there wasn't any way to see the organism or the strain of a genotype when editing the annotation for said genotype. I've fixed that by adding another row to the edit modal:

![phenotype-edit-organism](https://user-images.githubusercontent.com/37659591/58253509-8a2c4400-7d60-11e9-8e37-7bac5f769237.PNG)

I've restricted the strain name to only display when `CantoGlobals.strains_mode` is true.

@kimrutherford I have a few questions about the changes I've made:

1. Currently the organism name only shows in pathogen-host mode, because I wasn't sure if this would be useful for FlyBase (they didn't want the genotype page filtered by organism, so I'm assuming they can distinguish organisms by allele name). Should the organism name always show in multi-organism mode?

   (If `CantoGlobals.multi_organism_mode` is always true when `CantoGlobals.pathogen_host_mode` is true &ndash; meaning `pathogen_host_mode` is a subset of `multi_organism_mode` &ndash; we only need to check for `CantoGlobals.multi_organism_mode`. Is this the case?)

2. I've chosen to use the `scientific_name` for the organism for display purposes. Should I be using `full_name` instead? In the case of _F. graminearum_, both names are equivalent.