### PR TITLE
Link to genotypes from metagenotype annotation rows

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -205,9 +205,8 @@ function isSingleLocusDiploid(genotype) {
 }
 
 function isWildTypeGenotype(genotype) {
-  return genotype.genotype_identifier.indexOf('wild-type-genotype') !== -1
+  return genotype.alleles.length == 0;
 }
-
 function getGenotypeManagePath(organismMode) {
   var paths = {
     'unknown': 'genotype_manage',

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -204,6 +204,10 @@ function isSingleLocusDiploid(genotype) {
   return Object.keys(diploidNames).length === 1;
 }
 
+function isWildTypeGenotype(genotype) {
+  return genotype.genotype_identifier.indexOf('wild-type-genotype') !== -1
+}
+
 function getGenotypeManagePath(organismMode) {
   var paths = {
     'unknown': 'genotype_manage',
@@ -7654,6 +7658,7 @@ var annotationTableRow =
         $scope.featureType = null;
         $scope.interactionFeatureType = null;
         $scope.showInteractionTermColumns = false;
+        $scope.hasWildTypeHost = false;
 
         CursSessionDetails.get()
           .then(function (sessionDetails) {
@@ -7692,6 +7697,12 @@ var annotationTableRow =
         };
 
         $scope.displayEvidence = annotation.evidence_code;
+
+        $scope.hasWildTypeHost = (
+          $scope.annotation.feature_type == 'metagenotype' &&
+          CantoGlobals.pathogen_host_mode &&
+          isWildTypeGenotype($scope.annotation.host_genotype)
+        );
 
         if (typeof ($scope.annotation.conditions) !== 'undefined') {
           $scope.annotation.conditionsString =

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -10,14 +10,20 @@
     </div>
   </td>
   <td ng-if="annotationType.feature_type == 'metagenotype'">
-    <div ng-bind-html="annotation.pathogen_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></div>
+    <div>
+      <a ng-href="{{featureLink('genotype', annotation.pathogen_genotype.genotype_id)}}"><span ng-bind-html="annotation.pathogen_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></span></a>
     <div>
       <span class="organism-name">{{annotation.pathogen_genotype.organism.scientific_name | abbreviateGenus}}</span>
       <span ng-if="annotation.pathogen_genotype.strain_name" class="curs-strain-name-inline">({{annotation.pathogen_genotype.strain_name}})</span>
     </div>
   </td>
   <td ng-if="annotationType.feature_type == 'metagenotype'">
-    <div ng-bind-html="annotation.host_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></div>
+    <div ng-switch="hasWildTypeHost">
+      <a ng-switch-when="false" ng-href="{{featureLink('genotype', annotation.host_genotype.genotype_id)}}">
+        <span ng-bind-html="annotation.host_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></span>
+      </a>
+      <span ng-switch-when="true" ng-bind-html="annotation.host_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></span>
+    </div>
     <div>
       <span class="organism-name">{{annotation.host_genotype.organism.scientific_name | abbreviateGenus}}</span>
       <span ng-if="annotation.host_genotype.strain_name" class="curs-strain-name-inline">({{annotation.host_genotype.strain_name}})</span>


### PR DESCRIPTION
This PR links the pathogen and host genotype names in the metagenotype annotation table rows to the genotype details pages for their respective genotypes. Previously, the genotype names were just plain text, which wasn't consistent with the tables for single-species phenotype annotations.

The code doesn't create a link if the host is wild-type; the details page is irrelevant in this case, because the genotype should never have any annotations.

Here's how it looks:

![image](https://user-images.githubusercontent.com/37659591/84030965-cabb2780-a98c-11ea-93f5-90d316513a95.png)

This feature wasn't requested, but I think it's complementary to issue #2085.

- - -

@kimrutherford I was pretty rigorous in making sure that this doesn't affect any mode except pathogen-host mode, hence the code below:

```js
        $scope.hasWildTypeHost = (
          $scope.annotation.feature_type == 'metagenotype' &&
          CantoGlobals.pathogen_host_mode &&
          isWildTypeGenotype($scope.annotation.host_genotype)
        );
```

However, I'm concerned about the fact we're hard-coding the `host_genotype` and `pathogen_genotype` properties in the first place. Isn't this code used for FlyBase's metagenotypes as well? If I remember correctly, the agnostic display mode for other tables is 'Interactor A' and 'Interactor B'. For non-pathogen-host modes, do the `pathogen_genotype` and `host_genotype` properties implicitly map to the first and second genotype (respectively) in a metagenotype? If not, the whole directive probably needs to be refactored to not assume pathogen-host mode.