### PR TITLE
Handle read-only sessions in genotypeAndSummaryNavCtrl

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -9279,8 +9279,10 @@ var genotypeAndSummaryNav = function () {
 };
 
 var genotypeAndSummaryNavCtrl = function ($scope, CantoGlobals) {
-  $scope.summaryUrl = CantoGlobals.curs_root_uri;
-  $scope.genotypeManageUrl = CantoGlobals.curs_root_uri + '/' + getGenotypeManagePath($scope.role);
+  var readOnly = CantoGlobals.read_only_curs;
+  var readOnlyFragment = readOnly ? '/ro' : ''
+  $scope.summaryUrl = CantoGlobals.curs_root_uri + readOnlyFragment;
+  $scope.genotypeManageUrl = CantoGlobals.curs_root_uri + '/' + getGenotypeManagePath($scope.role) + readOnlyFragment;
 }
 
 canto.controller('genotypeAndSummaryNavCtrl', ['$scope', 'CantoGlobals', genotypeAndSummaryNavCtrl]);


### PR DESCRIPTION
Fixes #2074 

This pull request fixes an oversight in `genotypeAndSummaryNavCtrl` where the directive didn't account for the session being in read-only mode. I've tested this in single organism mode and there's no problems there.