### PR TITLE
Improve clarity of front page quick links

### DIFF
--- a/root/curs/front_page_quick_links.mhtml
+++ b/root/curs/front_page_quick_links.mhtml
@@ -7,13 +7,15 @@
     Quick links
   </div>
   <div class="curs-box-body">
+    <ul class="curs-quick-links-list">
 % for my $annotation_type (@annotation_type_list) {
-    <div>
-      <annotation-quick-add annotation-type-name="<% $annotation_type->{name} %>"
-                            link-label="<% $annotation_type->{display_name} %>"
-                            feature-type="<% $annotation_type->{feature_type} %>">
-      </annotation-quick-add>
-    </div>
+      <li>
+        <annotation-quick-add annotation-type-name="<% $annotation_type->{name} %>"
+                              link-label="<% $annotation_type->{display_name} %>"
+                              feature-type="<% $annotation_type->{feature_type} %>">
+        </annotation-quick-add>
+      </li>
 % }
+    </ul>
   </div>
 </div>

--- a/root/curs/front_page_quick_links.mhtml
+++ b/root/curs/front_page_quick_links.mhtml
@@ -11,7 +11,7 @@
 % for my $annotation_type (@annotation_type_list) {
       <li>
         <annotation-quick-add annotation-type-name="<% $annotation_type->{name} %>"
-                              link-label="<% $annotation_type->{display_name} %>"
+                              link-label="<% ucfirst($annotation_type->{display_name}) %>"
                               feature-type="<% $annotation_type->{feature_type} %>">
         </annotation-quick-add>
       </li>

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1650,3 +1650,10 @@ a:not([href]) {
 .curs-summary-gene-name-container {
   display: block;
 }
+.curs-quick-links-list {
+  padding-left: 0;
+}
+.curs-quick-links-list > li {
+  list-style-type: circle;
+  color: grey;
+}


### PR DESCRIPTION
Fixes #2042 

This pull request affects the list of quick links that are shown on the front page when in advanced mode. Previously, the number of links could be ambiguous when long link names wrapped onto multiple lines:

![image](https://user-images.githubusercontent.com/37659591/65971859-cdaa6380-e460-11e9-9958-5c84722d9be3.png)

I've addressed this by adding bullets to the list, and capitalising the first letter of every list item. Now it's more obvious how many list items there are, even when there's an excessive amount of line wrapping:

![image](https://user-images.githubusercontent.com/37659591/65971760-a05db580-e460-11e9-954b-8a18fc876227.png)

This change affects every version of Canto, but it's only really a problem for PHI-Canto due to the long annotation type names.