### PR TITLE
Auto-select strain when only one strain is available

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4218,7 +4218,13 @@ var strainSelectorCtrl = function ($scope, CantoGlobals) {
   function computeStyleClass(className) {
     return className === undefined ? 'form-control' : className;
   }
-
+  
+  $scope.$watch('strains', function () {
+    if ($scope.strains && $scope.strains.length === 1) {
+      $scope.data.selectedStrain = $scope.strains[0];
+      $scope.strainChanged();
+    }
+  });
 };
 
 canto.directive('strainSelector', ['CantoGlobals', strainSelector]);


### PR DESCRIPTION
Fixes #2040

This makes the strain selection drop-down select a strain automatically when there is only one strain in the list. This change affects everywhere the strain selector is used, which includes allele creation and genotype editing.