### PR TITLE
Simplify headers and text on metagenotype page

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1654,4 +1654,9 @@ a:not([href]) {
 }
 .curs-genotype-picker {
   padding-top: 10px;
-} 
+}
+.curs-metagenotype-picker-heading {
+  display: inline-block;
+  font-weight: 700;
+  margin-bottom: 10px;
+}

--- a/root/static/ng_templates/genotype_simple_list_view.html
+++ b/root/static/ng_templates/genotype_simple_list_view.html
@@ -4,7 +4,6 @@
       <thead>
         <tr>
           <th ng-if="showCheckBoxActions" class="curs-genotype-checkbox-column" rowspan="2">&nbsp;</th>
-          <th style="border-bottom: 1px solid grey" colspan="{{showBackground ? 5 : 4}}">Genotype</th>
         </tr>
         <tr>
           <th>Genes</th>

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -1,7 +1,9 @@
 <div class="curs-genotype-picker">
     <div ng-if="selectedOrganism">
         <div ng-show="genotypes.single.length > 0">
-            <div class="curs-box-title">Single locus genotypes</div>
+            <div class="curs-genotype-list-instructions curs-genotype-list-view-no-checkbox">
+                <span>Single locus genotypes</span>
+            </div>
             <genotype-simple-list-view
                 genotype-list="genotypes.single"
                 is-host="isHost"
@@ -11,7 +13,9 @@
         </div>
 
         <div ng-show="genotypes.multi.length > 0">
-            <div class="curs-box-title">Multi-allele genotypes</div>
+            <div class="curs-genotype-list-instructions curs-genotype-list-view-no-checkbox">
+                <span>Multi allele genotypes</span>
+            </div>
             <genotype-simple-list-view
                 genotype-list="genotypes.multi"
                 is-host="isHost"
@@ -21,7 +25,9 @@
         </div>
 
         <div ng-if="isHost">
-            <div class="curs-box-title">Wildtype genotype</div>
+            <div class="curs-genotype-list-instructions curs-genotype-list-view-no-checkbox">
+                <span>Wild-type genotypes</span>
+            </div>
             <wild-genotype-view
                 strains="data.wildTypeStrains"
                 show-check-box-actions="true"

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -1,7 +1,7 @@
 <div id="curs-genotype-manage" class="genotype-list ng-cloak container">
     <div class="row" ng-if="display">
         <div class="col-md-6">
-            <div class="curs-box-title" style="margin-bottom: 10px;">Pathogen Genotypes</div>
+            <div class="curs-metagenotype-picker-heading">Pathogen</div>
             <organism-selector
                 organisms="pathogenOrganisms"
                 organism-selected="onPathogenSelected(organism)">
@@ -14,7 +14,7 @@
             </metagenotype-genotype-picker>
         </div>
         <div class="col-md-6">
-            <div class="curs-box-title" style="margin-bottom: 10px;">Host Genotypes</div>
+            <div class="curs-metagenotype-picker-heading">Host</div>
             <organism-selector
                 organisms="hostOrganisms"
                 organism-selected="onHostSelected(organism)">

--- a/root/static/ng_templates/wild_genotype_view.html
+++ b/root/static/ng_templates/wild_genotype_view.html
@@ -6,7 +6,7 @@
           <th ng-if="showCheckBoxActions" class="curs-genotype-checkbox-column" rowspan="2">&nbsp;</th>
         </tr>
         <tr>
-          <th>Strain used</th>
+          <th>Strain</th>
         </tr>
       </thead>
       <tbody


### PR DESCRIPTION
Fixes #2053

This pull request simplifies the display of table headers on the Metagenotype Management page. It also removes the 'Genotype' table header group (since it's not required to contrast with the Annotation column), and changes some text to be more consistent with other text in Canto.

![image](https://user-images.githubusercontent.com/37659591/68398586-e5b28880-016c-11ea-91be-3a6a9f63b6c8.png)