### PR TITLE
Add option for unknown expression level

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3330,6 +3330,7 @@ var alleleEditDialogCtrl =
     };
 
     $scope.userIsAdmin = CantoGlobals.current_user_is_admin;
+    $scope.pathogenHostMode = CantoGlobals.pathogen_host_mode;
 
     function processSynonyms() {
       $.map($scope.alleleData.synonyms || [],

--- a/root/static/ng_templates/allele_edit.html
+++ b/root/static/ng_templates/allele_edit.html
@@ -213,6 +213,11 @@
               <input ng-model="alleleData.expression" name="curs-allele-expression" id="allele-edit-not-assayed"
                      type="radio" value="Not assayed" />
             </div>
+            <div ng-show="pathogenHostMode">
+              <label for="allele-edit-expression-unknown">Unknown</label>
+              <input ng-model="alleleData.expression" name="curs-allele-expression" id="allele-edit-expression-unknown"
+                     type="radio" value="Unknown" />
+            </div>
           </td>
         </tr>
       </table>


### PR DESCRIPTION
Fixes #2046 

This pull requests adds an option to specify the allele expression level as 'Unknown'. I think the option is only currently needed for pathogen-host mode, so I've restricted it to that mode in the template. I've tested allele creation with the new expression type and everything seems to work fine.

![image](https://user-images.githubusercontent.com/37659591/66034478-35b08680-e501-11e9-9223-e26fb34ae24c.png)

![image](https://user-images.githubusercontent.com/37659591/66034462-2f220f00-e501-11e9-9282-147f3e077e34.png)
