### PR TITLE
Display metagenotype details as individual rows

### DIFF
--- a/root/curs/metagenotype_page.mhtml
+++ b/root/curs/metagenotype_page.mhtml
@@ -69,8 +69,13 @@ Details
 % } else {
           <td class="title">Genotype A</td>
 % }
-          <td><% $_unicode_allele_symbol->($interactor_a->{'genotype'}) | n %></td>
+          <td>
+            <a href="<% $genotype_link_a %>">
+              <% $_unicode_allele_symbol->($interactor_a->{'genotype'}) | n %>
+            </a>
+          </td>
         </tr>
+
         <tr>
 % if ($pathogen_host_mode) {
           <td class="title">Host</td>
@@ -95,7 +100,15 @@ Details
 % } else {
           <td class="title">Genotype B</td>
 % }
-          <td><% $_unicode_allele_symbol->($interactor_b->{'genotype'}) | n %></td>
+          <td>
+% if ($genotype_link_b) {
+            <a href="<% $genotype_link_b %>">
+% }
+              <% $_unicode_allele_symbol->($interactor_b->{'genotype'}) | n %>
+% if ($genotype_link_b) {
+            </a>
+% }
+          </td>
         </tr>
       </tbody>
     </table>
@@ -161,6 +174,9 @@ my $read_only_curs = $c->stash()->{read_only_curs};
 
 my $interactor_a = get_genotype_details($metagenotype->first_genotype());
 my $interactor_b = get_genotype_details($metagenotype->second_genotype());
