### PR TITLE
Improvements to display of annotation tables (multi-organism)

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1080,11 +1080,6 @@ fieldset.curs-genes span {
 .curs-annotation-table {
   
 }
-
-.curs-annotation-row-strain {
-  white-space: nowrap
-}
-
 .curs-annotation-table .term-warning {
   color: #f00;
   font-weight: bold;

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1081,6 +1081,10 @@ fieldset.curs-genes span {
   
 }
 
+.curs-annotation-row-strain {
+  white-space: nowrap
+}
+
 .curs-annotation-table .term-warning {
   color: #f00;
   font-weight: bold;

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1412,11 +1412,6 @@ a.curs-editable-table-field img, a.curs-editable-table-long-field img
   font-style: italic;
 }
 
-.curs-annotation-table .organism-and-strain {
-/*  white-space: nowrap; */
-  font-weight: bold;
-}
-
 .screenshot {
   border: 1px solid black;
 }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6321,6 +6321,7 @@ var annotationTableCtrl =
         $scope.isActiveSession = isActiveSession($scope.curs_session_state);
 
         $scope.multiOrganismMode = false;
+        $scope.strainsMode = CantoGlobals.strains_mode;
 
         $scope.data = {};
 
@@ -6526,6 +6527,7 @@ var annotationTableRow =
         $scope.curs_root_uri = CantoGlobals.curs_root_uri;
         $scope.read_only_curs = CantoGlobals.read_only_curs;
         $scope.multiOrganismMode = false;
+        $scope.showStrain = $scope.strainsMode && $scope.annotationType.feature_type == 'genotype';
         $scope.sessionState = 'UNKNOWN';
 
         CursSessionDetails.get()

--- a/root/static/ng_templates/annotation_table.html
+++ b/root/static/ng_templates/annotation_table.html
@@ -28,8 +28,7 @@
         <table ng-switch-when="ontology" class="list">
           <thead>
             <tr>
-              <th ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">Organism</th>
-              <th ng-if="multiOrganismMode && annotationType.feature_type === 'genotype'&& !data.hideColumns.strain_name">Strain</th>
+              <th ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">Organism (strain)</th>
               <th ng-if="annotationType.feature_type == 'genotype'">Genes</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_background">Background</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_name">Genotype name</th>

--- a/root/static/ng_templates/annotation_table.html
+++ b/root/static/ng_templates/annotation_table.html
@@ -28,7 +28,7 @@
         <table ng-switch-when="ontology" class="list">
           <thead>
             <tr>
-              <th ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">Species (strain)</th>
+              <th ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">Species<span ng-if="strainsMode && annotationType.feature_type === 'genotype'"> (strain)</span></th>
               <th ng-if="annotationType.feature_type == 'genotype'">Genes</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_background">Background</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_name">Genotype name</th>

--- a/root/static/ng_templates/annotation_table.html
+++ b/root/static/ng_templates/annotation_table.html
@@ -28,7 +28,7 @@
         <table ng-switch-when="ontology" class="list">
           <thead>
             <tr>
-              <th ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">Organism (strain)</th>
+              <th ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">Species (strain)</th>
               <th ng-if="annotationType.feature_type == 'genotype'">Genes</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_background">Background</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_name">Genotype name</th>

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -1,6 +1,6 @@
 <tr ng-class="{ 'curs-row-checked' : sessionState == 'APPROVAL_IN_PROGRESS' && checked == 'yes' }">
   <td ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">
-    {{annotation.organism.scientific_name | abbreviateGenus}}<span class="curs-strain-name-inline" ng-if="showStrain"> ({{annotation.strain_name}})</span>
+    <span class="organism-name">{{annotation.organism.scientific_name | abbreviateGenus}}</span><span class="curs-strain-name-inline" ng-if="showStrain"> ({{annotation.strain_name}})</span>
   </td>
   <td ng-if="annotationType.feature_type == 'genotype'">
     <div style="white-space: nowrap" ng-repeat="locus in displayLoci">

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -1,6 +1,6 @@
 <tr ng-class="{ 'curs-row-checked' : sessionState == 'APPROVAL_IN_PROGRESS' && checked == 'yes' }">
   <td ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">
-    {{annotation.organism.scientific_name}}<span class="curs-strain-name-inline" ng-if="showStrain"> ({{annotation.strain_name}})</span>
+    {{annotation.organism.scientific_name | abbreviateGenus}}<span class="curs-strain-name-inline" ng-if="showStrain"> ({{annotation.strain_name}})</span>
   </td>
   <td ng-if="annotationType.feature_type == 'genotype'">
     <div style="white-space: nowrap" ng-repeat="locus in displayLoci">
@@ -10,14 +10,14 @@
   <td ng-if="annotationType.feature_type == 'metagenotype'">
     <div ng-bind-html="annotation.pathogen_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></div>
     <div class="organism-and-strain">
-      <span class="organism-name">{{annotation.pathogen_genotype.organism.scientific_name}}</span>
+      <span class="organism-name">{{annotation.pathogen_genotype.organism.scientific_name | abbreviateGenus}}</span>
       <span ng-if="annotation.pathogen_genotype.strain_name">({{annotation.pathogen_genotype.strain_name}})</span>
     </div>
   </td>
   <td ng-if="annotationType.feature_type == 'metagenotype'">
     <div ng-bind-html="annotation.host_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></div>
     <div class="organism-and-strain">
-      <span class="organism-name">{{annotation.host_genotype.organism.scientific_name}}</span>
+      <span class="organism-name">{{annotation.host_genotype.organism.scientific_name | abbreviateGenus}}</span>
       <span ng-if="annotation.host_genotype.strain_name">({{annotation.host_genotype.strain_name}})</span>
     </div>
   </td>

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -11,14 +11,14 @@
     <div ng-bind-html="annotation.pathogen_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></div>
     <div>
       <span class="organism-name">{{annotation.pathogen_genotype.organism.scientific_name | abbreviateGenus}}</span>
-      <span ng-if="annotation.pathogen_genotype.strain_name">({{annotation.pathogen_genotype.strain_name}})</span>
+      <span ng-if="annotation.pathogen_genotype.strain_name" class="curs-strain-name-inline">({{annotation.pathogen_genotype.strain_name}})</span>
     </div>
   </td>
   <td ng-if="annotationType.feature_type == 'metagenotype'">
     <div ng-bind-html="annotation.host_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></div>
     <div>
       <span class="organism-name">{{annotation.host_genotype.organism.scientific_name | abbreviateGenus}}</span>
-      <span ng-if="annotation.host_genotype.strain_name">({{annotation.host_genotype.strain_name}})</span>
+      <span ng-if="annotation.host_genotype.strain_name" class="curs-strain-name-inline">({{annotation.host_genotype.strain_name}})</span>
     </div>
   </td>
   <td ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_background">

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -1,9 +1,6 @@
 <tr ng-class="{ 'curs-row-checked' : sessionState == 'APPROVAL_IN_PROGRESS' && checked == 'yes' }">
   <td ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">
-    {{annotation.organism.scientific_name}}
-  </td>
-  <td ng-if="multiOrganismMode && annotationType.feature_type === 'genotype' && !data.hideColumns.strain_name">
-    {{annotation.strain_name}}
+    {{annotation.organism.scientific_name}}<span class="curs-annotation-row-strain" ng-if="showStrain"> ({{annotation.strain_name}})</span>
   </td>
   <td ng-if="annotationType.feature_type == 'genotype'">
     <div style="white-space: nowrap" ng-repeat="locus in displayLoci">

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -9,14 +9,14 @@
   </td>
   <td ng-if="annotationType.feature_type == 'metagenotype'">
     <div ng-bind-html="annotation.pathogen_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></div>
-    <div class="organism-and-strain">
+    <div>
       <span class="organism-name">{{annotation.pathogen_genotype.organism.scientific_name | abbreviateGenus}}</span>
       <span ng-if="annotation.pathogen_genotype.strain_name">({{annotation.pathogen_genotype.strain_name}})</span>
     </div>
   </td>
   <td ng-if="annotationType.feature_type == 'metagenotype'">
     <div ng-bind-html="annotation.host_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></div>
-    <div class="organism-and-strain">
+    <div>
       <span class="organism-name">{{annotation.host_genotype.organism.scientific_name | abbreviateGenus}}</span>
       <span ng-if="annotation.host_genotype.strain_name">({{annotation.host_genotype.strain_name}})</span>
     </div>

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -1,6 +1,6 @@
 <tr ng-class="{ 'curs-row-checked' : sessionState == 'APPROVAL_IN_PROGRESS' && checked == 'yes' }">
   <td ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">
-    {{annotation.organism.scientific_name}}<span class="curs-annotation-row-strain" ng-if="showStrain"> ({{annotation.strain_name}})</span>
+    {{annotation.organism.scientific_name}}<span class="curs-strain-name-inline" ng-if="showStrain"> ({{annotation.strain_name}})</span>
   </td>
   <td ng-if="annotationType.feature_type == 'genotype'">
     <div style="white-space: nowrap" ng-repeat="locus in displayLoci">


### PR DESCRIPTION
References #2037

This PR makes several changes to how the annotation tables are displayed in multi-organism / pathogen-host mode:

* merge the 'Strain' column with the 'Organism' column, and rename the column to 'Species (strain)';
* remove bold styling on organism and strain names;
* apply italic formatting to scientific names;
* ensure that strain names do not wrap, to prevent silly line breaks after a hyphen (in PH-1, for example).
  * Note I did this by applying the `inline-block` display mode to the `<span>` that holds the strain; if this disables any wrapping on long multi-word strains, that might not be ideal. Perhaps a better fix is to use pre-processing in the controller (or a filter) to substitute punctuation for their non-breaking variants, where possible.

