### PR TITLE
Let the organism-selector width be auto

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1553,10 +1553,6 @@ a:not([href]) {
   color: whitesmoke;
 }
 
-.curs-organism-selector-select {
-  width: 100%;
-}
-
 .strain-selector__container {
   display: inline-block;
 }

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1553,6 +1553,11 @@ a:not([href]) {
   color: whitesmoke;
 }
 
+.curs-organism-selector-select {
+  width: auto;
+  max-width: 300px;
+}
+
 .strain-selector__container {
   display: inline-block;
 }

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -5,7 +5,6 @@
 <div class="curs-organism-selector" ng-if="organisms">
   <p ng-if="::label" class="curs-organism-selector-label"><b>{{::label}}</b></p>
   <select ng-if="organisms.length > 1"
-      class="curs-organism-selector-select"
       name="select-organism"
       ng-model="data.selectedOrganism"
       ng-change="organismChanged()"

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -5,6 +5,7 @@
 <div class="curs-organism-selector" ng-if="organisms">
   <p ng-if="::label" class="curs-organism-selector-label"><b>{{::label}}</b></p>
   <select ng-if="organisms.length > 1"
+      class="curs-organism-selector-select"
       name="select-organism"
       ng-model="data.selectedOrganism"
       ng-change="organismChanged()"


### PR DESCRIPTION
Hi James.

Could you give me your opinion of this small change?  I tried it because sometimes things don't look good when genotype management page isn't wide enough.  Can you see any downsides?

![wide-selector-1](https://user-images.githubusercontent.com/90474/58395991-c92f0200-809e-11e9-9283-26990f22bd2a.png)
