### PR TITLE
Give more width to gene list column on summary page

### DIFF
--- a/root/curs/front.mhtml
+++ b/root/curs/front.mhtml
@@ -13,7 +13,7 @@ $total_annotation_count
 <div ng-controller="CursFrontPageCtrl" id="curs-front-page">
 <div>
   <div class="row">
-    <div class="curs-front-gene-list col-sm-4 col-md-4">
+    <div class="curs-front-gene-list col-sm-5 col-md-5">
 <& /curs/front_gene_section.mhtml, pub => $pub &>
     </div>
 % if (!$read_only_curs) {
@@ -21,7 +21,7 @@ $total_annotation_count
 <& /curs/front_page_quick_links.mhtml, annotation_type_list => \@annotation_type_list &>
     </div>
 % }
-    <div class="curs-front-pub-details col-sm-5 col-md-5">
+    <div class="curs-front-pub-details col-sm-4 col-md-4">
 <& /pub_details.mhtml, pub => $pub &>
    </div>
   </div>

--- a/root/pub_details.mhtml
+++ b/root/pub_details.mhtml
@@ -6,6 +6,7 @@ $pub
   <div class="curs-box-title">
 Publication details
   </div>
+  <& /linkouts.mhtml, object => $pub, context => 'pub' &>
   <div class="curs-box-body">
 <& /pub_details_contents.mhtml, pub => $pub &>
   </div>

--- a/root/pub_details_contents.mhtml
+++ b/root/pub_details_contents.mhtml
@@ -2,7 +2,6 @@
 $pub
 </%args>
 
-<& /linkouts.mhtml, object => $pub, context => 'pub' &>
 <table class="curs-definition-table">
   <tr>
     <td class="title"><% $uniquename_desc %></td>


### PR DESCRIPTION
Fixes #2140 

I've made some changes to ensure that the gene column (on the summary page) should have enough width to display as a two-column layout, even when using particularly long organism names (e.g.  _Parastagonospora nodorum_). Specific changes include:

* increase the column width of the gene list on the summary page; 
* narrow the Publication Details column; 
* move the PubMed link-out to be vertically aligned with the title of the section (using spare white space), rather than floated to the right of the whole section.

Note that the changes affect every version of Canto, even though the change probably won't be necessary in single-organism mode.

Here's how the new layout will look:

![image](https://user-images.githubusercontent.com/37659591/70142832-11ecf680-1692-11ea-9002-03341b39bdf2.png)
