### PR TITLE
Allow autocomplete when suggestion list is open

### DIFF
--- a/root/static/js/tag-it.js
+++ b/root/static/js/tag-it.js
@@ -266,7 +266,8 @@
                         }
 
                         // Autocomplete will create its own tag from a selection and close automatically.
-                        if (!that.tagInput.data('autocomplete-open')) {
+                        if (!(that.options.autocomplete.autoFocus && that.tagInput.data('autocomplete-open'))) {
+                            that.tagInput.autocomplete('close');
                             that.createTag(that._cleanedInput());
                         }
                     }


### PR DESCRIPTION
(Fixes #2025, partial fix for #1846)

This is a small patch copied from the tag-it repository, which allows tags to be created when the autocomplete menu is still open.

@kimrutherford We could also apply this by updating tag-it to the latest source version, but I seem to remember you tried this before and it broke the widget. This patch seems to work fine, though. Let me know if you want me to try updating the whole file instead, since that might help fix the other problem in issue #1846.