### PR TITLE
Disable host genotype link until host gene exists

### DIFF
--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -346,6 +346,7 @@ sub _metagenotype_flags
 
   my $has_host = 0;
   my $has_pathogen_genes = 0;
+  my $has_host_genes = 0;
   my $has_host_genotypes = 0;
   my $has_pathogen_genotypes = 0;
 
@@ -363,6 +364,9 @@ sub _metagenotype_flags
       if ($org->genotypes()->count() > 0) {
         $has_host_genotypes = 1;
       }
+      if ($org->genes()->count() > 0) {
+        $has_host_genes = 1;
+      }
     }
 
     if ($organism_details->{pathogen_or_host} eq 'pathogen') {
@@ -379,7 +383,7 @@ sub _metagenotype_flags
     }
   }
 
-  return ($has_pathogen_genotypes && $has_host, $has_host,
+  return ($has_pathogen_genotypes && $has_host, $has_host_genes,
           $has_pathogen_genes, $has_host_genotypes, $has_pathogen_genotypes,
           $organism_page_valid);
 };

--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -74,7 +74,7 @@ Annotate genotypes
 % if ($show_host_genotype_link) {
     <a href="<% $host_genotype_manage_url %>"><% $read_only_curs ? 'View host genotypes' : 'Host genotype management' %></a>
 % } else {
-    <span style="color: #888" title="Add at least one host organism to make a host genotype">
+    <span style="color: #888" title="Add at least one host gene to make a host genotype">
       <% $read_only_curs ? 'View host genotypes' : 'Host genotype management' %>
     </span>
 % }


### PR DESCRIPTION
Fixes #2059 

This pull request amends the condition that disables the Host genotype management link, so that it disables when there are no host genes, rather than no host organisms. This is to accommodate the case where a host has been added without genes (which is only possible for host organisms, not pathogens). It doesn't make sense to give access to the Host genotype management link when a genotype can't be created.