### PR TITLE
Filter organisms by role in annotation dialog

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6371,13 +6371,13 @@ var annotationEditDialogCtrl =
 
     $scope.filteredOrganismPromise
       .then(function (organisms) {
-        if (organisms.length == 1) {
-          $scope.selectedOrganism = organisms[0];
-        }
         if (args.annotationTypeName === 'host_phenotype') {
           organisms = filterOrganisms(organisms, 'host');
         } else if (args.annotationTypeName === 'pathogen_phenotype') {
           organisms = filterOrganisms(organisms, 'pathogen');
+        }
+        if (organisms.length == 1) {
+          $scope.selectedOrganism = organisms[0];
         }
         $scope.organisms = organisms;
         return organisms;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6376,7 +6376,7 @@ var annotationEditDialogCtrl =
         } else if (args.annotationTypeName === 'pathogen_phenotype') {
           organisms = filterOrganisms(organisms, 'pathogen');
         }
-        if (organisms.length == 1) {
+        if (organisms.length === 1) {
           $scope.selectedOrganism = organisms[0];
         }
         $scope.organisms = organisms;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6374,6 +6374,11 @@ var annotationEditDialogCtrl =
         if (organisms.length == 1) {
           $scope.selectedOrganism = organisms[0];
         }
+        if (args.annotationTypeName === 'host_phenotype') {
+          organisms = filterOrganisms(organisms, 'host');
+        } else if (args.annotationTypeName === 'pathogen_phenotype') {
+          organisms = filterOrganisms(organisms, 'pathogen');
+        }
         $scope.organisms = organisms;
         return organisms;
       })


### PR DESCRIPTION
Fixes #2122 

This is a quick fix to filter the list of organisms by their pathogen/host role when creating a 'pathogen phenotype' or 'host phenotype' annotation using the Quick Links.

I haven't thoroughly tested this in other modes, but I think the conditions are so restrictive (exact matching on the annotation type name) that it shouldn't affect anything except PHI-Canto.

It would be nice if we had a more flexible way of testing whether an annotation type applied to pathogens or hosts (perhaps a config option analogous to the feature type), but we probably don't need to worry about that yet.