### PR TITLE
Use a custom modal for delete confirmations

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6629,6 +6629,18 @@ var annotationTableRow =
             newAnnotation, $scope.featureFilterDisplayName,
             true, true);
         };
+        
+        $scope.confirmDelete = function () {
+          var modal = openDeleteDialog(
+            $uibModal,
+            'Delete Annotation',
+            'Delete Annotation',
+            'Are you sure you want to delete this annotation?'
+          )
+          modal.result.then(function () {
+            $scope.deleteAnnotation();
+          });
+        }
 
         $scope.deleteAnnotation = function () {
           loadingStart();

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -1258,6 +1258,43 @@ var simpleDialogCtrl =
 canto.controller('SimpleDialogCtrl',
   ['$scope', '$uibModalInstance', 'args', simpleDialogCtrl]);
 
+function openDeleteDialog($uibModal, title, heading, message) {
+  return $uibModal.open({
+    templateUrl: app_static_path + 'ng_templates/delete_dialog.html',
+    controller: 'DeleteDialogCtrl',
+    title: title,
+    resolve: {
+      args: function() {
+        return {
+          heading: heading,
+          message: message,
+        };
+      },
+    },
+    animate: false,
+    windowClass: "modal",
+    backdrop: 'static',
+  });
+}
+
+var DeleteDialogCtrl =
+  function ($scope, $uibModalInstance, args) {
+    $scope.heading = args.heading;
+    $scope.message = args.message;
+    
+    $scope.onDelete = function () {
+      $uibModalInstance.close('delete');
+    };
+
+    $scope.close = function () {
+      $uibModalInstance.dismiss('close');
+    };
+  };
+
+canto.controller(
+  'DeleteDialogCtrl',
+  ['$scope', '$uibModalInstance', 'args', DeleteDialogCtrl]
+);
 
 var pubmedIdStart =
   function ($http, toaster, CantoGlobals, CantoConfig) {

--- a/root/static/ng_templates/annotation_table_interaction_row.html
+++ b/root/static/ng_templates/annotation_table_interaction_row.html
@@ -39,7 +39,7 @@
         <a ng-click="duplicate()">Copy and edit</a>
       </div>
       <div>
-        <a ng-click="confirmDelete()">Delete</a>
+        <a title="Delete this annotation" ng-click="confirmDelete()">Delete</a>
       </div>
       <div ng-if="sessionState == 'APPROVAL_IN_PROGRESS'">
         <a ng-if="checked == 'no'" href="#" ng-click="setChecked($event)">Checked</a>

--- a/root/static/ng_templates/annotation_table_interaction_row.html
+++ b/root/static/ng_templates/annotation_table_interaction_row.html
@@ -39,8 +39,7 @@
         <a ng-click="duplicate()">Copy and edit</a>
       </div>
       <div>
-        <a confirm="Are you sure you want to delete this annotation?"
-           ng-click="deleteAnnotation()">Delete</a>
+        <a ng-click="confirmDelete()">Delete</a>
       </div>
       <div ng-if="sessionState == 'APPROVAL_IN_PROGRESS'">
         <a ng-if="checked == 'no'" href="#" ng-click="setChecked($event)">Checked</a>

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -127,9 +127,7 @@
            ng-click="duplicate()">Copy and edit</a>
       </div>
       <div>
-        <a title="Delete this annotation"
-           confirm="Are you sure you want to delete this annotation?"
-           ng-click="deleteAnnotation()">Delete</a>
+        <a title="Delete this annotation" ng-click="confirmDelete()">Delete</a>
       </div>
       <div ng-if="sessionState == 'APPROVAL_IN_PROGRESS'">
         <a ng-if="checked == 'no'" href="#" ng-click="setChecked($event)">Checked</a>

--- a/root/static/ng_templates/delete_dialog.html
+++ b/root/static/ng_templates/delete_dialog.html
@@ -1,0 +1,14 @@
+<div class="curs-extension-builder-dialog modal-content">
+  <div ng-show="heading" class="modal-header">
+    <h4 class="modal-title">
+      {{heading}}
+    </h4>
+  </div>
+  <div class="modal-body">
+    {{message}}
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-primary" ng-click="close()">Cancel</button>
+    <button class="btn btn-danger" ng-click="onDelete()">Delete</button>
+  </div>
+</div>


### PR DESCRIPTION
(Fixes #1589)

This pull request adds a custom modal that can be used for confirming the 'Delete' action on annotation table rows. The modal function is `openDeleteDialog`, with corresponding controller `DeleteDialogCtrl` and template `delete_dialog.html`.

Here's how it looks:

![image](https://user-images.githubusercontent.com/37659591/64338780-7be5f900-cfda-11e9-9eb9-f4e9a9c363de.png)

The modal is essentially a specialisation of `simple_dialog.html` with different buttons (and extra handlers for the extra buttons). I think this is a bit wasteful, since it's probably possible to generalise the existing simple dialog to allow custom buttons &ndash; although passing the handlers around could get complicated.

@kimrutherford I can try to generalise the simple modal if you want me to, but feel free to merge this if you don't feel the extra work is worth it.