### PR TITLE
Support wild-type pathogens in user interface

### DIFF
--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -1924,6 +1924,8 @@ sub _metagenotype_store
   my $body_data = _decode_json_content($c);
 
   my $pathogen_genotype_id = $body_data->{pathogen_genotype_id};
+  my $pathogen_taxonid = $body_data->{pathogen_taxon_id};
+  my $pathogen_strain_name = $body_data->{pathogen_strain_name};
   my $host_genotype_id = $body_data->{host_genotype_id};
   my $host_taxonid = $body_data->{host_taxon_id};
   my $host_strain_name = $body_data->{host_strain_name};
@@ -1932,7 +1934,7 @@ sub _metagenotype_store
     $c->stash->{json_data} = {
       status => "error",
       message => "Storing new metagenotype failed: internal error - " .
-        "metagenotype call much have 'host_genotype_id' or 'host_taxonid' param",
+        "metagenotype call must have 'host_genotype_id' or 'host_taxonid' param",
     };
 
     $c->forward('View::JSON');
@@ -1952,20 +1954,48 @@ sub _metagenotype_store
     return;
   }
 
+  if (!$pathogen_genotype_id && !$pathogen_taxonid) {
+    $c->stash->{json_data} = {
+      status => "error",
+      message => "Storing new metagenotype failed: internal error - " .
+        "metagenotype call must have 'pathogen_genotype_id' or 'pathogen_taxonid' param",
+    };
+
+    $c->forward('View::JSON');
+
+    return;
+  }
+
+  if ($pathogen_genotype_id && $pathogen_taxonid) {
+    $c->stash->{json_data} = {
+      status => "error",
+      message => "Storing new metagenotype failed: internal error - " .
+        "metagenotype call has both 'pathogen_genotype_id' and 'pathogen_taxonid' params",
+    };
+
+    $c->forward('View::JSON');
+
+    return;
+  }
+
   my @alleles = ();
 
   try {
-    my $pathogen_genotype = $schema->find_with_type('Genotype', $pathogen_genotype_id);
-
     my $genotype_manager =
       Canto::Curs::GenotypeManager->new(config => $c->config(), curs_schema => $schema);
 
     my $host_genotype;
+    my $pathogen_genotype;
 
     if ($host_genotype_id) {
       $host_genotype = $schema->find_with_type('Genotype', $host_genotype_id);
     } else {
       $host_genotype = $genotype_manager->get_wildtype_genotype($host_taxonid, $host_strain_name);
+    }
+    if ($pathogen_genotype_id) {
+      $pathogen_genotype = $schema->find_with_type('Genotype', $pathogen_genotype_id);
+    } else {
+      $pathogen_genotype = $genotype_manager->get_wildtype_genotype($pathogen_taxonid, $pathogen_strain_name);
     }
 
     my $existing_metagenotype =

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -9251,15 +9251,11 @@ var metagenotypeManage = function ($q, CantoGlobals, Curs, CursGenotypeList, Met
       }
 
       function createControlMetagenotype() {
-        var pathogenStrainTaxonId = $scope.selectedPathogenStrain.taxon_id;
-        var pathogenStrainName = $scope.selectedPathogenStrain.strain_name;
-        var hostStrainTaxonId = $scope.selectedHostStrain.taxon_id;
-        var hostStrainName = $scope.selectedHostStrain.strain_name;
         Metagenotype.create({
-          pathogen_taxon_id: hostStrainTaxonId,
-          pathogen_strain_name: hostStrainName,
-          host_taxon_id: hostStrainTaxonId,
-          host_strain_name: hostStrainName
+          pathogen_taxon_id: $scope.selectedPathogenStrain.taxon_id,
+          pathogen_strain_name: $scope.selectedPathogenStrain.strain_name,
+          host_taxon_id: $scope.selectedHostStrain.taxon_id,
+          host_strain_name: $scope.selectedHostStrain.strain_name
         });
       }
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7741,6 +7741,7 @@ var annotationTableRow =
         $scope.featureType = null;
         $scope.interactionFeatureType = null;
         $scope.showInteractionTermColumns = false;
+        $scope.hasWildTypePathogen = false;
         $scope.hasWildTypeHost = false;
         $scope.showTransferLink = false;
 
@@ -7781,6 +7782,12 @@ var annotationTableRow =
         };
 
         $scope.displayEvidence = annotation.evidence_code;
