### PR TITLE
Usability improvements for pathogen-host mode

### DIFF
--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -42,7 +42,7 @@ Annotate genes
   <div class="feature-list-action" style="margin-bottom: 20px;">
     <a href="<% $edit_path %>">
 %   if ($multi_organism_mode) {
-Delete or edit genes and organisms list
+Delete or edit genes and organisms
 %   } else {
 Edit gene list
 %   }

--- a/root/curs/gene_page.mhtml
+++ b/root/curs/gene_page.mhtml
@@ -68,6 +68,19 @@ Choose curation type for <% $gene->display_name() %>:
 %     }
 %   }
 % }
+% if ($pathogen_host_mode) {
+%   my $organism_role = $gene->organism_details()->{pathogen_or_host};
+%   my $role_annotation_type_name = 'pathogen_phenotype';
+%   if ($organism_role eq 'host') {
+%     $role_annotation_type_name = 'host_phenotype';
+%   }
+    <li class="annotation-type">
+      <a href="#" ng-click="singleAlleleQuick('<% $gene->display_name() |n %>', '<% $gene->primary_identifier() |n %>', <% $gene->gene_id() |n%>, '<%$role_annotation_type_name%>', <% $taxon_id %>)">
+        Single allele phenotype
+      </a>
+      <help-icon key="gene_page_single_allele"></help-icon>
+    </li>
+% }
   </ul>
   </div>
 </div>

--- a/root/static/ng_templates/genotype_manage.html
+++ b/root/static/ng_templates/genotype_manage.html
@@ -52,7 +52,7 @@
                           No genes have been added for this organism.
                         </p>
                         <a ng-if="data.splitGenotypesByOrganism"
-                           href="confirm_genes">Delete or edit genes and organisms list</a>
+                           href="confirm_genes">Delete or edit genes and organisms</a>
                         <a ng-if="!data.splitGenotypesByOrganism"
                            ng-click="openSingleGeneAddDialog()">Add another gene</a>
                         </div>

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -2,7 +2,7 @@
 <div ng-if="selectedOrganism">
     <div>
         <p class="metagenotype-genotype-shortcut">
-          <a href="{{genotypeShortcutUrl}}">Create a new {{organismType}} genotype</a>
+          <a href="{{genotypeShortcutUrl}}">Add another {{organismType}} genotype</a>
         </p>
         <div>
           

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -5,11 +5,9 @@
           <a href="{{genotypeShortcutUrl}}">Create a new {{organismType}} genotype</a>
         </p>
         <div>
-            <div class="curs-box-title">Single locus genotypes</div>
-            <div ng-show="genotypes.single.length === 0">
-                <p>No Single locus genotypes created</p>
-            </div>
-            <div ng-if="genotypes.single.length > 0">
+          
+            <div ng-show="genotypes.single.length > 0">
+                <div class="curs-box-title">Single locus genotypes</div>
                 <genotype-simple-list-view
                     genotype-list="genotypes.single"
                     is-host="isHost"
@@ -18,11 +16,8 @@
                 </genotype-simple-list-view>
             </div>
 
-            <div class="curs-box-title">Multi-allele genotypes</div>
-            <div ng-show="genotypes.multi.length === 0">
-                <p>No Multi-allele genotypes created</p>
-            </div>
             <div ng-show="genotypes.multi.length > 0">
+                <div class="curs-box-title">Multi-allele genotypes</div>
                 <genotype-simple-list-view
                     genotype-list="genotypes.multi"
                     is-host="isHost"


### PR DESCRIPTION
Fixes #2043 

This pull request bundles together a few small changes to pathogen-host mode that should make Canto easier to use. The changes are as follows:

* Hide empty sections of the genotype list on the metagenotype page; previously they still showed a heading and a message when empty, which took up unnecessary space.

  ![image](https://user-images.githubusercontent.com/37659591/66127502-bf388500-e5e3-11e9-9481-353f45a34b7e.png)

- - -

* Amend some link text to be more clear and concise:
  * 'Delete or edit genes and organisms list' &rarr; 'Delete or edit genes and organisms'
  * 'Create a new [...] genotype' &rarr; 'Add another [...] genotype'

- - -

* Re-implement the 'Single allele phenotype' link on gene pages in pathogen-host mode. Previously there were links for all three phenotype categories (host, pathogen, and pathogen-host), but two of three of those were never relevant. Instead of leaving them disabled, I've added one link &ndash; called 'single allele phenotype' &ndash; that picks the correct annotation type based on the pathogen/host role of the gene.

  ![image](https://user-images.githubusercontent.com/37659591/66127399-784a8f80-e5e3-11e9-8c72-5eb75543cb3f.png)

  It might be more clear if the link text included the name of the annotation (e.g. 'single allele pathogen phenotype'), and I can add this change if anyone thinks it's necessary.