### PR TITLE
Disable links when genes/genotypes are missing

### DIFF
--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -174,7 +174,10 @@ sub top : Chained('/') PathPart('curs') CaptureArgs(1)
   $st->{edit_organism_page_valid} = 0;
 
   if ($st->{pathogen_host_mode}) {
-    ($st->{show_metagenotype_links}, $st->{show_host_genotype_link}, $st->{edit_organism_page_valid}) =
+    ($st->{show_metagenotype_links}, $st->{show_host_genotype_link},
+     $st->{show_pathogen_genotype_link},
+     $st->{has_host_genotypes}, $st->{has_pathogen_genotypes},
+     $st->{edit_organism_page_valid}) =
       _metagenotype_flags($config, $schema);
   }
 
@@ -342,6 +345,8 @@ sub _metagenotype_flags
   my $rs = $schema->resultset('Organism');
 
   my $has_host = 0;
+  my $has_pathogen_genes = 0;
+  my $has_host_genotypes = 0;
   my $has_pathogen_genotypes = 0;
 
   my $organism_page_valid = 1;
@@ -355,11 +360,17 @@ sub _metagenotype_flags
 
     if ($organism_details->{pathogen_or_host} eq 'host') {
       $has_host = 1;
+      if ($org->genotypes()->count() > 0) {
+        $has_host_genotypes = 1;
+      }
     }
 
     if ($organism_details->{pathogen_or_host} eq 'pathogen') {
       if ($org->genotypes()->count() > 0) {
         $has_pathogen_genotypes = 1;
+      }
+      if ($org->genes()->count() > 0) {
+        $has_pathogen_genes = 1;
       }
     }
 
@@ -368,7 +379,9 @@ sub _metagenotype_flags
     }
   }
 
-  return ($has_pathogen_genotypes && $has_host, $has_host, $organism_page_valid);
+  return ($has_pathogen_genotypes && $has_host, $has_host,
+          $has_pathogen_genes, $has_host_genotypes, $has_pathogen_genotypes,
+          $organism_page_valid);
 };
 
 sub _set_genes_in_session

--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -62,7 +62,13 @@ Annotate genotypes
   </div>
 %   if ($pathogen_host_mode) {
   <div class="feature-list-action">
+% if ($show_pathogen_genotype_link) {
     <a href="<% $pathogen_genotype_manage_url %>"><% $read_only_curs ? 'View pathogen genotypes' : 'Pathogen genotype management' %></a>
+% } else {
+    <span style="color: #888" title="Add at least one pathogen gene to the session to make a pathogen genotype">
+      <% $read_only_curs ? 'View pathogen genotypes' : 'Pathogen genotype management' %>
+    </span>
+% }
   </div>
   <div class="feature-list-action">
 % if ($show_host_genotype_link) {
@@ -106,6 +112,7 @@ my $pathogen_host_mode = $st->{pathogen_host_mode};
 
 my $show_metagenotype_links = $st->{show_metagenotype_links};
 my $show_host_genotype_link = $st->{show_host_genotype_link};
+my $show_pathogen_genotype_link = $st->{show_pathogen_genotype_link};
 
 my $service_utils = Canto::Curs::ServiceUtils->new(curs_schema => $schema, config => $config);
 

--- a/root/curs/front_page_quick_links.mhtml
+++ b/root/curs/front_page_quick_links.mhtml
@@ -10,13 +10,22 @@
   <div class="curs-box-body">
     <ul class="curs-quick-links-list">
 % for my $annotation_type (@annotation_type_list) {
+%   my $feature_subtype = $annotation_type->{feature_subtype} || 'NONE';
+%   my $show_link = ($feature_subtype eq 'NONE' || $feature_subtype eq 'host' && $has_host_genotypes || $feature_subtype eq 'pathogen' && $has_pathogen_genotypes) ? 'true' : 'false';
+
     <li ng-if="getAnnotationMode() == 'advanced' || '<% $annotation_type->{category} %>' == 'interaction' && '<% $annotation_type->{feature_type} %>' == 'metagenotype'">
-      <annotation-quick-add annotation-type-name="<% $annotation_type->{name} %>"
+      <annotation-quick-add ng-if="<% $show_link %>"
+                            annotation-type-name="<% $annotation_type->{name} %>"
                             link-label="<% ucfirst($annotation_type->{display_name}) %>"
                             feature-type="<% $annotation_type->{feature_type} %>"
                             feature-taxon-id="">
       </annotation-quick-add>
+      <span ng-if="!<% $show_link %>" style="color: #888"
+            title="Add a <% $annotation_type->{feature_subtype} || '' %> genotype to make a phenotype annotation">
+        <% ucfirst $annotation_type->{display_name} %>
+      </span>
     </li>
+
 % }
     </ul>
   </div>
@@ -25,4 +34,7 @@
 
 <%init>
 my $read_only_curs = $c->stash()->{read_only_curs};
+
+my $has_host_genotypes = $c->stash()->{has_host_genotypes};
+my $has_pathogen_genotypes = $c->stash()->{has_pathogen_genotypes};
 </%init>


### PR DESCRIPTION
Disable host/pathogen phenotype Quick link when host/pathogen genotypes are
missing.  And disable pathogen gentype management link when there are no
pathogen genes.

Refs pombase/canto#2125