### PR TITLE
Add inline help text for genotype annotation links

### DIFF
--- a/canto.yaml
+++ b/canto.yaml
@@ -2029,9 +2029,10 @@ help_text:
       set of annotation options
   choose_genotype:
     inline: >
-      Phenotypes annotations are connected to genotypes in Canto. Required
-      genotypes can be added upfront, or individually as required, for
-      each annotation depending on your preferred workflow.
+      Add genotypes (including alleles, expression levels, and optional
+      background) to use in annotating phenotypes. You can add genotypes
+      individually as you go through the paper, or all at once before you
+      start adding phenotype annotations.
   gene_page_choose_curation_type:
     inline: >
       These are the types of data you can annotate. Follow one of the links for more detailed instructions.

--- a/canto.yaml
+++ b/canto.yaml
@@ -2027,6 +2027,11 @@ help_text:
     inline: >
       Once you have selected a gene to annotate you will be presented with a
       set of annotation options
+  choose_genotype:
+    inline: >
+      Phenotypes annotations are connected to genotypes in Canto. Required
+      genotypes can be added upfront, or individually as required, for
+      each annotation depending on your preferred workflow.
   gene_page_choose_curation_type:
     inline: >
       These are the types of data you can annotate. Follow one of the links for more detailed instructions.

--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -57,6 +57,7 @@ Genotypes from this publication
 % } else {
 Annotate genotypes
 % }
+    <& /curs/inline_help.mhtml, key => 'choose_genotype' &>
     </div>
   </div>
 %   if ($pathogen_host_mode) {


### PR DESCRIPTION
(Fixes #1658)

This pull request adds some missing inline help text for the 'Annotate genotypes' heading on the summary page. This keeps the heading consistent with the 'Annotate genes' heading.

I'm marking this pull request as a draft, since the help text might need some further edits, but we have the option to merge if we need to.