### PR TITLE
Fix experimental conditions not adding on blur

### DIFF
--- a/root/static/js/tag-it.js
+++ b/root/static/js/tag-it.js
@@ -274,7 +274,7 @@
                 }).blur(function(e){
                     // Create a tag when the element loses focus.
                     // If autocomplete is enabled and suggestion was clicked, don't add it.
-                    if (!that.tagInput.data('autocomplete-open')) {
+                    if (!that.tagInput.autocomplete('widget').find(".ui-menu-item a").hasClass("ui-state-focus")) {
                         that.createTag(that._cleanedInput());
                     }
                 });


### PR DESCRIPTION
Fixes #2162 

This is a one-line fix copied from an unmerged pull request (`https://github.com/aehlke/tag-it/pull/321`) on the tag-it repository. It ensures that any typed tags are always finished (added) when the user breaks focus on the widget's text field. I've tested the fix and haven't noticed any problems with it.

@kimrutherford I'm leaving this just for you to double-check, but feel free to squash-merge this if you don't notice any problems.
