### PR TITLE
Small improvements to navigation buttons

### DIFF
--- a/root/curs/metagenotype_page.mhtml
+++ b/root/curs/metagenotype_page.mhtml
@@ -62,13 +62,11 @@ Description
 
 <div class="clearall"/>
 
-<annotation-table-list feature-type-filter="metagenotype" feature-id-filter="<% $metagenotype_id %>"
-                       feature-filter-display-name="<% $metagenotype->display_name($c->config()) %>"></annotation-table-list>
-
-<div class="clearall"/>
-
 <button type="button" ng-click="backToMetagenotypes()"
         class="btn btn-primary curs-back-button">&larr; Back to metagenotypes</button>
+
+<annotation-table-list feature-type-filter="metagenotype" feature-id-filter="<% $metagenotype_id %>"
+                       feature-filter-display-name="<% $metagenotype->display_name($c->config()) %>"></annotation-table-list>
 
 </div>
 

--- a/root/curs/metagenotype_page.mhtml
+++ b/root/curs/metagenotype_page.mhtml
@@ -68,7 +68,7 @@ Description
 <div class="clearall"/>
 
 <button type="button" ng-click="backToMetagenotypes()"
-        class="btn btn-primary curs-back-button">&larr; Back</button>
+        class="btn btn-primary curs-back-button">&larr; Back to metagenotypes</button>
 
 </div>
 

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -38,7 +38,7 @@
             class="btn btn-primary curs-back-button"
             ng-disabled="isMetagenotypeInvalid()"
             ng-if="display">
-            Make metagenotype &rarr;
+            Make metagenotype
         </button>
     </div>
     <div class="row">


### PR DESCRIPTION
This PR makes some small changes to navigation buttons, mainly in pathogen-host mode, to make them more sensible and/or consistent with the rest of the application:

* Remove the right arrow from the 'Make metagenotype' button on the Metagenotype Management page: the button doesn't actually navigate forwards, so it shouldn't look like a navigation button.

* Rename the back button on the metagenotype details page from 'Back' to 'Back to metagenotypes', which is more consistent with the Genotype Management page.

* Put the 'back' button on the Metagenotype Details page above the metagenotype list, which is more consistent with the Genotype Management page.