### PR TITLE
Make link text internally consistent

### DIFF
--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -622,7 +622,7 @@ sub gene_upload : Chained('top') Args(0) Form
 
   my @no_genes_elements = ();
   my @no_genes_reasons =
-    ( [ '', 'Please choose a reason...' ],
+    ( [ '', 'Choose a reason...' ],
       map { [ $_, $_ ] } @{$c->config()->{curs_config}->{no_genes_reasons}} );
 
   if ($st->{gene_count} > 0) {

--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -622,7 +622,7 @@ sub gene_upload : Chained('top') Args(0) Form
 
   my @no_genes_elements = ();
   my @no_genes_reasons =
-    ( [ '', 'Please choose a reason ...' ],
+    ( [ '', 'Please choose a reason...' ],
       map { [ $_, $_ ] } @{$c->config()->{curs_config}->{no_genes_reasons}} );
 
   if ($st->{gene_count} > 0) {

--- a/root/autohandler
+++ b/root/autohandler
@@ -28,7 +28,7 @@ $hide_breadcrumbs => 0
 % if (!$hide_breadcrumbs) {
 <& breadcrumbs.mhtml &>
 % }
-<span class="curs-contact-page-link"><& contact.mhtml, link_text => 'Questions? Contact curators ...' &></span>
+<span class="curs-contact-page-link"><& contact.mhtml, link_text => 'Questions? Contact curators...' &></span>
 
 <& title.mhtml, show_title => $show_title, title => $title, right_title => $right_title &>
 

--- a/root/chado/index.mhtml
+++ b/root/chado/index.mhtml
@@ -3,7 +3,7 @@
       <div class="span4">
         <div>
           <h3>
-            View ...
+            View
           </h3>
           <ul>
             <li>

--- a/root/curs/finished_publication.mhtml
+++ b/root/curs/finished_publication.mhtml
@@ -41,7 +41,7 @@ find more of your publications</p>
     Actions
   </div>
   <div class="curs-box-body">
-    <a href="<% $review_session_uri %>">Review session ...</a>
+    <a href="<% $review_session_uri %>">Review session</a>
   </div>
 </div>
 
@@ -57,7 +57,7 @@ find more of your publications</p>
   </div>
 % if ($c->user_exists() && $c->user()->role()->name() eq 'admin') {
   <div class="curs-box-body" ng-hide="messageForCurators == null" >
-    <a href="" ng-click="editMessageForCurators()">Edit ...</a>
+    <a href="" ng-click="editMessageForCurators()">Edit</a>
   </div>
 % }
 </div>

--- a/root/curs/front.mhtml
+++ b/root/curs/front.mhtml
@@ -96,10 +96,10 @@ $total_annotation_count
 
 <div class="curs-inline-message-to-curators">
 % if ($current_user_is_admin) {
-  <a href="#" ng-click="editMessageToCurators()">Edit message to curators ...</a>
+  <a href="#" ng-click="editMessageToCurators()">Edit message to curators</a>
 % } else {
 %   if (defined $message_to_curators) {
-  <a href="#" ng-click="viewMessageToCurators()">Display message to curators ...</a>
+  <a href="#" ng-click="viewMessageToCurators()">Display message to curators</a>
 %   }
 % }
 </div>

--- a/root/curs/front.mhtml
+++ b/root/curs/front.mhtml
@@ -55,7 +55,7 @@ $total_annotation_count
     <div>
     <select name="reason" ng-model="data.reason"
             ng-options="r as r for r in noAnnotationReasons">
-      <option value="">Please choose a reason ...</option>
+      <option value="">Choose a reason...</option>
     </select>
     </div>
     <div>
@@ -64,7 +64,7 @@ $total_annotation_count
     <input type="hidden" name="reasonText" value="{{data.reason}}"/>
 % # reason if "Other" is chosen from the <select>
     <input ng-show="data.reason === 'Other'" size="30"
-           placeholder="Please type a reason here ..." 
+           placeholder="Type a reason"
            type="text" name="otherReason" ng-model="data.otherReason"/>
     </div>
   </div>
@@ -108,7 +108,7 @@ $total_annotation_count
 
 % if ($annotation_count > 0) {
 <div id="curs-annotation-download">
-  <a href="<% $download_action %>">Download all annotation (Zip format) ...</a>
+  <a href="<% $download_action %>">Download all annotations (Zip format)...</a>
 </div>
 % }
 </div>

--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -42,9 +42,9 @@ Annotate genes
   <div class="feature-list-action" style="margin-bottom: 20px;">
     <a href="<% $edit_path %>">
 %   if ($multi_organism_mode) {
-Delete or edit genes and organisms list ...
+Delete or edit genes and organisms list
 %   } else {
-Edit gene list ...
+Edit gene list
 %   }
     </a>
   </div>
@@ -61,17 +61,17 @@ Annotate genotypes
   </div>
 %   if ($pathogen_host_mode) {
   <div class="feature-list-action">
-    <a href="<% $pathogen_genotype_manage_url %>"><% $read_only_curs ? 'View pathogen genotypes ...' : 'Pathogen genotype management ...' %></a>
+    <a href="<% $pathogen_genotype_manage_url %>"><% $read_only_curs ? 'View pathogen genotypes' : 'Pathogen genotype management' %></a>
   </div>
   <div class="feature-list-action">
-    <a href="<% $host_genotype_manage_url %>"><% $read_only_curs ? 'View host genotypes ...' : 'Host genotype management ...' %></a>
+    <a href="<% $host_genotype_manage_url %>"><% $read_only_curs ? 'View host genotypes' : 'Host genotype management' %></a>
   </div>
   <div class="feature-list-action">
-    <a href="<% $metagenotype_manage_url %>"><% $read_only_curs ? 'View metagenotypes ...' : 'Metagenotype management ...' %></a>
+    <a href="<% $metagenotype_manage_url %>"><% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %></a>
   </div>
 %   } else {
   <div class="feature-list-action">
-    <a href="<% $genotype_manage_url %>"><% $read_only_curs ? 'View genotypes ...' : 'Genotype management ...' %></a>
+    <a href="<% $genotype_manage_url %>"><% $read_only_curs ? 'View genotypes' : 'Genotype management' %></a>
   </div>
 %   }
 % }

--- a/root/curs/front_page_quick_links.mhtml
+++ b/root/curs/front_page_quick_links.mhtml
@@ -10,7 +10,7 @@
 % for my $annotation_type (@annotation_type_list) {
     <div>
       <annotation-quick-add annotation-type-name="<% $annotation_type->{name} %>"
-                            link-label="<% $annotation_type->{display_name} %> ..."
+                            link-label="<% $annotation_type->{display_name} %>"
                             feature-type="<% $annotation_type->{feature_type} %>">
       </annotation-quick-add>
     </div>

--- a/root/curs/gene_list_edit.mhtml
+++ b/root/curs/gene_list_edit.mhtml
@@ -195,10 +195,10 @@ my $add_more_genes_message;
 
 if ($c->config()->{pathogen_host_mode}) {
   $add_more_genes_message =
-   'Add more genes and host organisms from ' . $pub->uniquename() . ' ...';
+   'Add more genes and host organisms from ' . $pub->uniquename();
 } else {
   $add_more_genes_message =
-    'Add more genes from ' . $pub->uniquename() . ' ...';
+    'Add more genes from ' . $pub->uniquename();
 }
 
 my @hosts_with_no_genes = ();

--- a/root/curs/genotype_page.mhtml
+++ b/root/curs/genotype_page.mhtml
@@ -25,7 +25,7 @@ Actions
       <a title="<% $title %>" href="<% $action_path %>">
 %   }
       <span class="annotation-type">
-Add a new <% $type_display_name %> for this genotype ...
+Add a new <% $type_display_name %> for this genotype
       </span>
 %   if (!$annotation_type->{disabled}) {
       </a>
@@ -109,10 +109,10 @@ Description
     <div>
       <a confirm="This genotype has existing annotations.  Really edit?"
          confirm-if="annotationCount > 0"
-         ng-click="editGenotype(<% $genotype->genotype_id() %>)">Edit ...</a>
+         ng-click="editGenotype(<% $genotype->genotype_id() %>)">Edit</a>
     </div>
     <div>
-      <a href="<% $duplicate_url %>">Duplicate ...</a>
+      <a href="<% $duplicate_url %>">Duplicate</a>
     </div>
 % }
   </div>

--- a/root/curs/metagenotype_page.mhtml
+++ b/root/curs/metagenotype_page.mhtml
@@ -25,7 +25,7 @@ Actions
       <a title="<% $title %>" href="<% $action_path %>">
 %   }
       <span class="annotation-type">
-Add a new <% $type_display_name %> for this genotype ...
+Add a new <% $type_display_name %> for this genotype
       </span>
 %   if (!$annotation_type->{disabled}) {
       </a>

--- a/root/curs/modules/interaction.mhtml
+++ b/root/curs/modules/interaction.mhtml
@@ -8,7 +8,7 @@ $feature
      annotation-type-name="<% $annotation_type_name %>" id="curs-interaction">
   <div ng-show="data.evidenceConfirmed" class="curs-box">
     <div class="curs-box-title">
-      Select the gene or genes that interact with <% $feature_display_name %> ...
+      Select the gene or genes that interact with <% $feature_display_name %>
 <& /curs/inline_help.mhtml, key => "${annotation_type_name}_select_gene" &>
     </div>
     <div class="curs-box-body">

--- a/root/curs/modules/ontology_multi_gene_select.mhtml
+++ b/root/curs/modules/ontology_multi_gene_select.mhtml
@@ -13,7 +13,7 @@ Genes to use with <% $start_gene_display_name %> in new genotype
   </div>
 
   <div class="upload-genes-link">
-    <a href="<% $upload_path %>">Add more genes from <% $pub->uniquename() %> to this session ...</a>
+    <a href="<% $upload_path %>">Add more genes from <% $pub->uniquename() %> to this session</a>
   </div>
 </div>
 

--- a/root/curs/modules/ontology_with_gene.mhtml
+++ b/root/curs/modules/ontology_with_gene.mhtml
@@ -16,7 +16,7 @@ with <% $term_ontid %> using <% $evidence_code %>
   </div>
 
   <div class="upload-genes-link">
-    <a href="<% $upload_path %>">Add more genes from <% $pub->uniquename() %> ...</a>
+    <a href="<% $upload_path %>">Add more genes from <% $pub->uniquename() %></a>
   </div>
 </div>
 

--- a/root/curs/page_template.mhtml
+++ b/root/curs/page_template.mhtml
@@ -24,7 +24,7 @@ $is_admin_user
     <div class="container-fluid" id="content">
       <div id="title-nav">
 <& breadcrumbs.mhtml &>
-<span class="curs-contact-page-link"><& contact.mhtml, link_text => 'Questions? Contact curators ...' &></span>
+<span class="curs-contact-page-link"><& contact.mhtml, link_text => 'Questions? Contact curators...' &></span>
 
 <& title.mhtml, show_title => $show_title, title => $title, right_title => $right_title &>
 

--- a/root/curs/session_exported.mhtml
+++ b/root/curs/session_exported.mhtml
@@ -17,7 +17,7 @@ were made during this session but no further changes are possible.
     Actions
   </div>
   <div class="curs-box-body">
-    <a href="<% $review_session_uri %>">Review session ...</a>
+    <a href="<% $review_session_uri %>">Review session</a>
   </div>
 </div>
 

--- a/root/docs/autohandler
+++ b/root/docs/autohandler
@@ -26,7 +26,7 @@ $hide_header => 0
 <& breadcrumbs.mhtml &>
 
 % if (!$hide_header) {
-    <span class="curs-contact-page-link"><& contact.mhtml, link_text => 'Questions? Contact curators ...' &></span>
+    <span class="curs-contact-page-link"><& contact.mhtml, link_text => 'Questions? Contact curators...' &></span>
 % }
 
 <& /err_mess_notice.mhtml, error => $error, message => $message, notice => $notice &>

--- a/root/docs/canto_front.mhtml
+++ b/root/docs/canto_front.mhtml
@@ -14,7 +14,7 @@ their publications for inclusion in public biological databases. Originally
 created for the fission yeast community, Canto is a generic
 tool that can be readily configured for use with other organisms and other
 databases.
-<span class="curs-contact-page-link"><& contact.mhtml, link_text => 'Questions? Contact the Canto team ...' &></span>
+<span class="curs-contact-page-link"><& contact.mhtml, link_text => 'Questions? Contact the Canto team...' &></span>
           </p>
         </div>
         <div class="col-md-4">
@@ -31,18 +31,18 @@ databases.
         Canto is currently deployed for:
         <ul>
           <li>
-  <a href="http://curation.pombase.org/pombe" class="btn btn-primary visit">Visit ...</a>
+  <a href="http://curation.pombase.org/pombe" class="btn btn-primary visit">Visit...</a>
   <span class="organism-name">Schizosaccharomyces pombe</span> (fission yeast)
   at PomBase.
   Curate GO, phenotypes, interactions, protein modifications for inclusion in
   <a href="http://www.pombase.org">PomBase</a>
           </li>
           <li>
-  <a href="http://curation.pombase.org/kpas" class="btn btn-primary visit">Visit ...</a>
+  <a href="http://curation.pombase.org/kpas" class="btn btn-primary visit">Visit...</a>
   <span class="organism-name">Komagataella pastoris</span> (formerly known as Pichia pastoris)
           </li>
           <li>
-  <a href="http://curation.pombase.org/uniprot" class="btn btn-primary visit">Visit ...</a>
+  <a href="http://curation.pombase.org/uniprot" class="btn btn-primary visit">Visit...</a>
   <span>Generic Gene Ontology Implementation: Curate GO annotations for proteins,
   using UniProtKB identifiers.</span>
           </li>
@@ -51,13 +51,13 @@ databases.
 
       <div class="col-md-6">
         <h3>Documentation</h3>
-        <a href="<% $c->uri_for('/docs/index/') %>" class="btn btn-primary visit">View ...</a>
+        <a href="<% $c->uri_for('/docs/index/') %>" class="btn btn-primary visit">View...</a>
         <p>
 Instructions for using Canto are available from
 the <a href="<% $c->uri_for('/docs/index/') %>">documentation
 pages</a>, or via the "Help" link at the top right of every Canto instance.
         <h3>Demo</h3>
-          <a href="<% $demo_url %>" class="btn btn-primary visit">Demo ...</a>
+          <a href="<% $demo_url %>" class="btn btn-primary visit">Demo...</a>
         <p>
 Try the <a href="<% $demo_url %>">demo</a>
 version of Canto: curate GO, phenotypes, interactions and protein modifications.
@@ -80,7 +80,7 @@ curation. <em>Bioinformatics</em> (2014) <a href="http://doi.org/10.1093/bioinfo
 
       <div class="col-md-6">
         <h3>Get The Code</h3>
-        <a href="https://github.com/pombase/canto" class="btn btn-primary visit">Visit ...</a>
+        <a href="https://github.com/pombase/canto" class="btn btn-primary visit">Visit...</a>
         <p>
 Canto is a free, open source application. The source code is
 available from Github.

--- a/root/docs/md/canto_admin/configuration_file.md
+++ b/root/docs/md/canto_admin/configuration_file.md
@@ -275,7 +275,7 @@ Short help to be soon initially to users when they begin an annotation of this
 type.  (Required)
 
 ### more_help_text
-A longer help text shown when the user clicks "more ..." under the help_text.
+A longer help text shown when the user clicks "more..." under the help_text.
 (Optional)
 
 ### detailed_help_path

--- a/root/reports.mhtml
+++ b/root/reports.mhtml
@@ -4,7 +4,7 @@ $model
 
 <div>
   <h3>
-    Reports ...
+    Reports
   </h3>
   <& /report_gen.mhtml, report_conf => $all_reports_conf, model => $model &>
 </div>

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3129,7 +3129,7 @@ var conditionPicker =
               minLength: 2,
               fieldName: 'curs-allele-condition-names',
               allowSpaces: true,
-              placeholderText: 'Type a condition ...',
+              placeholderText: 'Type a condition',
               tagSource: fetch_conditions,
               autocomplete: {
                 focus: ferret_choose.show_autocomplete_def,
@@ -6187,7 +6187,7 @@ var annotationQuickAdd =
         $scope.read_only_curs = CantoGlobals.read_only_curs;
 
         if (!$scope.linkLabel) {
-          $scope.linkLabel = 'Quick add ...';
+          $scope.linkLabel = 'Quick add';
         }
 
         $scope.add = function () {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -381,7 +381,7 @@ canto.filter('featureChooserFilter', function () {
     if (feature.background) {
       ret += "  (bkg: " + feature.background.substr(0, 15);
       if (feature.background.length > 15) {
-        ret += " ...";
+        ret += "...";
       }
       ret += ")";
     }
@@ -2870,7 +2870,7 @@ var ontologyWorkflowCtrl =
     $scope.storeAnnotation = function () {
       var storePop = toaster.pop({
         type: 'info',
-        title: 'Storing annotation ...',
+        title: 'Storing annotation...',
         timeout: 0, // last until page reload
         showCloseButton: false
       });
@@ -2965,7 +2965,7 @@ var interactionWorkflowCtrl =
 
     $scope.addInteractionAndEvidence = function () {
       $scope.postInProgress = true;
-      toaster.pop('info', 'Creating interaction ...');
+      toaster.pop('info', 'Creating interaction...');
       simpleHttpPost(toaster, $http, '../add_interaction/' + $scope.annotationTypeName, {
         evidence_code: $scope.data.evidence_code,
         prey_gene_ids: $scope.selectedFeatureIds,
@@ -6030,7 +6030,7 @@ var annotationEditDialogCtrl =
       loadingStart();
       var storePop = toaster.pop({
         type: 'info',
-        title: 'Storing annotation ...',
+        title: 'Storing annotation...',
         timeout: 0, // last until the finally()
         showCloseButton: false
       });
@@ -6770,7 +6770,7 @@ var termNameComplete =
             $scope.placeholder =
               $.map(results, function (data) {
                 return data.name;
-              }).join(" or ") + " ...";
+              }).join(" or ") + "...";
           });
         }
 

--- a/root/static/js/canto.js
+++ b/root/static/js/canto.js
@@ -169,7 +169,7 @@ $(document).ready(function() {
 
   $('#curs-pub-assign-popup-dialog').click(function () {
     $('#curs-pub-assign-dialog').dialog({ modal: true,
-                                          title: 'Set the corresponding author ...',
+                                          title: 'Set the corresponding author...',
                                           width: '40em' });
   });
 
@@ -203,7 +203,7 @@ $(document).ready(function() {
       $picker_div.find('.curs-person-picker-person-id').val(data.person_id);
     });
     $popup.dialog({
-      title: 'Add a person ...',
+      title: 'Add a person...',
       modal: true });
 
     $popup.find("form").ajaxForm({

--- a/root/static/ng_templates/allele_edit.html
+++ b/root/static/ng_templates/allele_edit.html
@@ -89,7 +89,7 @@
             <select class="form-control"
                     ng-model="alleleData.type" name="curs-allele-type"
                     ng-options="name for name in env.allele_type_names">
-              <option selected="selected" value="">Choose an allele type ...</option>
+              <option selected="selected" value="">Choose an allele type...</option>
             </select>
             <span ng-show="!isValidType()"
                   class="help-block">Please choose a type</span>

--- a/root/static/ng_templates/annotation_edit.html
+++ b/root/static/ng_templates/annotation_edit.html
@@ -81,11 +81,11 @@
             <button class="btn btn-default btn-xs"
                     ng-click="editExtension(annotation.term_ontid, annotation.feature_display_name)">
               <span ng-show="annotation.extension.length == 0">Add</span>
-              <span ng-show="annotation.extension.length > 0">Edit</span> ...
+              <span ng-show="annotation.extension.length > 0">Edit</span>
             </button>
           </span>
           <div ng-if="currentUserIsAdmin">
-            <a href="" ng-click="manualEdit()">Edit as text (admin only) ...</a>
+            <a href="" ng-click="manualEdit()">Edit as text (admin only)</a>
           </div>
         </td>
       </tr>
@@ -115,7 +115,7 @@
         <td class="title" rowspan="2">Term suggestion</td>
         <td colspan="2">
           <input class="form-control curs-edit-wide-field"
-                 type="text" placeholder="Name ..." size="60"
+                 type="text" placeholder="Name" size="60"
                  ng-model="annotation.term_suggestion_name"/>
         </td>
       </tr>
@@ -123,7 +123,7 @@
       <tr>
         <td colspan="2">
           <textarea class="form-control curs-edit-wide-field"
-                    placeholder="Definition ..." cols="60"
+                    placeholder="Definition" cols="60"
                     ng-model="annotation.term_suggestion_definition"/>
         </td>
       </tr>

--- a/root/static/ng_templates/annotation_evidence.html
+++ b/root/static/ng_templates/annotation_evidence.html
@@ -2,7 +2,7 @@
   <div ng-class="{ 'has-error': !isValidEvidenceCode() }">
     <select class="form-control"
             ng-model="evidenceCode">
-      <option value="">{{annotationType.category == 'interaction' ? 'Choose genetic interaction type ...' : 'Choose evidence code ...'}}</option>
+      <option value="">{{annotationType.category == 'interaction' ? 'Choose genetic interaction type...' : 'Choose evidence code...'}}</option>
       <option ng-repeat="code in evidenceCodes"
               ng-selected="{{evidenceCode == code}}" value="{{code}}" title="{{getDefinition(code)}}">{{getDisplayCode(code)}}</option>
     </select>
@@ -18,4 +18,3 @@
           class="help-block">Please select a 'with' gene</div>
   </div>
 </div>
-

--- a/root/static/ng_templates/annotation_table_list.html
+++ b/root/static/ng_templates/annotation_table_list.html
@@ -1,7 +1,7 @@
 <div class="clearall">
   <div ng-hide="annotationTypes.length">
     <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img>
-Annotation loading ...
+Annotation loading...
   </div>
   <div class="error_message" ng-show="data.serverError">
     Error: {{data.serverError}}

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -103,7 +103,7 @@
 {{annotation.term_suggestion_name}}
       </div>
       <div>
-        <initially-hidden-text text="{{annotation.term_suggestion_definition}}" link-label="View definition..."></initially-hidden-text>
+        <initially-hidden-text text="{{annotation.term_suggestion_definition}}" link-label="View definition"></initially-hidden-text>
       </div>
     </div>
   </td>

--- a/root/static/ng_templates/extension_builder.html
+++ b/root/static/ng_templates/extension_builder.html
@@ -30,11 +30,11 @@
   <div ng-if="currentUserIsAdmin" style="padding-top: 15px; font-size: 95%;">
      Admin only:
     <div style="padding: 5px; font-size: 95%" ng-show="extension[extension.length - 1].length != 0">
-      <a href="" ng-click="addOrGroup()">Add independent extension ...</a>
+      <a href="" ng-click="addOrGroup()">Add independent extension</a>
     </div>
 
     <div style="padding: 5px; font-size: 95%">
-      <a href="" ng-click="manualEdit()">Edit as text ...</a>
+      <a href="" ng-click="manualEdit()">Edit as text</a>
     </div>
   </div>
 </div>

--- a/root/static/ng_templates/extension_or_group_builder.html
+++ b/root/static/ng_templates/extension_or_group_builder.html
@@ -8,10 +8,10 @@
         {{extConf.displayText}}
       </span>
       <span ng-switch-when="MORE_POSSIBLE" uib-tooltip="{{debugConfText(extConf)}}">
-        <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}} ...</a>
+        <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
       </span>
       <span ng-switch-when="MORE_REQUIRED" uib-tooltip="{{debugConfText(extConf)}}">
-        <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}} ...</a>
+        <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
         <span style="color: red;">required</span>
       </span>
       </span>
@@ -19,4 +19,3 @@
     </ul>
   </div>
 </div>
-

--- a/root/static/ng_templates/feature_chooser.html
+++ b/root/static/ng_templates/feature_chooser.html
@@ -12,7 +12,7 @@ Loading...
     </select>
 
     <span ng-if="featureType === 'gene'" >
-      <a ng-click="openSingleGeneAddDialog()">Add another ...</a>
+      <a ng-click="openSingleGeneAddDialog()">Add another gene</a>
     </span>
 
 </span>

--- a/root/static/ng_templates/feature_chooser.html
+++ b/root/static/ng_templates/feature_chooser.html
@@ -1,10 +1,10 @@
 <span class="curs-feature-chooser">
   <span ng-hide="features">
-Loading ...
+Loading...
   </span>
 
     <select class="form-control" ng-model="chosenFeatureId">
-      <option value="">Choose a {{featureType}} ...</option>
+      <option value="">Choose a {{featureType}}...</option>
       <option ng-repeat="feature in features track by feature.feature_id"
               ng-value="{{feature.feature_id}}"
               ng-bind-html="feature | featureChooserFilter | encodeAlleleSymbols | toTrusted">

--- a/root/static/ng_templates/gene_selector.html
+++ b/root/static/ng_templates/gene_selector.html
@@ -19,7 +19,7 @@
      </tbody>
    </table>
 
-   <a href="" ng-click="addAnotherGene()">Add another gene from the paper ...</a>
+   <a href="" ng-click="addAnotherGene()">Add another gene from the paper</a>
    </div>
    <div ng-hide="data.genes">
      Loading ...

--- a/root/static/ng_templates/gene_selector.html
+++ b/root/static/ng_templates/gene_selector.html
@@ -22,6 +22,6 @@
    <a href="" ng-click="addAnotherGene()">Add another gene from the paper</a>
    </div>
    <div ng-hide="data.genes">
-     Loading ...
+     Loading...
   </div>
 </div>

--- a/root/static/ng_templates/genotype_background_edit.html
+++ b/root/static/ng_templates/genotype_background_edit.html
@@ -6,7 +6,7 @@
   </div>
   <div class="modal-body">
     <input class="form-control"
-           type="text" placeholder="Background ..." size="60"
+           type="text" placeholder="Background" size="60"
            ng-model="data.background"/>
   </div>
   <div class="modal-footer">

--- a/root/static/ng_templates/genotype_comment_edit.html
+++ b/root/static/ng_templates/genotype_comment_edit.html
@@ -6,7 +6,7 @@
   </div>
   <div class="modal-body">
     <input class="form-control"
-           type="text" placeholder="New note ..." size="60"
+           type="text" placeholder="New note" size="60"
            ng-model="data.comment"/>
   </div>
   <div class="modal-footer">

--- a/root/static/ng_templates/genotype_details.html
+++ b/root/static/ng_templates/genotype_details.html
@@ -1,6 +1,6 @@
 <div>
   <div class="curs-spinner" ng-if="!genotype">
-    <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img> Loading ...
+    <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img> Loading...
   </div>
 
   <div ng-if="genotype">

--- a/root/static/ng_templates/genotype_edit.html
+++ b/root/static/ng_templates/genotype_edit.html
@@ -3,21 +3,21 @@
       <div class="col-sm-7 col-md-7">
         <div>
           Name: <input type="text" title="Click to edit (optional) genotype name" href="#"
-                       placeholder="short genotype name (optional) ..."
+                       placeholder="short genotype name (optional)"
                        size="50"
                        ng-model="data.genotypeName" />
           <help-icon key="genotype_edit_name_input"></help-icon>
         </div>
         <div>
           Background: <input type="text" title="Click to edit (optional) genotype background" href="#"
-                             placeholder="genotype background (optional) ..."
+                             placeholder="genotype background (optional)"
                              size="50"
                              ng-model="data.genotypeBackground" />
           <help-icon key="genotype_edit_background_input"></help-icon>
         </div>
         <div>
           Comment: <input type="text" title="(optional) genotype comment" href="#"
-                             placeholder="comment (optional) ..."
+                             placeholder="comment (optional)"
                              size="50"
                              ng-model="data.genotypeComment" />
         </div>
@@ -127,6 +127,6 @@
       </div>
     </div>
     <div class="upload-genes-link">
-      <a ng-click="openSingleGeneAddDialog()">Add another gene from the paper ...</a>
+      <a ng-click="openSingleGeneAddDialog()">Add another gene from the paper</a>
     </div>
 </div>

--- a/root/static/ng_templates/genotype_edit.html
+++ b/root/static/ng_templates/genotype_edit.html
@@ -53,7 +53,7 @@
       <div class="col-sm-6 col-md-6">
         <div ng-hide="genes.length">
           <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img>
-          Loading genes ...
+          Loading genes...
         </div>
         <div class="curs-genotype-edit-gene-list" ng-show="genes.length">
           <table class="list">

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -24,7 +24,7 @@
           </td>
           <td>
             <button class="btn btn-primary btn-xs"
-                    ng-click="singleAlleleQuick(gene.primary_name || gene.primary_identifier, gene.primary_identifier, gene.gene_id)">Other genotype ...</button>
+                    ng-click="singleAlleleQuick(gene.primary_name || gene.primary_identifier, gene.primary_identifier, gene.gene_id)">Other genotype</button>
           </td>
         </tr>
       </tbody>

--- a/root/static/ng_templates/genotype_list_row.html
+++ b/root/static/ng_templates/genotype_list_row.html
@@ -33,12 +33,12 @@
 
     <span class="curs-genotype-comment-indicator"
           ng-if="userIsAdmin && genotype.comment && (genotype.alleles.length == 1 || !notesOnSingleAlleleGenotypesOnly)">
-      <a title="{{genotype.comment}} (click to edit)" ng-click="editComment()">new note ...</a>
+      <a title="{{genotype.comment}} (click to edit)" ng-click="editComment()">new note</a>
     </span>
 
     <span class="curs-genotype-comment-indicator"
           ng-if="userIsAdmin && firstLocus.comment">
-      <a title="{{firstLocus.comment}}" ng-click="viewAlleleComment(genotype.alleles[0])">note ...</a>
+      <a title="{{firstLocus.comment}}" ng-click="viewAlleleComment(genotype.alleles[0])">note</a>
     </span>
   </td>
   <td rowspan="{{genotype.alleles.length}}" ng-hide="columnsToHide.strain">{{ strain }}</td>
@@ -55,7 +55,7 @@
   <td rowspan="{{genotype.alleles.length}}"
       ng-if="navigateOnClick == 'true'" class="table-row-actions">
     <a href="{{detailsUrl}}">
-      <span style="white-space: nowrap">Details ...</span>
+      <span style="white-space: nowrap">Details</span>
     </a>
   </td>
   <td style="width: 0; border: 0px; padding: 0; margin: 0; background-color: white;">
@@ -95,7 +95,7 @@
 
       <span class="curs-genotype-comment-indicator"
             ng-if="userIsAdmin && currentAllele.comment">
-        <a title="{{currentAllele.comment}}" ng-click="viewAlleleComment(currentAllele)">note ...</a>
+        <a title="{{currentAllele.comment}}" ng-click="viewAlleleComment(currentAllele)">note</a>
       </span>
     </td>
   </tr>

--- a/root/static/ng_templates/genotype_list_row_links.html
+++ b/root/static/ng_templates/genotype_list_row_links.html
@@ -2,40 +2,40 @@
   <div ng-repeat="annotationType in matchingAnnotationTypes">
     <a ng-class="{disabled: genotypeId == null }" ng-if="!read_only_curs"
        href="{{curs_root_uri + '/feature/genotype/annotate/' + genotypeId + '/start/' + annotationType.name + '/'}}">
-      Start a {{ annotationType.display_name }} annotation ...
+      Start a {{ annotationType.display_name }} annotation
     </a>
   </div>
   <div>
     <a ng-class="{disabled: genotypeId == null }" href="{{viewAnnotationUri}}">
-      View annotations ...
+      View annotations
     </a>
   </div>
   <div>
     <a confirm="This genotype has existing annotations.  Really edit?"
        confirm-if="annotationCount > 0"
        ng-class="{disabled: genotypeId == null }" ng-if="!read_only_curs"
-       ng-click="editGenotype(genotypeId)">Edit details ...</a>
+       ng-click="editGenotype(genotypeId)">Edit details</a>
   </div>
   <div ng-if="!read_only_curs">
     <a ng-show="alleleCount == 1"
       ng-class="{disabled: genotypeId == null }"
-      ng-click="editAllele(genotypeId)">Copy and edit ...</a>
+      ng-click="editAllele(genotypeId)">Copy and edit</a>
     <a ng-show="alleleCount != 1"
       ng-class="{disabled: genotypeId == null }"
-      href="{{curs_root_uri + '/' + genotypeManagePath + '#/duplicate/' + genotypeId}}">Copy and edit ...</a>
+      href="{{curs_root_uri + '/' + genotypeManagePath + '#/duplicate/' + genotypeId}}">Copy and edit</a>
   </div>
   <div ng-if="!read_only_curs">
     <a ng-class="{disabled: genotypeId == null }"
-       ng-click="editBackground(genotypeId)">Add/edit background ...</a>
+       ng-click="editBackground(genotypeId)">Add/edit background</a>
   </div>
   <div ng-if="showNoteEdit()">
     <a ng-class="{disabled: genotypeId == null }"
-       ng-click="editComment(genotypeId)">Add/edit new note...</a>
+       ng-click="editComment(genotypeId)">Add/edit new note</a>
   </div>
   <div title="{{deleteTitle}}">
     <a ng-class="{disabled: genotypeId == null || !canDelete}"
        ng-if="!read_only_curs"
        confirm="Are you sure you want to remove this genotype from your session?"
-       ng-click="deleteGenotype(genotypeId)">Delete ...</a>
+       ng-click="deleteGenotype(genotypeId)">Delete</a>
   </div>
 </div>

--- a/root/static/ng_templates/genotype_list_view.html
+++ b/root/static/ng_templates/genotype_list_view.html
@@ -50,7 +50,7 @@ Annotations
     <button class="btn btn-primary btn-xs"
             ng-disabled="!validForDiploid()"
             title="{{checkedGenotypeCount() < 1 ? 'Select a single allele genotype' : 'Create a diploid genotype the includes the selected allele'}}"
-            ng-click="createDiploid()">Create diploid locus ...</button>
+            ng-click="createDiploid()">Create diploid locus</button>
   </div>
   </div>
 
@@ -107,10 +107,10 @@ Annotations
       <button class="btn btn-primary btn-xs"
                       ng-disabled="!validForDiploid()"
                       title="{{checkedGenotypeCount() < 1 ? 'Select a single allele genotype' : 'Create a diploid genotype the includes the selected allele'}}"
-                      ng-click="createDiploid()">Create diploid locus ...</button>
+                      ng-click="createDiploid()">Create diploid locus</button>
     </span>
     <span ng-if="checkedGenotypeCount() != 0" style="padding-left: 3em">
-      <a href="" ng-click="selectNone()">Unselect all ...</a>
+      <a href="" ng-click="selectNone()">Unselect all</a>
     </span>
   </div>
 </div>

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -52,9 +52,9 @@
                           No genes have been added for this organism.
                         </p>
                         <a ng-if="data.splitGenotypesByOrganism"
-                           href="confirm_genes">Delete or edit genes and organisms list ...</a>
+                           href="confirm_genes">Delete or edit genes and organisms list</a>
                         <a ng-if="!data.splitGenotypesByOrganism"
-                           ng-click="openSingleGeneAddDialog()">Add another gene ...</a>
+                           ng-click="openSingleGeneAddDialog()">Add another gene</a>
                         </div>
                     </div>
 

--- a/root/static/ng_templates/genotype_search.html
+++ b/root/static/ng_templates/genotype_search.html
@@ -34,7 +34,7 @@ No genotypes match the selected gene.
             <span ng-show="data.searchGenes.length > 1">
 No genotypes match all the selected genes.
             </span>
-            <a ng-click="addGenotype()">Add a genotype ...</a>
+            <a ng-click="addGenotype()">Add a genotype</a>
           </div>
         </div>
         </div>

--- a/root/static/ng_templates/message_for_curators_edit_dialog.html
+++ b/root/static/ng_templates/message_for_curators_edit_dialog.html
@@ -6,7 +6,7 @@
   </div>
   <div class="modal-body">
     <textarea class="form-control"
-              placeholder="Message for curators ..."
+              placeholder="Message for curators"
               rows="5" cols="90"
               ng-model="data.message">
     </textarea>

--- a/root/static/ng_templates/meta_genotype_genotypes_panel.html
+++ b/root/static/ng_templates/meta_genotype_genotypes_panel.html
@@ -1,7 +1,7 @@
 <div>
     <div ng-if="!data.allOrganisms">
         <img ng-src="{{app_static_path + '/images/spinner.gif'}}" />
-        loading genes ...
+        Loading genes...
     </div>
     <div ng-if="data.allOrganisms">
         <div ng-if="data.pathogenOrganisms.length != 0">

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -2,7 +2,7 @@
 <div ng-if="selectedOrganism">
     <div>
         <p class="metagenotype-genotype-shortcut">
-          <a href="{{genotypeShortcutUrl}}">Create a new {{organismType}} genotype...</a>
+          <a href="{{genotypeShortcutUrl}}">Create a new {{organismType}} genotype</a>
         </p>
         <div>
             <div class="curs-box-title">Single locus genotypes</div>

--- a/root/static/ng_templates/metagenotype_list_row.html
+++ b/root/static/ng_templates/metagenotype_list_row.html
@@ -19,7 +19,7 @@
                 ng-class="{disabled: metagenotype.metagenotype_id == null }"
                 ng-if="!read_only_curs"
                 href="{{curs_root_uri + '/feature/metagenotype/annotate/' + metagenotype.metagenotype_id + '/start/' + annotationType.name + '/'}}">
-                  Annotate {{ annotationType.display_name }}...
+                  Annotate {{ annotationType.display_name }}
               </a>
               </div>
             <div>

--- a/root/static/ng_templates/multi_feature_chooser.html
+++ b/root/static/ng_templates/multi_feature_chooser.html
@@ -10,6 +10,6 @@
   </div>
 
   <div class="clearall">
-    <a ng-click="openSingleGeneAddDialog()">Add another gene ...</a>
+    <a ng-click="openSingleGeneAddDialog()">Add another gene</a>
   </div>
 </div>

--- a/root/static/ng_templates/oganismPicker.html
+++ b/root/static/ng_templates/oganismPicker.html
@@ -1,6 +1,6 @@
 <div class="container">
     <span ng-show="organismsCount == null">
-        <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img> Loading ...
+        <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img> Loading...
     </span>
     <span ng-hide="organismsCount == null" class="">
         <span ng-show="organismsCount == 0" style="font-weight: bold" class="ng-hide">

--- a/root/static/ng_templates/ontology_term_confirm.html
+++ b/root/static/ng_templates/ontology_term_confirm.html
@@ -1,7 +1,7 @@
 <div>
   <div ng-hide="termDetails">
     <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img>
-Loading details ...
+Loading details...
   </div>
   <div ng-show="termDetails" id="ferret-term-details" class="ng-cloak">
     <div class="curs-box">
@@ -43,7 +43,7 @@ Loading details ...
         The currently selected term has no children. If you need a more specific
         term to describe the experiment you are annotating, please follow the
         link below to suggest it:
-        <a id="ferret-help-step-2-suggest-help" class="canto-more-button" href='#'>more ...</a>
+        <a id="ferret-help-step-2-suggest-help" class="canto-more-button" href='#'>more...</a>
 
         <div id="ferret-help-step-2-suggest-help-target" class="ferret-more-help">
           <div>

--- a/root/static/ng_templates/ontology_term_confirm.html
+++ b/root/static/ng_templates/ontology_term_confirm.html
@@ -30,7 +30,7 @@ Loading details ...
         <ul>
           <li>
             <a ng-click="openTermSuggestDialog(featureDisplayName)">
-              Suggest a new child term for <span class="ferret-term-id-display">{{termDetails.id}}</span> ...
+              Suggest a new child term for <span class="ferret-term-id-display">{{termDetails.id}}</span>
             </a>
           </li>
         </ul>
@@ -59,7 +59,7 @@ Loading details ...
         <ul>
           <li>
             <a ng-click="openTermSuggestDialog(featureDisplayName)">
-              Suggest a new child term for <span class="ferret-term-id-display">{{termDetails.id}}</span> ...
+              Suggest a new child term for <span class="ferret-term-id-display">{{termDetails.id}}</span>
             </a>
           </li>
         </ul>

--- a/root/static/ng_templates/ontology_term_select.html
+++ b/root/static/ng_templates/ontology_term_select.html
@@ -9,7 +9,7 @@ Search for {{annotationType.display_name}} term
 {{annotationType.help_text}}
         </div>
         <div ng-if="annotationType.more_help_text">
-          <a id="ferret-term-entry-type-help" class="canto-more-button" href='#'>more ...</a>
+          <a id="ferret-term-entry-type-help" class="canto-more-button" href='#'>more...</a>
           <div id="ferret-term-entry-type-help-target" class="ferret-more-help">
 {{annotationType.more_help_text}}
           </div>
@@ -19,7 +19,7 @@ Search for {{annotationType.display_name}} term
 Start typing a {{annotationType.short_display_name}} in the search
 box. If you do not find the term you are looking for with your initial search,
 begin with a broad term ({{annotationType.broad_term_suggestions}})
-<a id="ferret-term-entry-extra-help" class="canto-more-button" href='#'>more ...</a>
+<a id="ferret-term-entry-extra-help" class="canto-more-button" href='#'>more...</a>
           </div>
           <div id="ferret-term-entry-extra-help-target" class="ferret-more-help">
             <div>

--- a/root/static/ng_templates/pubmed_id_start.html
+++ b/root/static/ng_templates/pubmed_id_start.html
@@ -5,7 +5,7 @@
     </div>
     <div>
       <input type="text" ng-model="data.searchId"/>
-      <button class="btn btn-primary" ng-click="search()">Find ...</button>
+      <button class="btn btn-primary" ng-click="search()">Find</button>
     </div>
   </div>
   <div ng-if="data.results">

--- a/root/static/ng_templates/pubs_list_view.html
+++ b/root/static/ng_templates/pubs_list_view.html
@@ -3,7 +3,7 @@
     <a href="{{application_root}}/curs/{{row.curs_key}}">{{row.pub_uniquename}}</a>
     - <span class="pub-lookup-title">
     <initially-hidden-text text="{{row.pub_title}}" preview-char-count="50"
-                           link-label=" ..."></initially-hidden-text>
+                           link-label="..."></initially-hidden-text>
     </span>
   </li>
 </ul>

--- a/root/static/ng_templates/strain_selector.html
+++ b/root/static/ng_templates/strain_selector.html
@@ -5,6 +5,6 @@
       ng-change="strainChanged()"
       name="curs-allele-type"
       ng-options="s.strain_name for s in strains track by s.strain_name">
-    <option value="">Choose a strain ...</option>
+    <option value="">Choose a strain...</option>
   </select>
 </div>

--- a/root/static/ng_templates/term_confirm.html
+++ b/root/static/ng_templates/term_confirm.html
@@ -8,7 +8,7 @@ Confirm term
   <div class="modal-body">
     <div class="curs-box-body" ng-if="!data.termDetails">
       <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img>
-      Loading ...
+      Loading...
     </div>
     <div ng-if="data.termDetails">
       <div ng-if="data.state === 'definition'" class="curs-box-body">

--- a/root/static/ng_templates/term_name_complete.html
+++ b/root/static/ng_templates/term_name_complete.html
@@ -1,6 +1,6 @@
 <span>
   <span ng-show="termCount == null">
-    <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img> Loading ...
+    <img ng-src="{{app_static_path + '/images/spinner.gif'}}"></img> Loading...
   </span>
   <span ng-hide="termCount == null">
     <span ng-show="termCount == 0" style="font-weight: bold">
@@ -14,7 +14,7 @@
       <span ng-show="allTerms.length > 0">
         <select class="form-control" ng-model="chosenTerm"
                 ng-options="term.name for term in allTerms">
-          <option value="">Choose a term ...</option>
+          <option value="">Choose a term...</option>
         </select>
       </span>
     </span>

--- a/root/static/ng_templates/user_pubs_lookup.html
+++ b/root/static/ng_templates/user_pubs_lookup.html
@@ -4,7 +4,7 @@
     <form ng-hide="searching || pubResults && pubResults.length > 0"
           name="cursUserPaperLookupEmail">
       <input ng-model="emailAddress" name="email" type="email" size="30"
-             placeholder="Type an email address ...">
+             placeholder="Type an email address">
       <span class="error" ng-show="cursUserPaperLookupEmail.email.$error.email">
         Not valid email</span>
 
@@ -17,7 +17,7 @@
     <div ng-show="pubResults">
       <a ng-if="emailAddress.length > 0 && is_admin_user"
          href="{{application_root}}/view/object/person/{{emailAddress}}?model=track">
-        Person page (admin only) ...
+        Person page (admin only)
       </a>
       <div ng-show="pubResults.length == 0 && emailAddress.length > 0">
         No publications found

--- a/root/tools/triage.mhtml
+++ b/root/tools/triage.mhtml
@@ -68,7 +68,7 @@ $return_pub_id
         <div class="sect-content">
           <& /person_picker.mhtml, id_prefix => 'triage-corresponding-author',
              default_person => $pub->corresponding_author() &>
-          <button class="curs-person-picker-add" type="button">New ...</button>
+          <button class="curs-person-picker-add" type="button">Add author</button>
         </div>
       </div>
       <div class="sect triage-curation-priorities">

--- a/root/track/index.mhtml
+++ b/root/track/index.mhtml
@@ -7,7 +7,7 @@ $model
     <div class="col-sm-3 col-md-3">
         <div>
           <h3>
-            View ...
+            View
           </h3>
           <ul>
             <li>
@@ -29,7 +29,7 @@ $model
     </div>
     <div class="col-sm-3 col-md-3">
         <h3>
-          Add ...
+          Add
         </h3>
         <div>
           <ul>
@@ -48,7 +48,7 @@ $model
 % if ($c->user_exists() && $c->user()->role()->name() eq 'admin') {
     <div class="col-sm-6 col-md-6">
         <h3>
-          Tools ...
+          Tools
         </h3>
         <div>
           <ul>

--- a/root/view/object/track/curs.mhtml
+++ b/root/view/object/track/curs.mhtml
@@ -7,7 +7,7 @@ $class_info
 
 <div class="object_sub_action">
   <a href="<% $c->uri_for('/curs/' . $object->curs_key()) %>">
-    Enter this curation session ...
+    Enter this curation session
   </a>
 </div>
 </&>
@@ -18,9 +18,9 @@ $class_info
   <button href="<% $c->uri_for('/tools/send_session/' . $curs_key) %>"
           class="btn btn-primary" type="button" id="curs-pub-send-session-popup-dialog">\
 %   if ($session_sent) {
-Resend session to curator ...\
+Resend session to curator\
 %   } else {
-Send session to curator ...\
+Send session to curator\
 %   }
   </button>
 </div>

--- a/root/view/object/track/pub.mhtml
+++ b/root/view/object/track/pub.mhtml
@@ -27,7 +27,7 @@ $is_admin_user
 </div>
 
 <div class="curs-pub-assign-actions">
-  <button type="button" class="btn btn-primary" id="curs-pub-assign-popup-dialog">Set corresponding author ...</button>
+  <button type="button" class="btn btn-primary" id="curs-pub-assign-popup-dialog">Set corresponding author</button>
 </div>
 %   }
 %   if ($pub_curs_rs->count() == 0) {
@@ -51,7 +51,7 @@ $is_admin_user
 </div>
 <div class="curs-pub-assign-actions">
   <button type="button" class="btn btn-primary" id="curs-pub-create-session-popup-dialog">Create a curation
-  session ...</button>
+  session</button>
 </div>
 %   } else {
 <div id="curs-pub-reassign-session-dialog" style="display: none">
@@ -73,16 +73,16 @@ $is_admin_user
   </form>
 </div>
 <div class="curs-pub-assign-actions">
-  <button type="button" class="btn btn-primary" id="curs-pub-reassign-session-popup-dialog">Reassign session ...</button>
+  <button type="button" class="btn btn-primary" id="curs-pub-reassign-session-popup-dialog">Reassign session</button>
 </div>
 %     if ($session_assigned) {
 <div class="curs-pub-assign-actions">
   <button href="<% $c->uri_for('/tools/send_session/' . $curs_key) %>"
           class="btn btn-primary" type="button" id="curs-pub-send-session-popup-dialog">\
 %       if ($session_sent) {
-Resend session to curator ...\
+Resend session to curator\
 %       } else {
-Send session to curator ...\
+Send session to curator\
 %       }
   </button>
 </div>
@@ -100,7 +100,7 @@ Send session to curator ...\
 <div class="curs-pub-go-to-curs-actions">
   <div class="object_sub_action">
     <a href="<% $c->uri_for('/curs/' . $curs_key) %>">
-      Go to the curation session ...
+      Go to the curation session
     </a>
   </div>
 </div>


### PR DESCRIPTION
(Fixes #2001)

This pull request makes the following changes:

* Remove spaces before trailing ellipses ('more ...' becomes 'more...').

* Remove trailing ellipses from link text.
  * The current exceptions to this rule are when the link opens another application (e.g. `mailto:`), or when the link directs to another domain (e.g. 'Visit...' and 'Demo...').

  * This also removes trailing ellipses in button labels, except in the case of the exceptions above. 

* Edit some link text to clarify the link's meaning, or make the tone consistent with other links &ndash; specifically, remove pleading from some links (e.g. 'Please choose' &rarr; 'Choose').

**Note:** I've chosen to leave ellipses in the placeholder text for `<select>` elements, since sometimes this selection process isn't optional, so I think it hints to the user that they need to do the action. If anyone thinks it would be better to just remove these too, then I'll do that.

@kimrutherford The changes to `canto_front.mhtml` might be contentious, since this is a form of landing page for PomBase, and it might leave the page inconsistent with the rest of your domain (if you've used trailing ellipses with spaces there). Let me know if you want to leave out changes to this page &ndash; we never see this page in PHI-Canto anyway.

I wasn't able to check the following templates in my local copy. This might be because they're unused, or because I don't have the correct configuration:

- `extension_or_group_builder.html`
- `gene_selector.html`
- `genotype_search.html`
- `multi-feature-chooser`
- `front.mhtml`
- `interaction.mhtml`
- `ontology_multi_gene_select.mhtml`
- `ontology_with_gene.mhtml`
- `root/docs/instance_front.mhtml` (not sure if this file should be here)
- `annotation.mhtml` (possibly because my environment has no connection to Chado)