### PR TITLE
Add organism name after genes in feature chooser

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -380,10 +380,12 @@ function symbolEncoder() {
 canto.filter('encodeAlleleSymbols', symbolEncoder);
 canto.filter('encodeGeneSymbols', symbolEncoder);
 
-
-canto.filter('featureChooserFilter', function () {
+canto.filter('featureChooserFilter', ['CantoGlobals', function (CantoGlobals) {
   return function (feature) {
     var ret = feature.display_name;
+    if (feature.gene_id && CantoGlobals.multi_organism_mode) {
+      ret += " (" + feature.organism.full_name + ")";
+    }
     if (feature.background) {
       ret += "  (bkg: " + feature.background.substr(0, 15);
       if (feature.background.length > 15) {
@@ -400,7 +402,7 @@ canto.filter('featureChooserFilter', function () {
     }
     return ret;
   };
-});
+}]);
 
 canto.filter('renameGenotypeType', function () {
   return function (type) {


### PR DESCRIPTION
(Temporary fix for #2101)

This pull request appends organism names to genes in the feature chooser when in multi-organism mode (and pathogen-host mode). That makes it possible to tell the difference between two or more genes with the same name from different organisms.

This is intended to be a temporary fix until we can implement organism selectors into the workflow so that the gene lists can always be filtered by organism.

Here's how it looks:

![image](https://user-images.githubusercontent.com/37659591/68768752-04a49500-061b-11ea-9a0d-b3b19c0350d5.png)


- - -

@kimrutherford I'm not able to test this on single organism mode because my database fails when trying to upgrade to schema version 30 or 31 (not sure which). The error's below:

```
upgrading to version 30
DBIx::Class::Storage::DBI::_prepare_sth(): DBI Exception: DBD::SQLite::db 
prepare_cached failed: no such table: allele_note [for Statement "DELETE FROM 
allele_note WHERE ( allele_note_id IN ( SELECT allele_notes.allele_note_id 
FROM allele me  JOIN allele_note allele_notes ON allele_notes.allele = 
me.allele_id WHERE ( allele_id NOT IN (SELECT allele FROM allele_genotype) ) 
) )"] at lib/Canto/Curs/GenotypeManager.pm line 232
```
In the meantime, do you think you could test this change to make sure the gene names don't appear in the drop-down in single organism mode?