+
+my $genotype_link_a = genotype_link($start_path, $metagenotype->first_genotype());
+my $genotype_link_b = genotype_link($start_path, $metagenotype->second_genotype());
 
 my $_unicode_allele_symbol = sub {
   my $text = shift;

--- a/root/curs/metagenotype_page.mhtml
+++ b/root/curs/metagenotype_page.mhtml
@@ -97,6 +97,8 @@ my @types_to_show = grep {
 } @annotation_type_list;
 
 my $start_path = $c->stash()->{curs_root_uri};
+my $pathogen_host_mode = $c->stash()->{pathogen_host_mode};
+my $strains_mode = $c->stash()->{strains_mode};
 my $read_only_curs = $c->stash()->{read_only_curs};
 
 my $_unicode_allele_symbol = sub {

--- a/root/curs/metagenotype_page.mhtml
+++ b/root/curs/metagenotype_page.mhtml
@@ -46,12 +46,56 @@ Details
     <table class="curs-definition-table">
       <tbody>
         <tr>
-          <td class="title">
-Description
-          </td>
-          <td>
-<% $_unicode_allele_symbol->($metagenotype->display_name($c->config())) |n %>
-          </td>
+% if ($pathogen_host_mode) {
+          <td class="title">Pathogen</td>
+% } else {
+          <td class="title">Organism A</td>
+% }
+          <td><% $interactor_a->{'organism'} %></td>
+        </tr>
+% if ($strains_mode) {
+        <tr>
+% if ($pathogen_host_mode) {
+          <td class="title">Pathogen strain</td>
+% } else {
+          <td class="title">Strain A</td>
+% }
+          <td><% $interactor_a->{'strain'} %></td>
+        </tr>
+% }
+        <tr>
+% if ($pathogen_host_mode) {
+          <td class="title">Pathogen genotype</td>
+% } else {
+          <td class="title">Genotype A</td>
+% }
+          <td><% $_unicode_allele_symbol->($interactor_a->{'genotype'}) | n %></td>
+        </tr>
+        <tr>
+% if ($pathogen_host_mode) {
+          <td class="title">Host</td>
+% } else {
+          <td class="title">Organism B</td>
+% }
+          <td><% $interactor_b->{'organism'} %></td>
+        </tr>
+% if ($strains_mode) {
+        <tr>
+% if ($pathogen_host_mode) {
+          <td class="title">Host strain</td>
+% } else {
+          <td class="title">Strain B</td>
+% }
+          <td><% $interactor_b->{'strain'} %></td>
+        </tr>
+% }
+        <tr>
+% if ($pathogen_host_mode) {
+          <td class="title">Host genotype</td>
+% } else {
+          <td class="title">Genotype B</td>
+% }
+          <td><% $_unicode_allele_symbol->($interactor_b->{'genotype'}) | n %></td>
         </tr>
       </tbody>
     </table>
@@ -100,6 +144,9 @@ my $start_path = $c->stash()->{curs_root_uri};
 my $pathogen_host_mode = $c->stash()->{pathogen_host_mode};
 my $strains_mode = $c->stash()->{strains_mode};
 my $read_only_curs = $c->stash()->{read_only_curs};
+
+my $interactor_a = get_genotype_details($metagenotype->first_genotype());
+my $interactor_b = get_genotype_details($metagenotype->second_genotype());
 
 my $_unicode_allele_symbol = sub {
   my $text = shift;

--- a/root/curs/metagenotype_page.mhtml
+++ b/root/curs/metagenotype_page.mhtml
@@ -71,6 +71,23 @@ Description
 </div>
 
 <%init>
+sub get_genotype_details {
+  my $genotype = shift;
+
+  my $config = $c->config();
+  my $org_lookup = Canto::Track::get_adaptor($config, 'organism');
+  my $strain_lookup = Canto::Track::get_adaptor($config, 'strain');
+
+  my $taxon_id = $genotype->organism()->taxonid();
+  my $strain = $genotype->strain();
+
+  return {
+    "organism" => $org_lookup->lookup_by_taxonid($taxon_id)->{scientific_name},
+    "strain" => $strain->lookup_strain_name($strain_lookup),
+    "genotype" => $genotype->display_name()
+  };
+}
+
 my $metagenotype_id = $metagenotype->metagenotype_id();
 
 my $st = $c->stash();

--- a/root/curs/metagenotype_page.mhtml
+++ b/root/curs/metagenotype_page.mhtml
@@ -132,6 +132,20 @@ sub get_genotype_details {
   };
 }
 
+sub genotype_link {
+  my $curs_root_uri = shift;
+  my $genotype = shift;
+
+  my $id = $genotype->feature_id();
+
+  my $alleles = $genotype->allele_string($c->config());
+
+  if ($alleles ne '') {
+    return $curs_root_uri . '/feature/genotype/view/' . $id;
+  }
+  return undef;
+}
+
 my $metagenotype_id = $metagenotype->metagenotype_id();
 
 my $st = $c->stash();


### PR DESCRIPTION
Fixes #2220 

This PR updates the 'Details' section on the Metagenotype Details page, so that it displays the properties of the metagenotype's constituent genotypes individually, rather than just displaying the display name for the metagenotype:

![2220-before-after](https://user-images.githubusercontent.com/37659591/73943995-b33e3600-48e9-11ea-998d-ba8b8ca09f00.png)

The new code also links to the genotype page for the constituent genotypes, but only if the genotype is not the wild-type genotype (the code checks for this by testing if `$genotype->allele_string()` is empty, but it might be better to have a property on `Genotype.pm` that stores whether the genotype has alleles or not).

The template reuses the `$_unicode_allele_symbol` subroutine to encode allele symbols in the details section.

In pathogen-host mode, the rows are titled as 'Pathogen' or 'Host', but when not in pathogen-host mode, the template will display Organism A, Organism B (and so on) instead. This means that the change is able to support multi-organism mode when needed:

![image](https://user-images.githubusercontent.com/37659591/73944118-f0a2c380-48e9-11ea-819a-4f6c7f3b1a9f.png)

Note that if `strain_mode` is not true, then the strain rows are hidden.

- - -

@kimrutherford This hasn't been manually tested in single-organism or multi-organism modes, but single-organism mode surely isn't applicable, and multi-organism mode I think can be simulated just by overriding the relevant configuration values (which I did).

Also, let me know if you're not keen on dumping all this logic in a template, rather than keeping it in a module somewhere. I was hoping it would be possible to pull more of the data out of the `$metagenotype` itself rather than resorting to using the lookup services, but if you're okay with that, then I am too.