### PR TITLE
Remove 'Unknown' expression and use 'Not assayed'

### DIFF
--- a/root/static/ng_templates/allele_edit.html
+++ b/root/static/ng_templates/allele_edit.html
@@ -219,11 +219,6 @@
               <input ng-model="alleleData.expression" name="curs-allele-expression" id="allele-edit-not-assayed"
                      type="radio" value="Not assayed" />
             </div>
-            <div ng-show="pathogenHostMode || alleleData.type == 'wild type'">
-              <label for="allele-edit-expression-unknown">Unknown</label>
-              <input ng-model="alleleData.expression" name="curs-allele-expression" id="allele-edit-expression-unknown"
-                     type="radio" value="Unknown" />
-            </div>
           </td>
         </tr>
       </table>

--- a/root/static/ng_templates/allele_edit.html
+++ b/root/static/ng_templates/allele_edit.html
@@ -214,7 +214,7 @@
               <input ng-model="alleleData.expression" name="curs-allele-expression" id="allele-edit-null-expression"
                      type="radio" value="Null" />
             </div>
-            <div ng-show="alleleData.type !== 'wild type'">
+            <div ng-show="pathogenHostMode || alleleData.type !== 'wild type'">
               <label for="allele-edit-not-assayed">Not assayed</label>
               <input ng-model="alleleData.expression" name="curs-allele-expression" id="allele-edit-not-assayed"
                      type="radio" value="Not assayed" />


### PR DESCRIPTION
Closes #2215 

This pull request removes the 'Unknown' expression level option from the list of expression levels, since PHI-base and PomBase seem to have come to a joint decision that this expression level is redundant. This has the effect of reverting commits 5a201fd7f769356816d52ef8fddba8d33725cb71 and a117bce4ee80ef911bf300a78ef6b8069c866c7a.

I think PHI-base decided to use 'Not assayed' in place of 'Unknown' for wild-type alleles, and this diverges from PomBase (who disallow 'Not assayed' for wild-type alleles), so I've updated the configuration to preserve this distinction.

@kimrutherford I've tested this in both single-organism and pathogen-host modes and it works fine. You might want to cherry pick these changes onto the `pombase-release` branch, since PomBase doesn't want 'Unknown' expression shown either.
