### PR TITLE
Disable host genotype link until hosts are added

### DIFF
--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -174,7 +174,7 @@ sub top : Chained('/') PathPart('curs') CaptureArgs(1)
   $st->{edit_organism_page_valid} = 0;
 
   if ($st->{pathogen_host_mode}) {
-    ($st->{show_metagenotype_links}, $st->{edit_organism_page_valid}) =
+    ($st->{show_metagenotype_links}, $st->{show_host_genotype_link}, $st->{edit_organism_page_valid}) =
       _metagenotype_flags($config, $schema);
   }
 
@@ -368,7 +368,7 @@ sub _metagenotype_flags
     }
   }
 
-  return ($has_pathogen_genotypes && $has_host, $organism_page_valid);
+  return ($has_pathogen_genotypes && $has_host, $has_host, $organism_page_valid);
 };
 
 sub _set_genes_in_session

--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -65,7 +65,13 @@ Annotate genotypes
     <a href="<% $pathogen_genotype_manage_url %>"><% $read_only_curs ? 'View pathogen genotypes' : 'Pathogen genotype management' %></a>
   </div>
   <div class="feature-list-action">
+% if ($show_host_genotype_link) {
     <a href="<% $host_genotype_manage_url %>"><% $read_only_curs ? 'View host genotypes' : 'Host genotype management' %></a>
+% } else {
+    <span style="color: #888" title="Add at least one host organism to make a host genotype">
+      <% $read_only_curs ? 'View host genotypes' : 'Host genotype management' %>
+    </span>
+% }
   </div>
   <div class="feature-list-action">
 % if ($show_metagenotype_links) {
@@ -99,6 +105,7 @@ my $multi_organism_mode = $st->{multi_organism_mode};
 my $pathogen_host_mode = $st->{pathogen_host_mode};
 
 my $show_metagenotype_links = $st->{show_metagenotype_links};
+my $show_host_genotype_link = $st->{show_host_genotype_link};
 
 my $service_utils = Canto::Curs::ServiceUtils->new(curs_schema => $schema, config => $config);
 


### PR DESCRIPTION
Fixes #2148 

This PR disables the Host genotype management link on the summary page when there are no hosts in the session.

I changed the `_metagenotype_flags` subroutine in `lib/Canto/Controller/Curs.pm` so that it also returns the `$has_host` variable (rather than only using the variable to test if the metagenotype link should be enabled). That means that the subroutine isn't really accurately named anymore, since it doesn't relate only to metagenotypes. I don't know whether it would be better to rename the subroutine, or to extract the genotype link flag setting into a different subroutine.

Also, I didn't update the tests for this module, because I wasn't sure where to find them (or if there even are any tests for this functionality). I'm just going to open the PR and see what Travis-CI says.