### PR TITLE
Rename 'Back' button to 'Cancel' on gene upload page

### DIFF
--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -700,7 +700,7 @@ sub gene_upload : Chained('top') Args(0) Form
       map { [ $_, $_ ] } @{$c->config()->{curs_config}->{no_genes_reasons}} );
 
   if ($st->{gene_count} > 0) {
-    push @submit_buttons, "Back";
+    push @submit_buttons, "Cancel";
   } else {
     @no_genes_elements = (
       {
@@ -771,6 +771,9 @@ sub gene_upload : Chained('top') Args(0) Form
         if ($_ eq 'Continue') {
           $ret->{attributes}->{'ng-disabled'} = '!isValid()';
         }
+        if ($_ eq 'Cancel') {
+          $ret->{attributes}->{'class'} = 'btn btn-warning curs-finish-button button';
+        }
         $ret;
       } @submit_buttons),
         @no_genes_elements;
@@ -783,7 +786,7 @@ sub gene_upload : Chained('top') Args(0) Form
   $st->{form} = $form;
 
   if ($form->submitted()) {
-    if (defined $c->req->param('Back')) {
+    if (defined $c->req->param('Cancel')) {
       my $return_path = $form->param_value('return_path_input');
 
       if (defined $return_path && length $return_path > 0) {

--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -772,7 +772,7 @@ sub gene_upload : Chained('top') Args(0) Form
           $ret->{attributes}->{'ng-disabled'} = '!isValid()';
         }
         if ($_ eq 'Cancel') {
-          $ret->{attributes}->{'class'} = 'btn btn-warning curs-finish-button button';
+          $ret->{attributes}->{'class'} =~ s/btn-primary/btn-warning/;
         }
         $ret;
       } @submit_buttons),


### PR DESCRIPTION
Fixes #2181 

This PR changes the label of a navigation button on the gene upload page from 'Back' to 'Cancel', since the navigation doesn't navigate backwards in the workflow, it simply cancels adding genes.

The buttons are generated by `Curs.pm` in a very dynamic and generalised way; so this wasn't a simple case of editing a template. My changes involved adding a special override to the general button generation code that changes the style class when the button name equals 'Cancel'.

I think I've replaced all references to 'Back' in `sub gene_upload`, but I'm not certain. I'd appreciate some double-checking to make sure I haven't messed up any logic by accident.

**Suggestion:** It might be more maintainable to simply replace the substring `"btn-primary"` with `"btn-warning"` rather than setting the whole string ([see here](https://github.com/pombase/canto/compare/master...jseager7:2181-gene-page-cancel-button?expand=1#diff-a15d4a21daa64924f075539239ed6014R775)), but I wasn't sure of the best way to do this; I figure Perl has a lot of syntaxes for replacing text, and I'm not sure which is preferred.