+
+        $scope.hasWildTypePathogen = (
+          $scope.annotation.feature_type == 'metagenotype' &&
+          CantoGlobals.pathogen_host_mode &&
+          isWildTypeGenotype($scope.annotation.pathogen_genotype)
+        );
 
         $scope.hasWildTypeHost = (
           $scope.annotation.feature_type == 'metagenotype' &&

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -10,9 +10,12 @@
     </div>
   </td>
   <td ng-if="annotationType.feature_type == 'metagenotype'">
-    <div>
-      <a ng-href="{{featureLink('genotype', annotation.pathogen_genotype.genotype_id)}}"><span ng-bind-html="annotation.pathogen_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></span></a>
-    <div>
+    <div ng-switch="hasWildTypePathogen">
+      <a ng-switch-when="false" ng-href="{{featureLink('genotype', annotation.pathogen_genotype.genotype_id)}}">
+        <span ng-bind-html="annotation.pathogen_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></span>
+      </a>
+      <span ng-switch-when="true" ng-bind-html="annotation.pathogen_genotype.genotype_display_name | encodeAlleleSymbols | toTrusted"></span>
+    </div>
       <span class="organism-name">{{annotation.pathogen_genotype.organism.scientific_name | abbreviateGenus}}</span>
       <span ng-if="annotation.pathogen_genotype.strain_name" class="curs-strain-name-inline">({{annotation.pathogen_genotype.strain_name}})</span>
     </div>

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -24,16 +24,15 @@
             </genotype-simple-list-view>
         </div>
 
-        <div ng-if="isHost">
-            <div class="curs-genotype-list-instructions curs-genotype-list-view-no-checkbox">
-                <span>Wild-type genotypes</span>
-            </div>
-            <wild-genotype-view
-                strains="data.wildTypeStrains"
-                show-check-box-actions="true"
-                on-strain-select="onStrainChange(strain)">
-            </wild-genotype-view>
+        <div class="curs-genotype-list-instructions curs-genotype-list-view-no-checkbox">
+            <span>Wild-type genotypes</span>
         </div>
+        <wild-genotype-view
+            strains="data.wildTypeStrains"
+            show-check-box-actions="true"
+            is-host="isHost"
+            on-strain-select="onStrainChange(strain)">
+        </wild-genotype-view>
 
         <p class="metagenotype-genotype-shortcut">
             <a href="{{genotypeShortcutUrl}}">Add another {{organismType}} genotype</a>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -14,6 +14,7 @@
                 selected-organism="selectedPathogen"
                 genotypes="selectedPathogenGenotypes"
                 on-genotype-select="onPathogenGenotypeSelect(genotype)"
+                on-strain-select="onPathogenStrainSelect(strain)">
             </metagenotype-genotype-picker>
         </div>
         <div class="col-md-6">
@@ -27,7 +28,7 @@
                 selected-organism="selectedHost"
                 genotypes="selectedHostGenotypes"
                 on-genotype-select="onHostGenotypeSelect(genotype)"
-                on-strain-select="onHostStrainSelect(strain)"
+                on-strain-select="onHostStrainSelect(strain)">
             </metagenotype-genotype-picker>
         </div>
     </div>

--- a/root/static/ng_templates/wild_genotype_view.html
+++ b/root/static/ng_templates/wild_genotype_view.html
@@ -14,7 +14,8 @@
         ng-repeat="strain in strains track by strain.strain_name"
         show-check-box-actions="showCheckBoxActions"
         strain="strain"
-        on-strain-select="onStrainChange(strain)"
+        is-host="isHost"
+        on-strain-select="onStrainChange(strain)">
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
Closes https://github.com/pombase/canto/issues/2312

This pull request adds support for wild-type pathogen genotypes in metagenotypes, which is needed for the curation of scientific controls in pathogen-host interactions.

@kimrutherford I think I've made all the necessary changes to the front and back end to fix this, but I'd appreciate it if you could double-check the changes to `_metagenotype_store` (in `Curs.pm`).

- - -

Initially, the metagenotype API didn't support storing pathogen taxon IDs or pathogen strains. When trying to store both a wild-type pathogen and a wild-type host, you got a generic error message in the toaster.

I made a bunch of changes to `_metagenotype_store` to handle pathogens the same way as hosts when it came to creating metagenotypes (see 85f40ed93), and now it's possible to create a metagenotype where the pathogen and the host are both wild-type:

![image](https://user-images.githubusercontent.com/37659591/86014639-80234d00-ba18-11ea-877e-a6d26108eb89.png)

You can also create a metagenotype with a wild-type pathogen and a mutant host. I'm not sure if this is sensible, but it's easier to leave it enabled than it is to restrict this case.

![image](https://user-images.githubusercontent.com/37659591/86015245-3850f580-ba19-11ea-88f6-454fb3819756.png)