### PR TITLE
Allow deleting strain names containing slashes

### DIFF
--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -2966,8 +2966,10 @@ sub ws_delete_strain_by_id : Chained('top') PathPart('ws/strain_by_id/delete')
 
 sub ws_delete_strain_by_name : Chained('top') PathPart('ws/strain_by_name/delete')
 {
-  my ($self, $c, $taxon_id, $strain_name) = @_;
+  my ($self, $c, $taxon_id, @strain_name_parts) = @_;
 
+  my $strain_name = join '/', @strain_name_parts;
+  
   my $st = $c->stash();
   my $schema = $st->{schema};
 


### PR DESCRIPTION
Fixes #2024 

This is just a simple fix that copies the change to `ws_add_strain_by_name` to `ws_delete_strain_by_name`.