### PR TITLE
Replace extension hint message with input placeholder

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6809,6 +6809,7 @@ var termNameComplete =
         $scope.typeMatch = re.exec($scope.annotationTypeName);
 
         if ($scope.typeMatch) {
+          $scope.placeholder = 'Start typing a term name, e.g. ';
           var split = $scope.typeMatch[1].split(/\s*\|\s*/);
           var promises =
             $.map(split,
@@ -6816,7 +6817,7 @@ var termNameComplete =
                 return CantoService.lookup('ontology', [termId], {});
               });
           $q.all(promises).then(function (results) {
-            $scope.placeholder =
+            $scope.placeholder +=
               $.map(results, function (data) {
                 return data.name;
               }).join(" or ") + "...";

--- a/root/static/ng_templates/extension_relation_edit.html
+++ b/root/static/ng_templates/extension_relation_edit.html
@@ -13,7 +13,6 @@
                           found-callback="termFoundCallback(termId, termName, searchString)"
                           mode="extension" size="60"
                           annotation-type-name="{{rangeOntologyScope}}"></term-name-complete>
-      <span class="curs-extension-name-complete-hint">(Start typing a description)</span>
     </span>
   </span>
   <span ng-if="rangeConfig.type == 'Text'">


### PR DESCRIPTION
Fixes #1778

This pull request removes the message in the extension dialog that instructs the user to 'Start typing a description' when the input isn't text editable (not an `<input>`). Instead, that message is now provided as the placeholder text for the `<input>`; previously the placeholder was only a term name suggestion.

Here's how the placeholder looks now:

![image](https://user-images.githubusercontent.com/37659591/65500121-ae3a9600-deb6-11e9-8843-11a30554dfb6.png)
