### PR TITLE
Link to metagenotype details from metagenotype annotation rows

### DIFF
--- a/root/curs/front.mhtml
+++ b/root/curs/front.mhtml
@@ -106,7 +106,7 @@ $total_annotation_count
 % }
 </div>
 
-<annotation-table-list></annotation-table-list>
+<annotation-table-list show-metagenotype-link="true"></annotation-table-list>
 
 % if ($annotation_count > 0) {
 <div id="curs-annotation-download">

--- a/root/curs/metagenotype_page.mhtml
+++ b/root/curs/metagenotype_page.mhtml
@@ -120,10 +120,15 @@ Details
   </div>
 </div>
 
-<div class="clearall"/>
+<div class="clearall"></div>
 
-<button type="button" ng-click="backToMetagenotypes()"
-        class="btn btn-primary curs-back-button">&larr; Back to metagenotypes</button>
+<button type="button"
+        ng-click="toSummaryPage()"
+        class="btn btn-primary curs-back-button">&larr; Go to summary</button>
+
+<button type="button"
+        ng-click="toMetagenotypeManagement()"
+        class="btn btn-primary curs-back-button">Metagenotype management &rarr;</button>
 
 <annotation-table-list feature-type-filter="metagenotype" feature-id-filter="<% $metagenotype_id %>"
                        feature-filter-display-name="<% $metagenotype->display_name($c->config()) %>"></annotation-table-list>

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4504,9 +4504,14 @@ var metagenotypeViewCtrl =
         CantoGlobals.curs_root_uri + '/metagenotype_manage#/edit/' + metagenotypeId;
     };
 
-    $scope.backToMetagenotypes = function () {
+    $scope.toMetagenotypeManagement = function () {
       window.location.href = CantoGlobals.curs_root_uri +
         '/metagenotype_manage' + (CantoGlobals.read_only_curs ? '/ro' : '');
+    };
+
+    $scope.toSummaryPage = function () {
+      window.location.href = CantoGlobals.curs_root_uri + 
+      (CantoGlobals.read_only_curs ? '/ro' : '');
     };
   };
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7540,6 +7540,7 @@ var annotationTableCtrl =
         annotations: '=',
         featureStatusFilter: '@',
         alleleCountFilter: '@',
+        showMetagenotypeLink: '<',
       },
       restrict: 'E',
       replace: true,
@@ -7687,6 +7688,7 @@ var annotationTableList =
         featureIdFilter: '@',
         featureTypeFilter: '@',
         featureFilterDisplayName: '@',
+        showMetagenotypeLink: '<?'
       },
       restrict: 'E',
       replace: true,
@@ -7698,6 +7700,7 @@ var annotationTableList =
         $scope.annotationsByType = {};
         $scope.serverErrorsByType = {};
         $scope.byTypeSplit = {};
+        $scope.showMetagenotypeLink = $scope.showMetagenotypeLink || false;
 
         $scope.capitalizeFirstLetter = capitalizeFirstLetter;
         $scope.data = {};
@@ -7925,6 +7928,10 @@ var annotationTableRow =
         $scope.addLinks = function () {
           return !CantoGlobals.read_only_curs &&
             $attrs.featureStatusFilter == 'new';
+        };
+
+        $scope.isMetagenotypeLinkEnabled = function () {
+          return $attrs.showMetagenotypeLink == 'true';
         };
 
         $scope.featureLink = function (featureType, featureId) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7799,6 +7799,7 @@ var annotationTableRow =
         $scope.hasWildTypePathogen = false;
         $scope.hasWildTypeHost = false;
         $scope.showTransferLink = false;
+        $scope.isMetagenotypeAnnotation = false;
 
         CursSessionDetails.get()
           .then(function (sessionDetails) {
@@ -7806,6 +7807,10 @@ var annotationTableRow =
           });
 
         var annotation = $scope.annotation;
