### PR TITLE
Redesign summary page gene list to not use tables

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1627,3 +1627,18 @@ a:not([href]) {
 .curs-pub-finished-message-to-curator  {
   white-space: pre;
 }
+.curs-summary-gene-box {
+  overflow: auto;
+}
+.curs-summary-gene-column {
+  float: left;
+  margin-right: 10px;
+  padding-right: 10px;
+  margin-top: 10px;
+}
+.curs-summary-gene-organism-box {
+  margin-bottom: 8px;
+}
+.curs-summary-no-gene-text {
+  color: #737373;
+}

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1627,7 +1627,7 @@ a:not([href]) {
 .curs-pub-finished-message-to-curator  {
   white-space: pre;
 }
-.curs-summary-gene-box {
+.curs-summary-gene-container {
   overflow: auto;
 }
 .curs-summary-gene-column {
@@ -1636,9 +1636,12 @@ a:not([href]) {
   padding-right: 10px;
   margin-top: 10px;
 }
-.curs-summary-gene-organism-box {
+.curs-summary-organism-container {
   margin-bottom: 8px;
 }
 .curs-summary-no-gene-text {
   color: #737373;
+}
+.curs-summary-gene-name {
+  display: block;
 }

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1628,10 +1628,10 @@ a:not([href]) {
   white-space: pre;
 }
 .curs-summary-gene-container {
-  overflow: auto;
+  display: flex;
+  flex-wrap: wrap;
 }
 .curs-summary-gene-column {
-  float: left;
   margin-right: 10px;
   padding-right: 10px;
   margin-top: 10px;

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1642,6 +1642,6 @@ a:not([href]) {
 .curs-summary-no-gene-text {
   color: #737373;
 }
-.curs-summary-gene-name {
+.curs-summary-gene-name-container {
   display: block;
 }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -8033,6 +8033,7 @@ var summaryPageGeneList = function (CantoGlobals) {
     replace: true,
     templateUrl: app_static_path + 'ng_templates/summary_page_gene_list.html',
     controller: function ($scope) {
+      $scope.readOnlyFragment = getReadOnlyFragment();
       $scope.organismData = CantoGlobals.organismsAndGenes.sort(function (a, b) {
         return (a.full_name > b.full_name) ? 1 : -1;
       });
@@ -8058,7 +8059,27 @@ var summaryPageGeneList = function (CantoGlobals) {
         var padLength = $scope.maxCols() - 1;
         return new Array(padLength);
       };
-    },
+      $scope.getRoleHeading = function (role) {
+        if (role === 'pathogen') {
+          return 'Pathogens';
+        }
+        return 'Hosts';
+      };
+      $scope.getGeneUrl = function (gene) {
+        var root = CantoGlobals.curs_root_uri;
+        var readOnly = $scope.readOnlyFragment;
+        var url = root + '/feature/gene/view/' + gene.gene_id + readOnly;
+        return url;
+      }
+      function getReadOnlyFragment() {
+        var isReadOnly = CantoGlobals.read_only_curs;
+        var readOnlyFragment = ''
+        if (isReadOnly) {
+          readOnlyFragment = '/ro';
+        }
+        return readOnlyFragment;
+      }
+    }
   };
 };
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -236,6 +236,18 @@ function filterStrainsByTaxonId(strains, taxonId) {
   });
 }
 
+function sortByProperty(p) {
+  return function(a, b) {
+    if (a[p] < b[p]) {
+      return -1;
+    }
+    if (a[p] > b[p]) {
+      return 1;
+    }
+    return 0;
+  };
+}
+
 canto.filter('breakExtensions', function () {
   return function (text) {
     if (text) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -8048,6 +8048,10 @@ var summaryPageGeneList = function (CantoGlobals) {
       $scope.readOnlyFragment = getReadOnlyFragment();
       $scope.organismRoles = getOrganismRoles();
       $scope.organisms = getOrganismGroups($scope.organismRoles);
+      $scope.organismRoles = removeEmptyRoles(
+        $scope.organismRoles,
+        $scope.organisms
+      );
 
       $scope.getRoleHeading = function (role) {
         if (role === 'pathogen') {
@@ -8069,6 +8073,12 @@ var summaryPageGeneList = function (CantoGlobals) {
           roles = ['pathogen', 'host']
         }
         return roles;
+      }
+      
+      function removeEmptyRoles(roles, groups) {
+        return roles.filter(function(r) {
+          return groups[r].length > 0;
+        });
       }
 
       function getOrganismGroups(roles) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -8046,30 +8046,69 @@ var summaryPageGeneList = function (CantoGlobals) {
     templateUrl: app_static_path + 'ng_templates/summary_page_gene_list.html',
     controller: function ($scope) {
       $scope.readOnlyFragment = getReadOnlyFragment();
-      $scope.organismData = CantoGlobals.organismsAndGenes.sort(function (a, b) {
-        return (a.full_name > b.full_name) ? 1 : -1;
-      });
-      $scope.organisms = function (orgType) {
-        if (typeof orgType === 'undefined') {
-          return $scope.organismData;
-        }
+      $scope.organismRoles = getOrganismRoles();
+      $scope.organisms = getOrganismGroups($scope.organismRoles);
 
-        return $scope.organismData.filter(function (e) {
-          return (e.pathogen_or_host === orgType);
-        });
-      };
       $scope.getRoleHeading = function (role) {
         if (role === 'pathogen') {
           return 'Pathogens';
         }
         return 'Hosts';
       };
+
       $scope.getGeneUrl = function (gene) {
         var root = CantoGlobals.curs_root_uri;
         var readOnly = $scope.readOnlyFragment;
         var url = root + '/feature/gene/view/' + gene.gene_id + readOnly;
         return url;
       }
+
+      function getOrganismRoles() {
+        var roles = ['normal'];
+        if (CantoGlobals.pathogen_host_mode) {
+          roles = ['pathogen', 'host']
+        }
+        return roles;
+      }
+
+      function getOrganismGroups(roles) {
+        var allOrganisms = CantoGlobals.organismsAndGenes;
+        if (roles.length === 1 && roles[0] === 'normal') {
+          return { 'normal': sortGenes(allOrganisms) };
+        }
+        return groupOrganismsByRole(roles, allOrganisms);
+      }
+
+      function sortGenes(organisms) {
+        var sortedGenes;
+        for (var i = 0; i < organisms.length; i++) {
+          sortedGenes = organisms[i].genes.sort(
+            sortByProperty('display_name')
+          );
+          organisms[i].genes = sortedGenes;
+        }
+        return organisms;
+      }
+
+      function groupOrganismsByRole(roles, organisms) {
+        var organismGroups = {};
+        var filterByRole = function(role) {
+          return function (organism) {
+            return organism.pathogen_or_host === role;
+          }
+        }
+        var currentOrganisms, role;
+        for (var i = 0; i < roles.length; i++) {
+          role = roles[i]
+          currentOrganisms = organisms
+            .filter(filterByRole(role))
+            .sort(sortByProperty('full_name'));
+          currentOrganisms = sortGenes(currentOrganisms)
+          organismGroups[role] = currentOrganisms;
+        }
+        return organismGroups;
+      }
+
       function getReadOnlyFragment() {
         var isReadOnly = CantoGlobals.read_only_curs;
         var readOnlyFragment = ''
@@ -8078,6 +8117,7 @@ var summaryPageGeneList = function (CantoGlobals) {
         }
         return readOnlyFragment;
       }
+
     }
   };
 };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -8037,15 +8037,6 @@ var summaryPageGeneList = function (CantoGlobals) {
       $scope.organismData = CantoGlobals.organismsAndGenes.sort(function (a, b) {
         return (a.full_name > b.full_name) ? 1 : -1;
       });
-      $scope.maxCols = function () {
-        var maxCols = 0;
-        angular.forEach($scope.organismData, function (value) {
-          if (value.genes.length > maxCols) {
-            maxCols = value.genes.length;
-          }
-        }, maxCols);
-        return maxCols;
-      };
       $scope.organisms = function (orgType) {
         if (typeof orgType === 'undefined') {
           return $scope.organismData;
@@ -8054,10 +8045,6 @@ var summaryPageGeneList = function (CantoGlobals) {
         return $scope.organismData.filter(function (e) {
           return (e.pathogen_or_host === orgType);
         });
-      };
-      $scope.getPadding = function () {
-        var padLength = $scope.maxCols() - 1;
-        return new Array(padLength);
       };
       $scope.getRoleHeading = function (role) {
         if (role === 'pathogen') {
@@ -8084,39 +8071,6 @@ var summaryPageGeneList = function (CantoGlobals) {
 };
 
 canto.directive('summaryPageGeneList', ['CantoGlobals', summaryPageGeneList]);
-
-var summaryPageGeneRow = function () {
-  return {
-    scope: {
-      organism: '=',
-      maxCols: '=',
-    },
-    restrict: 'A',
-    replace: true,
-    templateUrl: app_static_path + 'ng_templates/summary_page_gene_row.html',
-    controller: function ($scope) {
-      $scope.readOnly = (read_only_curs) ? '/ro' : '';
-      $scope.curs_root_uri = curs_root_uri;
-      $scope.tidyName = function (name) {
-        var pos = name.indexOf("(");
-        if (pos > -1) {
-          name = name.substring(0, pos);
-        }
-        return name;
-      };
-      $scope.genes = $scope.organism.genes.sort(function (a, b) {
-        return (a.display_name > b.display_name) ? 1 : -1;
-      });
-      $scope.getPadding = function () {
-        var padLength = $scope.maxCols() - $scope.genes.length;
-        return new Array(padLength);
-      };
-    }
-  };
-};
-
-canto.directive('summaryPageGeneRow', [summaryPageGeneRow]);
-
 
 canto.service('EditOrganismsSvc', function (toaster, $http, CantoGlobals) {
 

--- a/root/static/ng_templates/summary_page_gene_list.html
+++ b/root/static/ng_templates/summary_page_gene_list.html
@@ -1,13 +1,15 @@
-<div class="curs-summary-gene-box">
+<div class="curs-summary-gene-container">
   <div class="curs-summary-gene-column" ng-repeat="role in organismRoles track by $index">
     <b ng-if="role !== 'normal'">{{ ::getRoleHeading(role) }}</b>
-    <div class="curs-summary-gene-organism-box" ng-repeat="organism in organisms[role]">
+    <div class="curs-summary-organism-container" ng-repeat="organism in organisms[role]">
       <span title="NCBI taxon ID: {{ ::organism.taxonid }}">{{ ::organism.full_name }}</span>
-      <div ng-if="organism.genes.length === 0">
+      <div class="curs-summary-gene-list" ng-if="organism.genes.length === 0">
         <span class="curs-summary-no-gene-text">(no genes)<span>
       </div>
-      <div ng-if="organism.genes.length > 0" ng-repeat="gene in organism.genes">
-        <a href="{{ ::getGeneUrl(gene) }}">{{ ::gene.display_name }}</a>
+      <div class="curs-summary-gene-list" ng-if="organism.genes.length > 0">
+        <a class="curs-summary-gene-name"
+           ng-repeat="gene in organism.genes"
+           href="{{ ::getGeneUrl(gene) }}">{{ ::gene.display_name }}</a>
       </div>
     </div>
   </div>

--- a/root/static/ng_templates/summary_page_gene_list.html
+++ b/root/static/ng_templates/summary_page_gene_list.html
@@ -1,7 +1,7 @@
 <div class="curs-summary-gene-box">
-  <div class="curs-summary-gene-column" ng-repeat="role in ['pathogen', 'host'] track by $index">
-    <b>{{ ::getRoleHeading(role) }}</b>
-    <div class="curs-summary-gene-organism-box" ng-repeat="organism in organisms(role)">
+  <div class="curs-summary-gene-column" ng-repeat="role in organismRoles track by $index">
+    <b ng-if="role !== 'normal'">{{ ::getRoleHeading(role) }}</b>
+    <div class="curs-summary-gene-organism-box" ng-repeat="organism in organisms[role]">
       <span title="NCBI taxon ID: {{ ::organism.taxonid }}">{{ ::organism.full_name }}</span>
       <div ng-if="organism.genes.length === 0">
         <span class="curs-summary-no-gene-text">(no genes)<span>

--- a/root/static/ng_templates/summary_page_gene_list.html
+++ b/root/static/ng_templates/summary_page_gene_list.html
@@ -7,9 +7,8 @@
         <span class="curs-summary-no-gene-text">(no genes)<span>
       </div>
       <div class="curs-summary-gene-list" ng-if="organism.genes.length > 0">
-        <a class="curs-summary-gene-name"
-           ng-repeat="gene in organism.genes"
-           href="{{ ::getGeneUrl(gene) }}">{{ ::gene.display_name }}</a>
+        <div class="curs-summary-gene-name-container" ng-repeat="gene in organism.genes">
+          <a href="{{ ::getGeneUrl(gene) }}">{{ ::gene.display_name }}</a>
       </div>
     </div>
   </div>

--- a/root/static/ng_templates/summary_page_gene_list.html
+++ b/root/static/ng_templates/summary_page_gene_list.html
@@ -1,19 +1,14 @@
-<div class="curs-box-body">
-  <table class="table">
-    <tr>
-      <th>Pathogens</td>
-      <th>Genes</td>
-      <td ng-repeat="pad in getPadding() track by $index"></td>
-    </tr>
-    <tr summary-page-gene-row ng-repeat="org in organisms('pathogen')" organism="org" max-cols="maxCols"></tr>
-  </table>
-  <br>
-   <table class="table">
-      <tr>
-        <th>Hosts</th>
-        <th>Genes</th>
-        <td ng-repeat="pad in getPadding() track by $index"></td>
-      </tr>
-      <tr summary-page-gene-row ng-repeat="org in organisms('host')" organism="org" max-cols="maxCols"></tr>
-    </table>
+<div class="curs-summary-gene-box">
+  <div class="curs-summary-gene-column" ng-repeat="role in ['pathogen', 'host'] track by $index">
+    <b>{{ ::getRoleHeading(role) }}</b>
+    <div class="curs-summary-gene-organism-box" ng-repeat="organism in organisms(role)">
+      <span title="NCBI taxon ID: {{ ::organism.taxonid }}">{{ ::organism.full_name }}</span>
+      <div ng-if="organism.genes.length === 0">
+        <span class="curs-summary-no-gene-text">(no genes)<span>
+      </div>
+      <div ng-if="organism.genes.length > 0" ng-repeat="gene in organism.genes">
+        <a href="{{ ::getGeneUrl(gene) }}">{{ ::gene.display_name }}</a>
+      </div>
+    </div>
+  </div>
 </div>

--- a/root/static/ng_templates/summary_page_gene_row.html
+++ b/root/static/ng_templates/summary_page_gene_row.html
@@ -1,5 +1,0 @@
-<tr>
-    <td title="NCBI taxon ID: {{ organism.taxonid }}">{{ tidyName(organism.full_name) }}</td>
-    <td ng-repeat="gene in genes"><a href="{{ curs_root_uri }}/feature/gene/view/{{ gene.gene_id }}{{ readOnly }}">{{ gene.display_name }}</a></td>
-    <td ng-repeat="pad in getPadding() track by $index"></td>
-</tr>


### PR DESCRIPTION
(Fixes #1981)

This pull request redesigns the gene list on the curation summary page to be a simpler, two column layout. Pathogens are placed in the left column and hosts are in the right column. The list will collapse to a single column view when there isn't enough screen width.

Here's how it looks:

![image](https://user-images.githubusercontent.com/37659591/62549529-8f2d6980-b860-11e9-8d2f-e50e691d993a.png)

@kimrutherford I haven't tried to run the genes across two columns yet &ndash; I'm planning to try that next.

One thing I was wondering about is whether we want to show organisms that have no genes. The old table did this, but I'm not sure if there's much point, since the list is about annotating genes, and you can't annotate a gene if you don't have any for the organism.