### PR TITLE
Small improvements to genotype row actions

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -470,7 +470,6 @@ table.curs-genotype-list tbody {
 .curs-genotype-list-row-actions {
   border: 2px solid #bbb;
   padding: 3px;
-  font-size: 90%;
   z-index: 100;
   position: absolute;
   overflow: visible;

--- a/root/static/ng_templates/genotype_list_row_links.html
+++ b/root/static/ng_templates/genotype_list_row_links.html
@@ -1,8 +1,4 @@
 <div class="genotype-list-row-links">
-  <div ng-if="!read_only_curs">
-    <a ng-class="{disabled: genotypeId == null }"
-       ng-click="editBackground(genotypeId)">Add/edit background</a>
-  </div>
   <div ng-repeat="annotationType in matchingAnnotationTypes">
     <a ng-class="{disabled: genotypeId == null }" ng-if="!read_only_curs"
        href="{{curs_root_uri + '/feature/genotype/annotate/' + genotypeId + '/start/' + annotationType.name + '/'}}">

--- a/root/static/ng_templates/genotype_list_row_links.html
+++ b/root/static/ng_templates/genotype_list_row_links.html
@@ -9,17 +9,6 @@
       Start a {{ annotationType.display_name }} annotation
     </a>
   </div>
-  <div>
-    <a ng-class="{disabled: genotypeId == null }" href="{{viewAnnotationUri}}">
-      View annotations
-    </a>
-  </div>
-  <div>
-    <a confirm="This genotype has existing annotations.  Really edit?"
-       confirm-if="annotationCount > 0"
-       ng-class="{disabled: genotypeId == null }" ng-if="!read_only_curs"
-       ng-click="editGenotype(genotypeId)">Edit details</a>
-  </div>
   <div ng-if="!read_only_curs">
     <a ng-show="alleleCount == 1"
       ng-class="{disabled: genotypeId == null }"
@@ -27,6 +16,21 @@
     <a ng-show="alleleCount != 1"
       ng-class="{disabled: genotypeId == null }"
       href="{{curs_root_uri + '/' + genotypeManagePath + '#/duplicate/' + genotypeId}}">Copy and edit</a>
+  </div>
+  <div>
+    <a confirm="This genotype has existing annotations.  Really edit?"
+       confirm-if="annotationCount > 0"
+       ng-class="{disabled: genotypeId == null }" ng-if="!read_only_curs"
+       ng-click="editGenotype(genotypeId)">Edit details</a>
+  </div>
+  <div>
+    <a ng-class="{disabled: genotypeId == null }" href="{{viewAnnotationUri}}">
+      View annotations
+    </a>
+  </div>
+  <div ng-if="!read_only_curs">
+    <a ng-class="{disabled: genotypeId == null }"
+       ng-click="editBackground(genotypeId)">Add/edit background</a>
   </div>
   <div ng-if="showNotesLink()">
     <a ng-class="{disabled: genotypeId == null }"


### PR DESCRIPTION
Related: #1945 

This pull request changes the actions popup on genotype tables, specifically:

* increases the font size to match Canto's table data; and

* reorders the actions in the list so that the more frequently-used actions are closer to the top.

![image](https://user-images.githubusercontent.com/37659591/73947010-b982e100-48ee-11ea-8de3-c5191fb89029.png)

@ValWood I've followed your suggestion to place 'Copy and Edit' and 'Edit' as the second and third items in the list (respectively); for the rest of the items their ordering is unchanged, relatively speaking.

This change will affect all versions of Canto, so @mah11 @vmt25 are you happy with these changes, or would you prefer any other changes to the ordering of the actions list? I know there's a few actions not shown in the screenshot that are used by FlyBase (e.g. genotype notes).

(Note that PomBase isn't tracking the `master` branch of Canto, so even if these changes are merged, they might not appear on PomBase's Canto immediately.)