### PR TITLE
Fix EditOrganismsSvc excluding hosts with no genes

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -9278,16 +9278,14 @@ canto.service('EditOrganismsSvc', function (toaster, $http, CantoGlobals) {
   };
 
   vm.unsetOrganismGene = function (organisms, gene_id) {
-    organisms = organisms.map(function (o) {
+    return organisms.map(function (o) {
       o.genes = o.genes.filter(function (g) {
         return g.gene_id !== gene_id;
       });
       return o;
+    }).filter(function (o) {
+      return o.pathogen_or_host === 'host' || o.genes.length > 0;
     });
-    organisms = organisms.filter(function (o) {
-      return o.genes.length > 0;
-    });
-    return organisms;
   };
 
   vm.unsetHostOrganism = function (organisms, taxon_id) {


### PR DESCRIPTION
Fixes #2172 

This PR makes a small change to `unsetOrganismGene` (in `EditOrganismsSvc`) so that it doesn't filter out organisms with no genes when said organism is a host.

@kimrutherford While working on this, I noticed something odd in `EditOrganismsSvc.removeGene`. Why is it necessary to remove a gene by doing a raw `$http.get` to another page in the application? Isn't there a service we can use for this?
```js
var url = curs_root_uri + '/edit_genes?gene-select=' + gene_id + '&submit=Remove selected';
$http.get(url).then(function () {...})
```