### PR TITLE
Replace ASCII arrows with Unicode arrows

### DIFF
--- a/root/curs/gene_page.mhtml
+++ b/root/curs/gene_page.mhtml
@@ -130,7 +130,7 @@ Genotypes for <% $gene->display_name() %> in this session
 
 <div class="clearall"/>
 
-<a href="<% $summary_url %>" type="button" class="btn btn-primary curs-back-button"><% $finish_text %></a>
+<a href="<% $summary_url %>" type="button" class="btn btn-primary curs-back-button">&larr; <% $finish_text %></a>
 
 <annotation-table-list feature-type-filter="gene" feature-id-filter="<% $gene_id %>"
                        feature-filter-display-name="<% $gene->display_name() %>"></annotation-table-list>
@@ -160,7 +160,7 @@ if (defined $org_config) {
 my $st = $c->stash();
 
 my $gene_count = $st->{gene_count};
-my $finish_text = '<- Back to summary';
+my $finish_text = 'Back to summary';
 my $read_only_curs = $st->{read_only_curs};
 my $pathogen_host_mode = $st->{pathogen_host_mode};
 

--- a/root/curs/genotype_page.mhtml
+++ b/root/curs/genotype_page.mhtml
@@ -121,7 +121,7 @@ Description
 <div class="clearall"/>
 
 <button type="button" ng-click="backToGenotypes()"
-        class="btn btn-primary curs-back-button">&lt;- Back to genotypes</button>
+        class="btn btn-primary curs-back-button">&larr; Back to genotypes</button>
 
 <annotation-table-list feature-type-filter="genotype" feature-id-filter="<% $genotype_id %>"
                        feature-filter-display-name="<% $genotype->display_name($c->config()) %>"></annotation-table-list>

--- a/root/curs/metagenotype_page.mhtml
+++ b/root/curs/metagenotype_page.mhtml
@@ -68,7 +68,7 @@ Description
 <div class="clearall"/>
 
 <button type="button" ng-click="backToMetagenotypes()"
-        class="btn btn-primary curs-back-button">&lt;- Back</button>
+        class="btn btn-primary curs-back-button">&larr; Back</button>
 
 </div>
 

--- a/root/curs/modules/interaction.mhtml
+++ b/root/curs/modules/interaction.mhtml
@@ -17,12 +17,12 @@ $feature
 
       <button type="submit" class="btn btn-primary curs-back-button"
               title="Back to previous page"
-              ng-click="unconfirmEvidence()">&lt;- Back</button>
+              ng-click="unconfirmEvidence()">&larr; Back</button>
 
       <button type="submit" class="btn btn-primary curs-finish-button"
               title="{{someFeaturesSelected() ? 'Confirm' : 'Select some genes to confirm this interaction'}}"
               ng-disabled="!someFeaturesSelected()"
-              ng-click="addInteractionAndEvidence()">Confirm -&gt;</button>
+              ng-click="addInteractionAndEvidence()">Confirm &rarr;</button>
     </div>
   </div>
 
@@ -49,11 +49,11 @@ the interaction once.
     </div>
 
     <button type="submit" class="btn btn-primary curs-back-button"
-            title="&lt;- Back"
-            ng-click="backToGene()">&lt;- Back</button>
+            title="&larr; Back"
+            ng-click="backToGene()">&larr; Back</button>
     <button type="submit" class="btn btn-primary curs-finish-button"
             ng-disabled="!isValidEvidence() || postInProgress"
-            ng-click="confirmEvidence()" >Proceed -&gt;</button>
+            ng-click="confirmEvidence()" >Proceed &rarr;</button>
 
   </div>
 </div>

--- a/root/curs/modules/ontology.mhtml
+++ b/root/curs/modules/ontology.mhtml
@@ -74,22 +74,22 @@ Annotation extensions
 
   <div ng-show="currentTerm()" class="ng-cloak curs-ontology-workflow-buttons">
     <button type="submit" class="btn btn-primary curs-back-button"
-            title="&lt;- Back"
-            ng-click="back()">&lt;- Back</button>
+            title="&larr; Back"
+            ng-click="back()">&larr; Back</button>
     <div ng-if="getState() == 'searching' && doNotAnnotateCurrentTerm" class="curs-do-not-annotate">
       This term should not be used for direct annotations. Please
       select a more specific term, or suggest a new descendant term.
     </div>
     <button ng-if="getState() != 'searching' || !doNotAnnotateCurrentTerm"
             type="submit" class="btn btn-primary curs-finish-button"
-            title="Proceed -&gt;"
+            title="Proceed &rarr;"
             ng-disabled="!isValid() || postInProgress"
-            ng-click="proceed()" >Proceed -&gt;</button>
+            ng-click="proceed()" >Proceed &rarr;</button>
   </div>
 
   <a ng-show="!prevState() && !currentTerm() && backToFeatureUrl"
      href="{{backToFeatureUrl}}"
-     class="btn btn-primary curs-back-button">&lt;- Back</a>
+     class="btn btn-primary curs-back-button">&larr; Back</a>
 </div>
 
 <%init>

--- a/root/curs/modules/ontology_allele_select.mhtml
+++ b/root/curs/modules/ontology_allele_select.mhtml
@@ -54,7 +54,7 @@ $editing
 
   <button id="curs-add-allele-proceed" name="allele-proceed" type="submit"
           style="display: none" class="curs-finish-button">
-    Proceed -&gt;
+    Proceed &rarr;
   </button>
 </div>
 

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -108,12 +108,12 @@
     <div class="row">
         <div class="col-sm-5 col-md-5">
             <button ng-click="backToSummary()" type="button" class="btn btn-primary curs-back-button">
-                &lt;-- Back to summary
+                &larr; Back to summary
             </button>
             <span ng-if="pathogen_host_mode">
             <button ng-click="toMetagenotype()" type="button" class="btn btn-primary curs-back-button"
                     ng-disabled="data.isMetagenotypeLinkDisabled">
-                Metagenotype management --&gt;
+                Metagenotype management &rarr;
             </button>
             </span>
         </div>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -30,7 +30,7 @@
     </div>
     <div class="row">
         <button ng-click="toGenotype()" type="button" class="btn btn-primary curs-back-button">
-            &lt;-- Back to Summary
+            &larr; Back to Summary
         </button>
         <button
             ng-click="createMetagenotype()"
@@ -38,7 +38,7 @@
             class="btn btn-primary curs-back-button"
             ng-disabled="isMetagenotypeInvalid()"
             ng-if="display">
-            Make metagenotype --&gt;
+            Make metagenotype &rarr;
         </button>
     </div>
     <div class="row">

--- a/root/static/ng_templates/term_confirm.html
+++ b/root/static/ng_templates/term_confirm.html
@@ -41,10 +41,10 @@ Confirm term
   <div class="modal-footer">
     <div ng-if="data.state == 'definition'">
       <button class="btn btn-warning" ng-click="cancel()">Cancel</button>
-      <button class="btn btn-primary" ng-click="next()">Next -&gt;</button>
+      <button class="btn btn-primary" ng-click="next()">Next &rarr;</button>
     </div>
     <div ng-if="data.state == 'children'">
-      <button class="btn btn-warning" ng-click="back()">&lt;- Back</button>
+      <button class="btn btn-warning" ng-click="back()">&larr; Back</button>
       <button ng-if="!data.doNotAnnotateCurrentTerm"
               class="btn btn-primary" ng-click="finish()">Finish</button>
     </div>


### PR DESCRIPTION
Fixes #1919

This pull request replaces every instance of an arrow styled as ASCII with its corresponding Unicode representation. This primarily affects Canto's navigation buttons:

**Before**

![image](https://user-images.githubusercontent.com/37659591/58949290-fc9b1c00-8783-11e9-9ae7-0a6b9bbaa32b.png)

**After**

![image](https://user-images.githubusercontent.com/37659591/58949298-03299380-8784-11e9-941f-82d9d1205644.png)
