### PR TITLE
Update titles on table sort buttons to reflect sorting state

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7728,7 +7728,7 @@ var annotationTableCtrl =
 
         $scope.setSortBy = function(col) {
           if ($scope.sortColumn === col) {
-            $scope.setDefaulSort();
+            $scope.setDefaultSort();
           } else {
             $scope.prevSortColumn = $scope.sortColumn;
             $scope.sortColumn = col;
@@ -7736,7 +7736,7 @@ var annotationTableCtrl =
           }
         };
 
-        $scope.setDefaulSort = function() {
+        $scope.setDefaultSort = function() {
           $scope.sortColumn = null;
           $scope.sortAnnotations();
         };

--- a/root/static/ng_templates/annotation_table.html
+++ b/root/static/ng_templates/annotation_table.html
@@ -31,7 +31,8 @@
               <th ng-if="multiOrganismMode && annotationType.feature_type !== 'metagenotype'">Species<span ng-if="strainsMode && annotationType.feature_type === 'genotype'"> (strain)</span></th>
               <th ng-if="annotationType.feature_type == 'genotype'">
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('genotype_genes')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('genotype_genes')">
                   Genes
                   <img ng-src="{{app_static_path + (sortColumn == 'genotype_genes' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>
@@ -39,14 +40,16 @@
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_background">Background</th>
               <th ng-if="annotationType.feature_type == 'genotype' && !data.hideColumns.genotype_name">
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('genotype_name')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('genotype_name')">
                   Genotype name
                   <img ng-src="{{app_static_path + (sortColumn == 'genotype_name' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>
               </th>
               <th ng-if="annotationType.feature_type == 'genotype' || !featureIdFilter && annotationType.feature_type != 'metagenotype'">
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('feature_display_name')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('feature_display_name')">
                   {{displayAnnotationFeatureType}}
                   <span ng-if="annotationType.feature_type == 'genotype'">(allele and expression)</span>
                   <img ng-src="{{app_static_path + (sortColumn == 'feature_display_name' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
@@ -56,21 +59,24 @@
               <th ng-if="annotationType.feature_type == 'metagenotype'">Host genotype</th>
               <th>
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('term_ontid')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('term_ontid')">
                   Term ID
                   <img ng-src="{{app_static_path + (sortColumn == 'term_ontid' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>
               </th>
               <th>
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('term_name')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('term_name')">
                   Term name
                   <img ng-src="{{app_static_path + (sortColumn == 'term_name' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>
               </th>
               <th ng-if="!data.hideColumns.evidence_code">
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('evidence_code')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('evidence_code')">
                   Evidence code
                   <img ng-src="{{app_static_path + (sortColumn == 'evidence_code' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>
@@ -83,21 +89,24 @@
               <th ng-if="!data.hideColumns.term_suggestion">Term suggestion</th>
               <th ng-if="!data.hideColumns.submitter_comment">
                <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('submitter_comment')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('submitter_comment')">
                   Comment
                   <img ng-src="{{app_static_path + (sortColumn == 'submitter_comment' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                </a>
               </th>
               <th ng-if="!data.hideColumns.figure">
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('figure')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('figure')">
                   Figure
                   <img ng-src="{{app_static_path + (sortColumn == 'figure' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>
               </th>
               <th ng-if="!data.hideColumns.extension">
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('extension')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('extension')">
                   <span ng-show="flyBaseMode">Phenotype extensions</span>
                   <span ng-hide="flyBaseMode">Annotation extension</span>
                   <img ng-src="{{app_static_path + (sortColumn == 'extension' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
@@ -105,7 +114,8 @@
               </th>
               <th ng-if="!data.hideColumns.curator">
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('curator')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('curator')">
                   Curator
                   <img ng-src="{{app_static_path + (sortColumn == 'curator' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>
@@ -126,7 +136,8 @@
             <tr>
               <th>
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('feature_a_display_name')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('feature_a_display_name')">
                   Interactor A
                   <img ng-src="{{app_static_path + (sortColumn == 'feature_a_display_name' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>
@@ -134,7 +145,8 @@
               <th ng-if="multiOrganismMode">Taxon Id A</th>
               <th ng-if="!data.hideColumns.evidence_code">
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('evidence_code')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('evidence_code')">
                   Evidence
                   <img ng-src="{{app_static_path + (sortColumn == 'evidence_code' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>
@@ -142,7 +154,8 @@
               <th ng-if="annotationType.can_have_conditions && !data.hideColumns.conditions">Conditions</th>
               <th>
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('feature_b_display_name')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('feature_b_display_name')">
                   Interactor B
                   <img ng-src="{{app_static_path + (sortColumn == 'feature_b_display_name' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>
@@ -150,21 +163,24 @@
               <th ng-if="multiOrganismMode">Taxon Id B</th>
               <th ng-if="showInteractionTermColumns">
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('term_ontid')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('term_ontid')">
                   Term ID
                   <img ng-src="{{app_static_path + (sortColumn == 'term_ontid' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>
               </th>
               <th ng-if="showInteractionTermColumns">
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('term_name')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('term_name')">
                   Phenotype
                   <img ng-src="{{app_static_path + (sortColumn == 'term_name' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>
               </th>
               <th ng-if="!data.hideColumns.extension">
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('extension')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('extension')">
                   <span ng-show="flyBaseMode">Phenotype extensions</span>
                   <span ng-hide="flyBaseMode">Annotation extension</span>
                   <img ng-src="{{app_static_path + (sortColumn == 'extension' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
@@ -173,7 +189,8 @@
               <th ng-if="!data.hideColumns.qualifiers">Qualifiers</th>
               <th ng-if="!data.hideColumns.submitter_comment">
                 <a class="curs-sort-button" href=""
-                   title="Click to sort" ng-click="setSortBy('submitter_comment')">
+                   title="{{sortColumn == 'feature_display_name' ? 'Reset sort order' : 'Sort ascending'}}"
+                   ng-click="setSortBy('submitter_comment')">
                   Comment
                   <img ng-src="{{app_static_path + (sortColumn == 'submitter_comment' ? '/images/sort_up.svg' : '/images/sort_both.svg')}}"/>
                 </a>


### PR DESCRIPTION
(Closes #2336)

This pull request changes the titles on sort buttons so that they better reflect the actions from clicking the buttons.

In the default state, the sort button title is 'Sort ascending'. After being clicked, the title changes to 'Reset sort order'. I don't know what the default sorting criteria is, but if it's creation time, it could be better to be explicit about that and change the label to 'Sort by creation time' instead. Personally I don't have any preference.

I copied the logic used to determine the sort button title from the logic used to display the correct sorting icon, and it seems to work as expected based on my testing.

- - -

I've also bundled a fix for a typo in a function name: `setDefaulSort` &rarr; `setDefaultSort`.