### PR TITLE
Add genotype management shortcuts to feature pages

### DIFF
--- a/root/curs/gene_page.mhtml
+++ b/root/curs/gene_page.mhtml
@@ -130,7 +130,7 @@ Genotypes for <% $gene->display_name() %> in this session
 
 <div class="clearall"/>
 
-<a href="<% $summary_url %>" type="button" class="btn btn-primary curs-back-button">&larr; <% $finish_text %></a>
+<genotype-and-summary-nav role="<% $gene->organism_details()->{pathogen_or_host} %>"></genotype-and-summary-nav>
 
 <annotation-table-list feature-type-filter="gene" feature-id-filter="<% $gene_id %>"
                        feature-filter-display-name="<% $gene->display_name() %>"></annotation-table-list>

--- a/root/curs/genotype_page.mhtml
+++ b/root/curs/genotype_page.mhtml
@@ -120,8 +120,7 @@ Description
 
 <div class="clearall"/>
 
-<button type="button" ng-click="backToGenotypes()"
-        class="btn btn-primary curs-back-button">&larr; Back to genotypes</button>
+<genotype-and-summary-nav role="<% $genotype->genotype_type($c->config()) %>"></genotype-and-summary-nav>
 
 <annotation-table-list feature-type-filter="genotype" feature-id-filter="<% $genotype_id %>"
                        feature-filter-display-name="<% $genotype->display_name($c->config()) %>"></annotation-table-list>

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -8385,6 +8385,26 @@ var editOrganisms = function ($window, EditOrganismsSvc, StrainsService, CantoGl
 canto.directive('editOrganisms', ['$window', 'EditOrganismsSvc', 'StrainsService', 'CantoGlobals', editOrganisms]);
 
 
+var genotypeAndSummaryNav = function () {
+  return {
+    scope: {
+      role: '@'
+    },
+    restrict: 'E',
+    templateUrl: app_static_path + 'ng_templates/genotype_and_summary_nav.html',
+    controller: 'genotypeAndSummaryNavCtrl',
+  };
+};
+
+var genotypeAndSummaryNavCtrl = function ($scope, CantoGlobals) {
+  $scope.summaryUrl = CantoGlobals.curs_root_uri;
+  $scope.genotypeManageUrl = CantoGlobals.curs_root_uri + '/' + getGenotypeManagePath($scope.role);
+}
+
+canto.controller('genotypeAndSummaryNavCtrl', ['$scope', 'CantoGlobals', genotypeAndSummaryNavCtrl]);
+
+canto.directive('genotypeAndSummaryNav', [genotypeAndSummaryNav]);
+
 
 var messageForCuratorsEditDialogCtrl =
   function ($scope, $uibModalInstance, toaster, CursSettings, args) {

--- a/root/static/ng_templates/genotype_and_summary_nav.html
+++ b/root/static/ng_templates/genotype_and_summary_nav.html
@@ -1,0 +1,4 @@
+<div>
+  <a ng-href="{{summaryUrl}}" type="button" class="btn btn-primary curs-back-button">&larr; Back to summary</a>
+  <a ng-href="{{genotypeManageUrl}}" type="button" class="btn btn-primary curs-back-button">Genotype management &rarr;</a>
+</div>


### PR DESCRIPTION
(Fixes #1896)

This pull request will add a forward navigation button (to complement the back navigation button) to the gene and genotype detail pages.

Currently, the PR creates a new directive `genotypeAndSummaryNav` that keeps these buttons together. The genotype management button is able to link to the correct genotype management page based on a 'role' binding (which acts on the values 'pathogen' or 'host' and otherwise defaults to the standard genotype management page.

This PR is currently a work in progress, due to an unresolved problem preventing this from working on the genotype page: see https://github.com/pombase/canto/issues/1896#issuecomment-528373625.