### PR TITLE
Hide organism row when editing metagenotype annotations

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -5721,13 +5721,16 @@ var annotationEditDialogCtrl =
       showEvidence: true,
     };
 
+    copyObject(args.annotation, $scope.annotation);
+
     $scope.showOrganismName = (
       CantoGlobals.pathogen_host_mode &&
-      args.annotation.feature_type !== 'metagenotype'
+      $scope.annotation.feature_type !== 'metagenotype'
     );
-    $scope.showStrainName = CantoGlobals.strains_mode && !!args.annotation.strain_name;
-
-    copyObject(args.annotation, $scope.annotation);
+    $scope.showStrainName = (
+      CantoGlobals.strains_mode &&
+      $scope.annotation.strain_name
+    );
 
     $scope.isValidFeature = function () {
       return $scope.annotation.feature_id;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -5721,7 +5721,10 @@ var annotationEditDialogCtrl =
       showEvidence: true,
     };
 
-    $scope.showOrganismName = CantoGlobals.pathogen_host_mode;
+    $scope.showOrganismName = (
+      CantoGlobals.pathogen_host_mode &&
+      args.annotation.feature_type !== 'metagenotype'
+    );
     $scope.showStrainName = CantoGlobals.strains_mode && !!args.annotation.strain;
 
     copyObject(args.annotation, $scope.annotation);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -5725,7 +5725,7 @@ var annotationEditDialogCtrl =
       CantoGlobals.pathogen_host_mode &&
       args.annotation.feature_type !== 'metagenotype'
     );
-    $scope.showStrainName = CantoGlobals.strains_mode && !!args.annotation.strain;
+    $scope.showStrainName = CantoGlobals.strains_mode && !!args.annotation.strain_name;
 
     copyObject(args.annotation, $scope.annotation);
 


### PR DESCRIPTION
Fixes #1903 

The dialog for editing metagenotype annotations was still showing a row for the organism name and strain, when this should have only been shown for single-organism phenotype annotations. This fixes that. I've also fixed a bug where I was using the wrong property name for the strain name.