### PR TITLE
Move Physical Interaction link to gene page

### DIFF
--- a/root/curs/front_page_quick_links.mhtml
+++ b/root/curs/front_page_quick_links.mhtml
@@ -3,14 +3,14 @@
 </%args>
 
 % if (!$read_only_curs) {
-<div class="curs-box">
+<div ng-if="getAnnotationMode() == 'advanced'" class="curs-box">
   <div class="curs-box-title">
     Quick links
   </div>
   <div class="curs-box-body">
     <ul class="curs-quick-links-list">
 % for my $annotation_type (@annotation_type_list) {
-    <li ng-if="getAnnotationMode() == 'advanced' || '<% $annotation_type->{category} %>' == 'interaction'">
+    <li>
       <annotation-quick-add annotation-type-name="<% $annotation_type->{name} %>"
                             link-label="<% ucfirst($annotation_type->{display_name}) %>"
                             feature-type="<% $annotation_type->{feature_type} %>"

--- a/root/curs/gene_page.mhtml
+++ b/root/curs/gene_page.mhtml
@@ -23,14 +23,14 @@ Choose curation type for <% $gene->display_name() %>:
 %   my $type_display_name = $annotation_type->{display_name};
 %   if ($annotation_type->{feature_type} eq 'gene') {
 %    if ($annotation_type->{category} eq 'interaction') {
-%#    <li class="annotation-type">
-%#      <annotation-quick-add annotation-type-name="<% $annotation_type->{name} %>"
-%#                            feature-type="gene" feature-id="<% $gene->gene_id() %>"
-%#                            feature-display-name="<% $gene_proxy->display_name() %>"
-%#                            link-label="<% ucfirst $type_display_name %>">
-%#      </annotation-quick-add>
-%#      <help-icon key="<% $annotation_type->{name} . '_definition' %>"></help-icon>
-%#    </li>
+    <li class="annotation-type">
+      <annotation-quick-add annotation-type-name="<% $annotation_type->{name} %>"
+                            link-label="<% ucfirst($annotation_type->{display_name}) %>"
+                            feature-type="<% $annotation_type->{feature_type} %>"
+                            feature-taxon-id="">
+      </annotation-quick-add>
+      <help-icon key="<% $annotation_type->{name} . '_definition' %>"></help-icon>
+    </li>
 %    } else {
 %     my $action_path = "$curs_root_uri/feature/gene/annotate/$gene_id/" .
 %       "start/$annotation_type_name";


### PR DESCRIPTION
Fixes #2108 

This pull request moves the Physical Interaction link back to the gene page, so that it doesn't need to be permanently visible on the curation summary page. I think this makes sense now that physical interactions use genes again (instead of genotypes).

Note that the Physical Interaction link always uses the 'Quick Add' workflow style (the modal-based workflow) when on the gene page, unlike the other annotation types that have the option for a more guided workflow. As far as I know there isn't any guided workflow for physical interaction annotations.