### PR TITLE
Add shortcut to restart session approval on front page

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -1441,9 +1441,8 @@ var pubmedIdStart =
 
         $scope.restartApproval = function () {
           if ($scope.userIsAdmin) {
-            window.location.href =
-              CantoGlobals.application_root + '/curs/'
-              + $scope.data.results.sessions[0];
+            window.location.href = CantoGlobals.application_root + '/curs/'
+              + $scope.data.results.sessions[0]
               + '/restart_approval/';
           }
         };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -1383,7 +1383,7 @@ var pubmedIdStart =
           searchId: null,
           results: null,
         };
-        $scope.userIsAdmin = CantoGlobals.current_user_is_admin;
+        $scope.userIsAdmin = CantoGlobals.is_admin_user == "1";
         CantoConfig.get('public_mode')
           .then(function (data) {
             $scope.publicMode = data.value != "0";

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -1438,6 +1438,15 @@ var pubmedIdStart =
               CantoGlobals.application_root + '/tools/start/' + $scope.data.results.pub.uniquename;
           }
         };
+
+        $scope.restartApproval = function () {
+          if ($scope.userIsAdmin) {
+            window.location.href =
+              CantoGlobals.application_root + '/curs/'
+              + $scope.data.results.sessions[0];
+              + '/restart_approval/';
+          }
+        };
       }
     };
   };

--- a/root/static/ng_templates/pubmed_id_start.html
+++ b/root/static/ng_templates/pubmed_id_start.html
@@ -59,6 +59,11 @@
         <span ng-if="data.results.sessions.length > 0">View session</span>
         <span ng-if="data.results.sessions.length == 0">Continue</span>
       </button>
+      <button
+        ng-if="userIsAdmin && data.results.sessions.length > 0"
+        type="button"
+        class="btn btn-primary"
+        ng-click="restartApproval()">Restart approval</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #2186 

This pull request adds an extra button after searching for a publication in admin mode that provides a shortcut to restarting approval of a session:

![image](https://user-images.githubusercontent.com/37659591/73264725-53e67480-41cb-11ea-836b-27274ecd7289.png)

The link only shows if the user is an admin, and if the publication has a session assigned to it.

I noticed that `CantoGlobals.current_user_is_admin` isn't defined on the front page, so I swapped it out for `CantoGlobals.is_admin_user`, which is defined. Not sure if this indicates a wider problem that needs to be addressed.

Also, the new code doesn't check that the chosen session is actually in approval mode before restarting it, but as far as I can tell this doesn't make a difference, because for sessions that aren't in the correct mode, the link doesn't have any (obvious) effect anyway.

If you think that the extra check for `$scope.userIsAdmin` in `$scope.restartApproval` is needlessly paranoid, then I'm happy to remove it. The button doesn't even get included in the DOM if `$scope.userIsAdmin` is false (due to `ng-if`).