+
+        $scope.isMetagenotypeAnnotation = (
+          $scope.annotation.feature_type === 'metagenotype'
+        );
 
         $scope.$watchCollection('annotation.alleles',
                                 function(newAlleles) {

--- a/root/static/ng_templates/annotation_table.html
+++ b/root/static/ng_templates/annotation_table.html
@@ -61,6 +61,7 @@
             <tr annotation-table-row add-links="addLinks()"
                 annotation-type-name="ontology"
                 feature-status-filter="{{featureStatusFilter}}"
+                show-metagenotype-link="{{showMetagenotypeLink}}"
                 ng-repeat="annotation in data.sortedAnnotations">
             </tr>
           </tbody>

--- a/root/static/ng_templates/annotation_table_list.html
+++ b/root/static/ng_templates/annotation_table_list.html
@@ -24,11 +24,13 @@ Annotation loading...
             <annotation-table annotation-type-name="{{annotationType.name}}"
                               annotations="byTypeSplit[annotationType.name].new"
                               feature-status-filter="new"
-                              feature-filter-display-name="{{featureFilterDisplayName}}"></annotation-table>
+                              feature-filter-display-name="{{featureFilterDisplayName}}"
+                              show-metagenotype-link="showMetagenotypeLink"></annotation-table>
             <annotation-table annotation-type-name="{{annotationType.name}}"
                               annotations="byTypeSplit[annotationType.name].existing"
                               feature-status-filter="existing"
-                              feature-filter-display-name="{{featureFilterDisplayName}}"></annotation-table>
+                              feature-filter-display-name="{{featureFilterDisplayName}}"
+                              show-metagenotype-link="showMetagenotypeLink"></annotation-table>
           </div>
           <div ng-if="annotationType.feature_type == 'genotype'">
             <annotation-table annotation-type-name="{{annotationType.name}}"

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -138,7 +138,7 @@
   </td>
   <td class="table-row-actions">
     <div ng-if="addLinks()">
-      <div ng-if="isMetagenotypeAnnotation">
+      <div ng-if="isMetagenotypeAnnotation && isMetagenotypeLinkEnabled()">
         <a title="View metagenotype for this annotation"
            href="{{featureLink('metagenotype', annotation.metagenotype_id)}}">View metagenotype</a>
       </div>

--- a/root/static/ng_templates/annotation_table_ontology_row.html
+++ b/root/static/ng_templates/annotation_table_ontology_row.html
@@ -138,6 +138,10 @@
   </td>
   <td class="table-row-actions">
     <div ng-if="addLinks()">
+      <div ng-if="isMetagenotypeAnnotation">
+        <a title="View metagenotype for this annotation"
+           href="{{featureLink('metagenotype', annotation.metagenotype_id)}}">View metagenotype</a>
+      </div>
       <div>
         <a title="Edit this annotation" ng-click="edit()">Edit</a>
       </div>


### PR DESCRIPTION
(References #2085)

This pull request adds a 'View metagenotype' link to the `annotation_table_ontology_row.html` template when the `feature_type` is equal to `"metagenotype"`. It's needed because the feature names in the row only link to the constituent genotypes, not the metagenotype itself. Here's how it looks:

![image](https://user-images.githubusercontent.com/37659591/88173900-44486580-cc1b-11ea-89a0-256c22ebee23.png)

I also changed the navigation on the metagenotype details page so it's possible to get back to the summary page from there. Previously, it only linked back to metagenotype management:

![image](https://user-images.githubusercontent.com/37659591/88177833-62b15f80-cc21-11ea-837b-22fbc946edb9.png)

## Remaining problems

I've set the pull request as a draft because of the (minor) unresolved problems below.

### FlyBase

@kimrutherford As far as I can tell, this change only affects ontology annotations on metagenotypes. I'm not sure if FlyBase use this type of annotation, or whether they only use metagenotypes in interactions. It might be a useful option for them too but I'm not sure.

### Circular links on metagenotype details

The metagenotype details page uses the same template as the summary page to list the annotations, meaning the 'View annotations' link is still visible on the metagenotype details page. It's completely redundant here, as it only links to the same page. I'm not sure of the best way to fix this. I can think of two options:

* **Option 1**: Check the URL of the page to see if the template is being rendered on the summary page, and only show the link if so. This is probably fine if our URL format is stable.

* **Option 2**: Add a binding to the table directive that controls whether to show metagenotype view links, or – as a more general solution – use a binding to specify the context in which the template is being rendered (e.g. 'summary' or 'details'). There might be an established pattern for this contextual display problem, but I'm not aware of one.

Note that this problem also applies to genotype details, where you can click the genotype link in the annotation rows to link yourself back to the same page, but I feel like it's less conspicuous in that case.