### PR TITLE
Prompt users to add at least one pathogen gene

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1686,12 +1686,12 @@ a:not([href]) {
   font-weight: 700;
   margin-bottom: 10px;
 }
-.curs-strain-notice-container {
+.curs-warning-container {
   display: flex;
   justify-content: flex-end;
   margin-bottom: 10px;
 }
-.curs-strain-notice {
+.curs-warning {
   border-radius: 4px;
   border: 3px solid #F6B26B;
   display: inline-block;

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1689,13 +1689,13 @@ a:not([href]) {
 .curs-warning-container {
   display: flex;
   justify-content: flex-end;
-  margin-bottom: 10px;
 }
 .curs-warning {
   border-radius: 4px;
   border: 3px solid #F6B26B;
   display: inline-block;
   font-size: 14.4px;
+  margin-bottom: 10px;
   padding: 6px 12px;
   text-align: center;
   white-space: nowrap;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -9272,6 +9272,10 @@ var editOrganisms = function ($window, EditOrganismsSvc, StrainsService, CantoGl
       $scope.continueUrl = curs_root_uri;
       $scope.addGenesUrl = curs_root_uri + '/gene_upload/';
 
+      $scope.pathogenGeneExists = function () {
+        return $scope.getPathogens().length > 0;
+      };
+
       $scope.getWarningVisibility = function () {
         if (! $scope.hasMissingStrains()) {
           return 'invisible';

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -9276,11 +9276,13 @@ var editOrganisms = function ($window, EditOrganismsSvc, StrainsService, CantoGl
         return $scope.getPathogens().length > 0;
       };
 
-      $scope.getWarningVisibility = function () {
-        if (! $scope.hasMissingStrains()) {
-          return 'invisible';
+      $scope.getWarningType = function () {
+        if (!$scope.pathogenGeneExists()) {
+          return 'gene';
         }
-        return '';
+        if ($scope.hasMissingStrains()) {
+          return 'strain';
+        }
       };
 
       $scope.hasMissingStrains = function() {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -9272,7 +9272,7 @@ var editOrganisms = function ($window, EditOrganismsSvc, StrainsService, CantoGl
       $scope.continueUrl = curs_root_uri;
       $scope.addGenesUrl = curs_root_uri + '/gene_upload/';
 
-      $scope.getStrainNoticeClass = function () {
+      $scope.getWarningVisibility = function () {
         if (! $scope.hasMissingStrains()) {
           return 'invisible';
         }

--- a/root/static/ng_templates/edit_organisms.html
+++ b/root/static/ng_templates/edit_organisms.html
@@ -1,8 +1,8 @@
 <div>
   <edit-organisms-table title="Pathogen genes" organisms="getPathogens"></edit-organisms-table>
   <edit-organisms-table title="Host genes" organisms="getHosts"></edit-organisms-table>
-  <div ng-class="getStrainNoticeClass()" class="curs-strain-notice-container">
-    <span class="curs-strain-notice">Specify strains for all organisms before continuing.</span>
+  <div ng-class="getWarningVisibility()" class="curs-warning-container">
+    <span class="curs-warning">Specify strains for all organisms before continuing.</span>
   </div>
   <div class="submit">
     <a href="{{addGenesUrl}}" class="btn btn-primary">Add more genes and organisms</a>&nbsp;

--- a/root/static/ng_templates/edit_organisms.html
+++ b/root/static/ng_templates/edit_organisms.html
@@ -1,8 +1,9 @@
 <div>
   <edit-organisms-table title="Pathogen genes" organisms="getPathogens"></edit-organisms-table>
   <edit-organisms-table title="Host genes" organisms="getHosts"></edit-organisms-table>
-  <div ng-class="getWarningVisibility()" class="curs-warning-container">
-    <span class="curs-warning">Specify strains for all organisms before continuing.</span>
+  <div ng-switch="getWarningType()" class="curs-warning-container">
+    <span ng-switch-when="gene" class="curs-warning">Add at least one pathogen gene before continuing.</span>
+    <span ng-switch-when="strain" class="curs-warning">Specify strains for all organisms before continuing.</span>
   </div>
   <div class="submit">
     <a href="{{addGenesUrl}}" class="btn btn-primary">Add more genes and organisms</a>&nbsp;


### PR DESCRIPTION
Fixes #2174

This PR extends commit https://github.com/pombase/canto/commit/eadc8141dad3696f75778dd7ad6cbd3eba19d2eb to also warn users to add a pathogen gene before they can start a curation session. The user isn't warned about missing strains until they've added a gene; that prevents a bug from before where users would be warned about missing strains despite having no way to add them.