### PR TITLE
Add help text and placeholders for Figure field

### DIFF
--- a/root/static/ng_templates/annotation_edit.html
+++ b/root/static/ng_templates/annotation_edit.html
@@ -222,8 +222,10 @@
       <tr ng-if="filteredFeatures && filteredFeatures.length != 0 && (showFigureField || hasFigure)">
         <td class="title">Figure</td>
         <td colspan="2">
+          <span>Prefix figure numbers with 'Figure' and table numbers with 'Table'. Prefix supplementary figure and table numbers with an 'S', for example: 'Figure S1'.</span>
           <input class="form-control curs-edit-wide-field"
                  type="text" size="60"
+                 placeholder="Figure 1, Table 1"
                  ng-model="annotation.figure"/>
         </td>
       </tr>

--- a/root/static/ng_templates/annotation_edit.html
+++ b/root/static/ng_templates/annotation_edit.html
@@ -225,7 +225,7 @@
           <span>Prefix figure numbers with 'Figure' and table numbers with 'Table'. Prefix supplementary figure and table numbers with an 'S', for example: 'Figure S1'.</span>
           <input class="form-control curs-edit-wide-field"
                  type="text" size="60"
-                 placeholder="Figure 1, Table 1"
+                 placeholder="e.g. Figure 1, Table 1"
                  ng-model="annotation.figure"/>
         </td>
       </tr>

--- a/root/static/ng_templates/ontology_term_comment_transfer.html
+++ b/root/static/ng_templates/ontology_term_comment_transfer.html
@@ -14,7 +14,7 @@ You have made the following annotation:
 
   <div class="curs-workflow-fig-or-table" ng-show="showFigureField">
     <label for="figure-field">Figure or table:</label>
-    <input id="figure-field" type="text" ng-model="figOrTable" placeholder="Figure 1, Table 1"/>
+    <input id="figure-field" type="text" ng-model="figOrTable" placeholder="e.g. Figure 1, Table 1"/>
     <p>Prefix figure numbers with 'Figure' and table numbers with 'Table'. Prefix supplementary figure and table numbers with an 'S', for example: 'Figure S1'.</p>
   </div>
 

--- a/root/static/ng_templates/ontology_term_comment_transfer.html
+++ b/root/static/ng_templates/ontology_term_comment_transfer.html
@@ -14,7 +14,8 @@ You have made the following annotation:
 
   <div class="curs-workflow-fig-or-table" ng-show="showFigureField">
     <label for="figure-field">Figure or table:</label>
-    <input id="figure-field" type="text" ng-model="figOrTable"/>
+    <input id="figure-field" type="text" ng-model="figOrTable" placeholder="Figure 1, Table 1"/>
+    <p>Prefix figure numbers with 'Figure' and table numbers with 'Table'. Prefix supplementary figure and table numbers with an 'S', for example: 'Figure S1'.</p>
   </div>
 
   <div class="curs-workflow-confirm-comment">


### PR DESCRIPTION
(References #2320)

This PR adds some explanatory text and a `placeholder` attribute for the 'Figure or Table' text input. I've made these changes both to the step-based ontology workflow and the modal-based workflow. See below:

### Step-based workflow

![image](https://user-images.githubusercontent.com/37659591/92385682-363a9f80-f10a-11ea-9db3-d110c94f7d62.png)

### Modal-based workflow

![image](https://user-images.githubusercontent.com/37659591/92597963-02917e00-f2a0-11ea-9161-6de153906f85.png)

Note that the advice is specific to PHI-base, but this shouldn't matter if the Figure field is specific to PHI-Canto. I think the advice is fairly sensible for any curation to follow, anyway. 