### PR TITLE
Improvements to organism display in metagenotype table

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1659,5 +1659,5 @@ a:not([href]) {
 }
 
 .curs-strain-name-inline {
-  display: inline-block;
+  display: block;
 }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7661,7 +7661,7 @@ var metagenotypeListRow = function (CantoGlobals, Metagenotype, AnnotationTypeCo
       $scope.getStrainName = function (type) {
         var metagenotype = $scope.metagenotype[type + '_genotype'];
         var strain = metagenotype.strain_name || 'Wild type';
-        return '(strain: ' + strain + ')';
+        return '(' + strain + ')';
       };
 
       $scope.getScope = function (type) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7660,7 +7660,7 @@ var metagenotypeListRow = function (CantoGlobals, Metagenotype, AnnotationTypeCo
       };
       $scope.getStrainName = function (type) {
         var metagenotype = $scope.metagenotype[type + '_genotype'];
-        var strain = metagenotype.strain_name || 'Wild type';
+        var strain = metagenotype.strain_name;
         return '(' + strain + ')';
       };
 

--- a/root/static/ng_templates/metagenotype_list_row.html
+++ b/root/static/ng_templates/metagenotype_list_row.html
@@ -1,13 +1,13 @@
 <tbody>
     <tr>
         <td>
-          <b>{{ getOrganismName('pathogen') }}</b>
+          <b>{{ getOrganismName('pathogen') | abbreviateGenus }}</b>
           <span class="metagenotype-list-strain">{{ getStrainName('pathogen') }}</span>
         </td>
         <td>{{ metagenotype.pathogen_genotype.display_name }}</td>
         <td ng-if="showBackground.pathogen">{{ metagenotype.pathogen_genotype.background }}</td>
         <td>
-          <b>{{ getOrganismName('host') }}</b>
+          <b>{{ getOrganismName('host') | abbreviateGenus }}</b>
           <span class="metagenotype-list-strain">{{ getStrainName('host') }}</span>
         </td>
         <td>{{ metagenotype.host_genotype.display_name }}</td>

--- a/root/static/ng_templates/metagenotype_list_row.html
+++ b/root/static/ng_templates/metagenotype_list_row.html
@@ -1,13 +1,13 @@
 <tbody>
     <tr>
         <td>
-          <b>{{ getOrganismName('pathogen') | abbreviateGenus }}</b>
+          {{ getOrganismName('pathogen') | abbreviateGenus }}
           <span class="metagenotype-list-strain">{{ getStrainName('pathogen') }}</span>
         </td>
         <td>{{ metagenotype.pathogen_genotype.display_name }}</td>
         <td ng-if="showBackground.pathogen">{{ metagenotype.pathogen_genotype.background }}</td>
         <td>
-          <b>{{ getOrganismName('host') | abbreviateGenus }}</b>
+          {{ getOrganismName('host') | abbreviateGenus }}
           <span class="metagenotype-list-strain">{{ getStrainName('host') }}</span>
         </td>
         <td>{{ metagenotype.host_genotype.display_name }}</td>

--- a/root/static/ng_templates/metagenotype_list_row.html
+++ b/root/static/ng_templates/metagenotype_list_row.html
@@ -2,13 +2,13 @@
     <tr>
         <td>
           {{ getOrganismName('pathogen') | abbreviateGenus }}
-          <span class="metagenotype-list-strain">{{ getStrainName('pathogen') }}</span>
+          <span class="curs-strain-name-inline">{{ getStrainName('pathogen') }}</span>
         </td>
         <td>{{ metagenotype.pathogen_genotype.display_name }}</td>
         <td ng-if="showBackground.pathogen">{{ metagenotype.pathogen_genotype.background }}</td>
         <td>
           {{ getOrganismName('host') | abbreviateGenus }}
-          <span class="metagenotype-list-strain">{{ getStrainName('host') }}</span>
+          <span class="curs-strain-name-inline">{{ getStrainName('host') }}</span>
         </td>
         <td>{{ metagenotype.host_genotype.display_name }}</td>
         <td ng-if="showBackground.host">{{ metagenotype.host_genotype.background }}</td>

--- a/root/static/ng_templates/metagenotype_list_view.html
+++ b/root/static/ng_templates/metagenotype_list_view.html
@@ -11,10 +11,10 @@
                             <th></th>
                         </tr>
                         <tr>
-                            <th>Organism</th>
+                            <th>Species (strain)</th>
                             <th>Genotype</th>
                             <th ng-if="showBackground.pathogen">Background</th>
-                            <th>Organism</th>
+                            <th>Species (strain)</th>
                             <th>Genotype</th>
                             <th ng-if="showBackground.host">Background</th>
                             <th>Annotations</th>


### PR DESCRIPTION
References #2072 

This PR makes a few small changes to the metagenotype table on the Metagenotype Management page, in order to reduce the space used, and to make the styling more consistent with other annotation.

Note that this PR uses a new AngularJS filter called `abbreviateGenus` which is used to abbreviate the genus of a scientific name to a single character, for example: _Arapidopsis thaliana_ &rarr; _A. thaliana_. The annotation tables don't use this formatting yet, but there's another PR in the works that will implement that.

Before:

![image](https://user-images.githubusercontent.com/37659591/67274944-6e68cd80-f4b9-11e9-9f03-720dfc5a36e2.png)

After:

![image](https://user-images.githubusercontent.com/37659591/67205065-d1e5f300-f406-11e9-99f7-5483d7356120.png)


