### PR TITLE
Add missing ng-click to delete host button

### DIFF
--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -40,11 +40,12 @@
           <td ng-if="o.genes.length == 0">
             <button ng-if="canRemoveHost(o)"
               title="Remove host"
-              class="btn-danger">X</button>
-            </button>
+              class="btn-danger"
+              ng-click="removeHost(o.taxonid)">X</button>
             <button ng-if="!canRemoveHost(o)"
               disabled="disabled"
-              title="Host can't be removed because it is used in a metagenotype">
+              title="Host can't be removed because it is used in a metagenotype"
+              ng-click="removeHost(o.taxonid)">
               <span class="gene-button-delete-text-disabled">X</span></button>
           </td>
         </tr>


### PR DESCRIPTION
Fixes #2041

This pull request fixes a regression in the host organism deletion button that removed the click handlers for deleting the organism.

@kimrutherford I would have pushed this straight to `master`, but I wasn't sure if modifying templates requires a version bump in `canto.yaml` for cache-busting. I'm happy to amend this pull request to add that change.