### PR TITLE
Allow choosing session organisms in extensions

### DIFF
--- a/lib/Canto/Config/ExtensionConf.pm
+++ b/lib/Canto/Config/ExtensionConf.pm
@@ -112,48 +112,38 @@ sub parse {
       map {
         if (/:/) {
           push @new_ontology_range_scope, $_;
-        } else {
-          if (/^(Number|TaxonID|HostTaxonID|PathogenTaxonID)$/i) {
-            if (!grep { $_->{type} eq 'Number'} @new_range_bits) {
-              push @new_range_bits, {
-                type => 'Number',
-              };
-            }
-          } else {
-            if (/^text$/i) {
-              if (!grep { $_->{type} eq 'Text'} @new_range_bits) {
-                push @new_range_bits, {
-                  type => 'Text',
-                  input_type => lc $_,
-                };
-              }
-            } else {
-              if (/^(Gene|FeatureID|GeneID|ProteinID|TranscriptID|tRNAID|SP.*)$/i) {
-                # hack: treat everything else as a gene (and normalise the case)
-                if (!grep { $_->{type} eq 'Gene'} @new_range_bits) {
-                  push @new_range_bits, {
-                    type => 'Gene',
-                  }
-                }
-              } else {
-                if ($_ eq '%') {
-                  if (!grep { $_->{type} eq '%'} @new_range_bits) {
-                    push @new_range_bits, {
-                      type => '%',
-                    };
-                  }
-                } else {
-                  if (/^metagenotype/i) {
-                    push @new_range_bits, {
-                      type => 'Metagenotype',
-                    }
-                  } else {
-                    die "unsupported range part: $_\n";
-                  }
-                }
-              }
+        } elsif (/^(Number|TaxonID|HostTaxonID|PathogenTaxonID)$/i) {
+          if (!grep { $_->{type} eq 'Number'} @new_range_bits) {
+            push @new_range_bits, {
+              type => 'Number',
+            };
+          }
+        } elsif (/^text$/i) {
+          if (!grep { $_->{type} eq 'Text'} @new_range_bits) {
+            push @new_range_bits, {
+              type => 'Text',
+              input_type => lc $_,
+            };
+          }
+        } elsif (/^(Gene|FeatureID|GeneID|ProteinID|TranscriptID|tRNAID|SP.*)$/i) {
+          # hack: treat everything else as a gene (and normalise the case)
+          if (!grep { $_->{type} eq 'Gene'} @new_range_bits) {
+            push @new_range_bits, {
+              type => 'Gene',
             }
           }
+        } elsif ($_ eq '%') {
+          if (!grep { $_->{type} eq '%'} @new_range_bits) {
+            push @new_range_bits, {
+              type => '%',
+            };
+          }
+        } elsif (/^metagenotype/i) {
+          push @new_range_bits, {
+            type => 'Metagenotype',
+          }
+        } else {
+          die "unsupported range part: $_\n";
         }
       } @range_bits;
 

--- a/lib/Canto/Config/ExtensionConf.pm
+++ b/lib/Canto/Config/ExtensionConf.pm
@@ -112,7 +112,7 @@ sub parse {
       map {
         if (/:/) {
           push @new_ontology_range_scope, $_;
-        } elsif (/^(Number|TaxonID|HostTaxonID|PathogenTaxonID)$/i) {
+        } elsif (/^Number$/i) {
           if (!grep { $_->{type} eq 'Number'} @new_range_bits) {
             push @new_range_bits, {
               type => 'Number',
@@ -141,6 +141,18 @@ sub parse {
         } elsif (/^metagenotype/i) {
           push @new_range_bits, {
             type => 'Metagenotype',
+          }
+        } elsif (/^TaxonID$/i) {
+          push @new_range_bits, {
+            type => 'TaxonID',
+          }
+        } elsif (/^PathogenTaxonID$/i) {
+          push @new_range_bits, {
+            type => 'PathogenTaxonID',
+          }
+        } elsif (/^HostTaxonID$/i) {
+          push @new_range_bits, {
+            type => 'HostTaxonID',
           }
         } else {
           die "unsupported range part: $_\n";

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2779,6 +2779,9 @@ var extensionRelationEdit =
 
         $scope.genes = null;
         $scope.metagenotypes = null;
+        $scope.organisms = null;
+        $scope.pathogens = null;
+        $scope.hosts = null;
 
         $scope.getGenesFromServer = function() {
           CursGeneList.geneList().then(function (results) {
@@ -2798,7 +2801,26 @@ var extensionRelationEdit =
           });
         };
 
+        $scope.getOrganismsFromServer = function () {
+          Curs.list('organism').then(function (organisms) {
+            var rangeType = $scope.extensionRelation.rangeType;
+            if (rangeType === 'PathogenTaxonID') {
+              $scope.pathogens = filterOrganisms(organisms, 'pathogen');
+            } else if (rangeType === 'HostTaxonID') {
+              $scope.hosts = filterOrganisms(organisms, 'host');
+            } else {
+              $scope.organisms = organisms;
+            }
+          }).catch(function () {
+            toaster.pop('note', "couldn't read the organism list from the server");
+          });
+        }
+
         $scope.getMetagenotypesFromServer();
+
+        if ($scope.extensionRelation.rangeType.indexOf('TaxonID') !== -1) {
+          $scope.getOrganismsFromServer();
+        }
 
         $scope.openSingleGeneAddDialog = function () {
           var modal = openSingleGeneAddDialog($uibModal);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2780,8 +2780,6 @@ var extensionRelationEdit =
         $scope.genes = null;
         $scope.metagenotypes = null;
         $scope.organisms = null;
-        $scope.pathogens = null;
-        $scope.hosts = null;
 
         $scope.getGenesFromServer = function() {
           CursGeneList.geneList().then(function (results) {
@@ -2805,16 +2803,16 @@ var extensionRelationEdit =
           Curs.list('organism').then(function (organisms) {
             var rangeType = $scope.extensionRelation.rangeType;
             if (rangeType === 'PathogenTaxonID') {
-              $scope.pathogens = filterOrganisms(organisms, 'pathogen');
+              $scope.organisms = filterOrganisms(organisms, 'pathogen');
             } else if (rangeType === 'HostTaxonID') {
-              $scope.hosts = filterOrganisms(organisms, 'host');
+              $scope.organisms = filterOrganisms(organisms, 'host');
             } else {
               $scope.organisms = organisms;
             }
           }).catch(function () {
             toaster.pop('note', "couldn't read the organism list from the server");
           });
-        }
+        };
 
         $scope.getMetagenotypesFromServer();
 
@@ -2832,6 +2830,12 @@ var extensionRelationEdit =
         $scope.disableAll = function (element, disabled) {
           $(element).find('input').attr('disabled', disabled);
           $(element).find('select').attr('disabled', disabled);
+        };
+
+        $scope.organismSelected = function (organism) {
+          $scope.extensionRelation.rangeValue = organism.taxonid;
+          $scope.extensionRelation.rangeDisplayName = organism.scientific_name;
+          $scope.finishWithOrganism(organism);
         };
 
         $scope.termFoundCallback = function (termId, termName, searchString) {
@@ -4555,6 +4559,7 @@ var organismSelector = function () {
       organismSelected: '&',
       organisms: '<',
       initialSelectionTaxonId: '@',
+      alwaysShowSelect: '@',
       label: '@'
     },
     restrict: 'E',
@@ -4579,7 +4584,7 @@ var organismSelectorCtrl = function ($scope, CantoGlobals) {
 
   $scope.$watch('organisms', function () {
     if ($scope.organisms && $scope.organisms.length > 0)
-      if ($scope.organisms.length === 1) {
+      if (!$scope.alwaysShowSelect && $scope.organisms.length === 1) {
           $scope.data.selectedOrganism = $scope.organisms[0];
         $scope.organismChanged();
       } else {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4559,7 +4559,7 @@ var organismSelector = function () {
       organismSelected: '&',
       organisms: '<',
       initialSelectionTaxonId: '@',
-      alwaysShowSelect: '@',
+      alwaysShowSelect: '<',
       label: '@'
     },
     restrict: 'E',

--- a/root/static/ng_templates/extension_relation_edit.html
+++ b/root/static/ng_templates/extension_relation_edit.html
@@ -43,18 +43,12 @@
     <input ng-if="!disabled"
            type="number" required ng-model="extensionRelation.rangeValue"/>
   </span>
-  <span ng-if="rangeConfig.type === 'PathogenTaxonID'">
-    <feature-chooser ng-if="!disabled && pathogens"
-                     features="pathogens" feature-type="'organism'"
-                     chosen-feature-display-name="extensionRelation.rangeDisplayName"
-                     chosen-feature-id="extensionRelation.rangeValue">
-    </feature-chooser>
-  </span>
-  <span ng-if="rangeConfig.type === 'HostTaxonID'">
-    <feature-chooser ng-if="!disabled && hosts"
-                     features="pathogens" feature-type="'organism'"
-                     chosen-feature-display-name="extensionRelation.rangeDisplayName"
-                     chosen-feature-id="extensionRelation.rangeValue">
-    </feature-chooser>
+  <span ng-if="rangeConfig.type === 'TaxonID' || rangeConfig.type === 'PathogenTaxonID' || rangeConfig.type === 'HostTaxonID'">
+    <organism-selector
+      ng-if="!disabled && organisms"
+      organisms="organisms"
+      organism-selected="organismSelected(organism)"
+      always-show-select="true">
+    </organism-selector>
   </span>
 </span>

--- a/root/static/ng_templates/extension_relation_edit.html
+++ b/root/static/ng_templates/extension_relation_edit.html
@@ -43,4 +43,18 @@
     <input ng-if="!disabled"
            type="number" required ng-model="extensionRelation.rangeValue"/>
   </span>
+  <span ng-if="rangeConfig.type === 'PathogenTaxonID'">
+    <feature-chooser ng-if="!disabled && pathogens"
+                     features="pathogens" feature-type="'organism'"
+                     chosen-feature-display-name="extensionRelation.rangeDisplayName"
+                     chosen-feature-id="extensionRelation.rangeValue">
+    </feature-chooser>
+  </span>
+  <span ng-if="rangeConfig.type === 'HostTaxonID'">
+    <feature-chooser ng-if="!disabled && hosts"
+                     features="pathogens" feature-type="'organism'"
+                     chosen-feature-display-name="extensionRelation.rangeDisplayName"
+                     chosen-feature-id="extensionRelation.rangeValue">
+    </feature-chooser>
+  </span>
 </span>

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -4,7 +4,7 @@
 </div>
 <div class="curs-organism-selector" ng-if="organisms">
   <p ng-if="::label" class="curs-organism-selector-label"><b>{{::label}}</b></p>
-  <select ng-if="organisms.length > 1"
+  <select ng-if="alwaysShowSelect || organisms.length > 1"
       class="form-control curs-organism-selector-select"
       name="select-organism"
       ng-model="data.selectedOrganism"
@@ -12,5 +12,5 @@
       ng-options="o as o.full_name for o in organisms track by o.taxonid">
     <option value="" disabled>Select an organism...</option>
   </select>
-  <span ng-if="organisms.length === 1">{{organisms[0].full_name}}</span>
+  <span ng-if="!alwaysShowSelect && organisms.length === 1">{{organisms[0].full_name}}</span>
 </div>


### PR DESCRIPTION
Related: #2255 

To create a complete GAF file for PHI-Canto, we need a way to capture all the organisms involved for the GO term 'interspecies interaction between organisms' (GO:0044419) and its children. The current plan is to capture the taxon IDs for the organisms using one or more annotation extensions.

Partial support for the range types 'TaxonID', 'PathogenTaxonID' and 'HostTaxonID' was added in commit 47a4a0e42a626d57cf897bcf327a496ef51dfbc3, where the new types are an alias of 'Number'. However, recent discussion indicates that it would be better to use a feature chooser that suggests organisms from the session based on their species names, rather than expecting the curator to enter the taxon ID manually.

@kimrutherford I've done as much as I can on the back and front end to add support for this. `ExtensionConf.pm` now handles the taxon ID types specially, and the `extensionRelationEdit` directive uses these range types to fetch the correct organisms. I'd appreciate some double-checking of the `ExtensionConf.pm` changes, since I also refactored the big tree of if-else blocks.

Unfortunately, I'm now stuck because the `featureChooser` directive doesn't work correctly with organisms. The property names for organisms aren't consistent with other features: for example, organisms use `full_name` instead of `display_name`, and they have no `feature_id`. This means they're incompatible with `featureChooser` and `featureChooserFilter`.

I'm not sure of the best way to fix this. I can think of the following options:

* **Option 1:** Rename the relevant object properties in a containing controller before passing them to `featureChooser`. This is the simplest option, but doesn't help us if we need to use the organism feature chooser in a different context.

* **Option 2:** Change the organism properties to be the same as any other feature (giving them a `display_name` and a `feature_id` and anything else they need). I expect this will be disruptive to a lot of existing code that relies on the current property names.

* **Option 3:** Keep all the old properties, but add the ones needed for `featureChooser`. This introduces redundancy, but would be helpful if we have to use the organism feature chooser in a different context.

* **Option 4:** Use the `organismSelector` instead of `featureChooser`. I'm not sure if this will work correctly, since `organismSelector` may not pass back the right data (taxon IDs), but it could allow us to avoid the problems with `featureChooser`.

Note that if we adapt `featureChooser` to support organisms, then the `organismSelector` directive will probably become redundant, and we should consider replacing it with `featureChooser`.