### PR TITLE
Improvements to organism/gene confirmation layout

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1688,3 +1688,7 @@ a:not([href]) {
   text-align: center;
   white-space: nowrap;
 }
+.curs-strain-tag {
+  margin: 2px 2px 2px 0;
+  display: inline-block;
+}

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1674,3 +1674,17 @@ a:not([href]) {
   font-weight: 700;
   margin-bottom: 10px;
 }
+.curs-strain-notice-container {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 10px;
+}
+.curs-strain-notice {
+  border-radius: 4px;
+  border: 3px solid #F6B26B;
+  display: inline-block;
+  font-size: 14.4px;
+  padding: 6px 12px;
+  text-align: center;
+  white-space: nowrap;
+}

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -9213,6 +9213,13 @@ var editOrganisms = function ($window, EditOrganismsSvc, StrainsService, CantoGl
       $scope.continueUrl = curs_root_uri;
       $scope.addGenesUrl = curs_root_uri + '/gene_upload/';
 
+      $scope.getStrainNoticeClass = function () {
+        if (! $scope.isContinueUrlDisabled()) {
+          return 'invisible';
+        }
+        return '';
+      };
+
       $scope.isContinueUrlDisabled = function () {
         if ($scope.getPathogens().length == 0 &&
           $scope.getHosts().length == 0) {

--- a/root/static/ng_templates/edit_organisms.html
+++ b/root/static/ng_templates/edit_organisms.html
@@ -1,6 +1,9 @@
 <div>
   <edit-organisms-table title="Pathogen genes" organisms="getPathogens"></edit-organisms-table>
   <edit-organisms-table title="Host genes" organisms="getHosts"></edit-organisms-table>
+  <div ng-class="getStrainNoticeClass()" class="curs-strain-notice-container">
+    <span class="curs-strain-notice">Specify strains for all organisms before continuing.</span>
+  </div>
   <div class="submit">
     <a href="{{addGenesUrl}}" class="btn btn-primary">Add more genes and organisms</a>&nbsp;
     <button ng-click="goToSummaryPage()" ng-disabled="isContinueUrlDisabled()" class="btn btn-primary" title="{{ getContinueButtonTitle() }}">Continue</a>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -22,7 +22,7 @@
       <tbody ng-repeat="o in organisms() track by o.taxonid">
         <tr>
           <td rowspan="{{ o.genes.length === 0 ? 1 : o.genes.length }}">
-            <b>{{ o.scientific_name }}</b> <span ng-if="o.common_name">({{ o.common_name }})</span> [{{ o.taxonid }}]
+            <b>{{ o.scientific_name }}</b>
           </td>
           <td ng-if="o.genes.length > 0">{{ firstGene(o.genes).systematic_identifier }}</td>
           <td ng-if="o.genes.length > 0">{{ firstGene(o.genes).name }}</td>

--- a/root/static/ng_templates/edit_organisms_table.html
+++ b/root/static/ng_templates/edit_organisms_table.html
@@ -22,7 +22,7 @@
       <tbody ng-repeat="o in organisms() track by o.taxonid">
         <tr>
           <td rowspan="{{ o.genes.length === 0 ? 1 : o.genes.length }}">
-            <b>{{ o.scientific_name }}</b>
+            <i>{{ o.scientific_name }}</i>
           </td>
           <td ng-if="o.genes.length > 0">{{ firstGene(o.genes).systematic_identifier }}</td>
           <td ng-if="o.genes.length > 0">{{ firstGene(o.genes).name }}</td>

--- a/root/static/ng_templates/strainPicker.html
+++ b/root/static/ng_templates/strainPicker.html
@@ -1,7 +1,7 @@
 <div>
   <div ng-if="data.sessionStrains && data.strains">
     <div>
-        <span ng-repeat="st in data.sessionStrains track by $index" class="btn-primary btn-xs" style="margin: 2px; float: left;">
+        <span ng-repeat="st in data.sessionStrains track by $index" class="curs-strain-tag btn-primary btn-xs">
             <span style="cursor: pointer;"
             ng-click="remove(st.strain_name)">{{st.strain_name}} <span style="color: red;">x</span></span>
         </span>

--- a/root/static/ng_templates/strainPicker.html
+++ b/root/static/ng_templates/strainPicker.html
@@ -9,7 +9,7 @@
     <div style="width:280px;">
         <select ng-model="data.strainSelector" ng-change="changed()">
             <optgroup>
-                <option value="">Add experimental strains for this organism</option>
+                <option value="">Add experimental strains</option>
             </optgroup>
             <optgroup label="-----------------------------">
                 <option>Type a new strain</option>


### PR DESCRIPTION
Fixes #2055

This pull request makes multiple small changes to the organism and gene confirmation page (pathogen-host mode only) to remove some unnecessary information:

* remove the synonyms column,
* remove organism common names and taxon identifiers,
* simplify placeholder text for the strain picker, and
* add a more conspicuous notice to the page for when the user still needs to select strains.

Here's how the organism table looks now:

![image](https://user-images.githubusercontent.com/37659591/69725541-561e4b00-1116-11ea-904c-7cf17da1bb68.png)

And here's an example of the message that prompts the user to add strains:

![image](https://user-images.githubusercontent.com/37659591/69725674-954c9c00-1116-11ea-927f-fa4161fcc0e5.png)

Note that I chose to set the `visibility` of the message to `hidden` (rather than using `ng-hide`) when it doesn't need to show, because I thought it disturbed the layout too much when the message was being removed from the layout when the strains were changed.