### PR TITLE
Add a second org. selector for phys. interactions

### DIFF
--- a/root/docs/md/canto_admin/configuration_file.md
+++ b/root/docs/md/canto_admin/configuration_file.md
@@ -290,6 +290,11 @@ genotypes for the same locus selected in the genotype A list.
 For interactions, selecting a term is required if and only if this
 option is set to 1.
 
+### second_feature_organism_selector
+For interactions, if set the annotation dialog will have a independent
+organism selector for the second feature of the interaction.  Defaults
+to 0 (false).
+
 ### evidence_codes
 Possible evidence codes (or interaction types) for this annotation type.
 Each evidence code must

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6569,11 +6569,7 @@ var annotationEditDialogCtrl =
                 };
               filterFeatures(results, filterFunc);
 
-              if (annotationType.single_locus_only) {
-                $scope.filteredFeaturesB = null;
-              } else {
-                $scope.filteredFeaturesB = $scope.filteredFeatures;
-              }
+              $scope.filteredFeaturesB = $scope.filteredFeatures;
             });
           }).catch(function (err) {
             toaster.pop('note', "couldn't read the genotype list from the server");

--- a/root/static/ng_templates/annotation_edit.html
+++ b/root/static/ng_templates/annotation_edit.html
@@ -41,7 +41,6 @@
           <div ng-if="featureEditable && filteredFeatures">
             <feature-chooser feature-type="{{chooseFeatureType}}"
                              features="filteredFeatures"
-                             filter-organism="selectedOrganism"
                              chosen-feature-id="annotation.feature_id"></feature-chooser>
             <span ng-show="filteredFeatures.length != 0 && !annotation.feature_id"
                   class="help-block">Please select a {{chooseFeatureType}}</span>
@@ -128,6 +127,25 @@
         </td>
       </tr>
 
+      <tr ng-if="multiOrganismMode && annotationType.second_feature_organism_selector"
+          ng-class="{ 'has-error': !isValidOrganismB() }">
+        <td class="title">
+          Interacting organism
+        </td>
+        <td ng-if="!selectedOrganismB || featureEditable">
+          <organism-selector
+            organisms="organisms"
+            initial-selection-taxon-id="{{initialSelectedOrganismBId}}"
+            organism-selected="organismBSelected(organism)">
+          </organism-selector>
+          <span ng-show="!isValidOrganism()"
+                class="help-block">Please select an organism</span>
+        </td>
+        <td ng-if="selectedOrganismB && !featureEditable">
+          {{selectedOrganism.scientific_name}}
+        </td>
+      </tr>
+
       <tr ng-if="annotationType.category == 'interaction'"
           ng-class="{ 'has-error': !annotation.second_feature_id }">
         <td class="title">
@@ -140,7 +158,6 @@
           <div ng-if="filteredFeaturesB">
             <feature-chooser feature-type="{{chooseFeatureType}}"
                              features="filteredFeaturesB"
-                             filter-organism="selectedOrganism"
                              chosen-feature-id="annotation.second_feature_id"></feature-chooser>
             <span ng-show="filteredFeaturesB.length == 0 && annotationType && annotationType.interaction_same_locus">
               <span ng-show="annotationType.single_allele_only">


### PR DESCRIPTION
Hi @jseager7 

Here's my first attempt at fixing #2129

Could you try it out at some point?  You'll need to add `second_feature_organism_selector: 1` to your physical interaction configuration, like:

```yaml
   - name: physical_interaction
     category: interaction
     display_name: 'physical interaction'
     feature_type: 'gene'
     second_feature_organism_selector: 1
     help_text: 'Examples: co-purification, two-hybrid, affinity capture'
     evidence_codes:
       - Affinity Capture-Luminescence
       - Affinity Capture-MS
       - Affinity Capture-RNA
       - Affinity Capture-Western
...
```
