### PR TITLE
Rename 'Unknown strain used' to 'Unknown strain'

### DIFF
--- a/root/static/ng_templates/strainPicker.html
+++ b/root/static/ng_templates/strainPicker.html
@@ -15,7 +15,7 @@
                 <option>Type a new strain</option>
             </optgroup>
             <optgroup label="-----------------------------">
-                <option>Unknown strain used</option>
+                <option>Unknown strain</option>
             </optgroup>
             <optgroup label="-----------------------------">
                 <option ng-repeat="st in data.strains track by $index">{{st.strain_name}}</option>


### PR DESCRIPTION
Fixes #2072

This pull request renames the strain picker option for unknown strains from 'Unknown strain used' to 'Unknown strain'.

Even though this is a minor change, I don't want to push it because I'm not sure if PHI-Canto is the only instance that uses strains mode: if this change is implemented without changing the existing strain names in the database first, then Canto will have two names for the same concept ('Unknown strain used' and 'Unknown strain'), which could cause issues for anyone relying on unknown strains being named a certain (consistent) way.