### PR TITLE
Add strain mapping notice to gene_list_edit page

### DIFF
--- a/root/curs/gene_list_edit.mhtml
+++ b/root/curs/gene_list_edit.mhtml
@@ -22,9 +22,9 @@ var hostsWithNoGenes = <% $hosts_with_no_genes_js |n %>;
 <% $title %>
   </div>
   <div class="curs-box-body">
-
 % if ($pathogen_host_mode) {
-<edit-organisms></edit-organisms>
+    <p><b>Note:</b> PHI-Canto does not curate at taxonomic ranks lower than species. If you have entered UniProt identifiers that are at the strain or subspecies level, these identifiers may have been re-mapped to the nearest species rank. Please use the 'experimental strains' field to specify lower taxonomic ranks (strains, pathovars, subpsecies, etc.)</p>
+    <edit-organisms></edit-organisms>
 % } else {
   <form name="gene-edit" method="get" action="<% $edit_path %>">
 % if (scalar(@table_1_hashes) > 0 || scalar(@table_2_hashes) > 0) {

--- a/root/curs/gene_list_edit.mhtml
+++ b/root/curs/gene_list_edit.mhtml
@@ -23,7 +23,7 @@ var hostsWithNoGenes = <% $hosts_with_no_genes_js |n %>;
   </div>
   <div class="curs-box-body">
 % if ($pathogen_host_mode) {
-    <p><b>Note:</b> PHI-Canto does not curate at taxonomic ranks lower than species. If you have entered UniProt identifiers that are at the strain or subspecies level, these identifiers may have been re-mapped to the nearest species rank. Please use the 'experimental strains' field to specify lower taxonomic ranks (strains, pathovars, subpsecies, etc.)</p>
+    <p><b>Note:</b> PHI-Canto does not curate at taxonomic ranks lower than species. If you have entered UniProt identifiers that are at the strain or subspecies level, their corresponding NCBI taxonomy identifiers will have been re-mapped to the nearest species rank (the UniProt identifier itself is not modified). Please use the 'experimental strains' field to specify lower taxonomic ranks (such as strains, pathovars, and subpsecies).</p>
     <edit-organisms></edit-organisms>
 % } else {
   <form name="gene-edit" method="get" action="<% $edit_path %>">


### PR DESCRIPTION
This pull request adds a notice to the top of `gene_list_edit.mhtml` that explains the fact that PHI-Canto doesn't curate at taxonomic ranks lower than the species level. The notice should only show in pathogen-host mode.

In future this text should be moved into a configuration slot, but we decided to put the notice in the template for now, since we have no other users of pathogen-host mode.

It would also be nice in future if we could give users an option to hide the message after they've seen it for the first time, but that would require setting a cookie.