### PR TITLE
Show species name when transferring genotype annotations

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -383,9 +383,13 @@ canto.filter('encodeAlleleSymbols', symbolEncoder);
 canto.filter('encodeGeneSymbols', symbolEncoder);
 
 canto.filter('featureChooserFilter', ['CantoGlobals', function (CantoGlobals) {
-  return function (feature) {
+  return function (feature, showOrganism) {
     var ret = feature.display_name;
-    if (feature.gene_id && CantoGlobals.multi_organism_mode) {
+    var showOrganismName = (
+      CantoGlobals.multi_organism_mode &&
+      (feature.gene_id || feature.genotype_id && showOrganism)
+    );
+    if (showOrganismName) {
       ret += " (" + feature.organism.full_name + ")";
     }
     if (feature.background) {

--- a/root/static/ng_templates/multi_feature_chooser.html
+++ b/root/static/ng_templates/multi_feature_chooser.html
@@ -5,7 +5,7 @@
       <input type="checkbox" name="selectedFeatureIds[]"
              ng-checked="selectedFeatureIds.indexOf(featurere.feature_id) > -1"
              ng-click="toggleSelection(feature.feature_id)" />
-      <span ng-bind-html="feature.display_name | encodeAlleleSymbols | toTrusted"></span>
+      <span ng-bind-html="feature | featureChooserFilter:true | encodeAlleleSymbols | toTrusted"></span>
     </label>
   </div>
 </div>


### PR DESCRIPTION
References #2290

This pull request ensures that species names are shown in the Transfer Annotation dialog when transferring genotype annotations in multi-organism mode. Previously, the organism names were only shown for genes and metagenotypes.

This is how the transfer dialog looks now:

![feature-chooser-transfer](https://user-images.githubusercontent.com/37659591/83517437-cac0b080-a4d0-11ea-98c4-484c25e25926.PNG)

This PR changes the interface to `featureChooserFilter` to accept a `showOrganism` argument, but it defaults back to the old behaviour when not set. The new behaviour is currently restricted to the `multiFeatureChooser` directive, so the organism name doesn't show in cases where it would be redundant – for example, in the Edit Annotation dialog:

![feature-chooser-edit](https://user-images.githubusercontent.com/37659591/83517614-11160f80-a4d1-11ea-9d07-26e36478bfd5.PNG)

@kimrutherford I haven't tested this in single organism mode, but I've checked all the possible combinations for the new logical expression and it seems sound (see below for a table of combinations that show the organism name). I haven't changed the condition that the organism name only shows in multi-organism mode.

- - -

multi_organism_mode | gene_id | genotype_id | showOrganism | Result
-- | -- | -- | -- | --
TRUE | **FALSE** | TRUE | TRUE | TRUE
TRUE | TRUE | **FALSE** | **FALSE** | TRUE
TRUE | TRUE | **FALSE** | TRUE | TRUE
TRUE | TRUE | TRUE | **FALSE** | TRUE
TRUE | TRUE | TRUE | TRUE | TRUE



