### PR TITLE
Change 'Back to summary' to 'Go to summary' everywhere

### DIFF
--- a/root/curs/gene_page.mhtml
+++ b/root/curs/gene_page.mhtml
@@ -160,7 +160,7 @@ if (defined $org_config) {
 my $st = $c->stash();
 
 my $gene_count = $st->{gene_count};
-my $finish_text = 'Back to summary';
+my $finish_text = 'Go to summary';
 my $read_only_curs = $st->{read_only_curs};
 my $pathogen_host_mode = $st->{pathogen_host_mode};
 

--- a/root/static/ng_templates/genotype_and_summary_nav.html
+++ b/root/static/ng_templates/genotype_and_summary_nav.html
@@ -1,4 +1,4 @@
 <div>
-  <a ng-href="{{summaryUrl}}" type="button" class="btn btn-primary curs-back-button">&larr; Back to summary</a>
+  <a ng-href="{{summaryUrl}}" type="button" class="btn btn-primary curs-back-button">&larr; Go to summary</a>
   <a ng-href="{{genotypeManageUrl}}" type="button" class="btn btn-primary curs-back-button">Genotype management &rarr;</a>
 </div>

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -108,7 +108,7 @@
     <div class="row">
         <div class="col-sm-5 col-md-5">
             <button ng-click="backToSummary()" type="button" class="btn btn-primary curs-back-button">
-                &larr; Back to summary
+                &larr; Go to summary
             </button>
             <span ng-if="pathogen_host_mode">
             <button ng-click="toMetagenotype()" type="button" class="btn btn-primary curs-back-button"

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -30,7 +30,7 @@
     </div>
     <div class="row">
         <button ng-click="toGenotype()" type="button" class="btn btn-primary curs-back-button">
-            &larr; Back to Summary
+            &larr; Go to Summary
         </button>
         <button
             ng-click="createMetagenotype()"


### PR DESCRIPTION
Fixes #2019

This changes the link text on backwards navigation buttons from 'Back to summary' to 'Go to summary', as a temporary fix to make the workflow from the Metagenotype Management page less confusing.