### PR TITLE
Add an extension config column to constrain by annotation type

### DIFF
--- a/lib/Canto/Config/ExtensionConf.pm
+++ b/lib/Canto/Config/ExtensionConf.pm
@@ -70,7 +70,7 @@ sub parse {
       next if $line =~ /^#/;
 
       my ($domain, $subset_rel, $allowed_relation, $range, $display_text, $help_text,
-          $cardinality, $role) =
+          $cardinality, $role, $annotation_type_name) =
             split (/\t/, $line);
 
       if ($domain =~ /^\s*domain/i) {
@@ -175,6 +175,7 @@ sub parse {
         help_text => $help_text,
         cardinality => \@cardinality,
         role => $role,
+        annotation_type_name => $annotation_type_name,
       );
 
       if ($domain =~ /(\S+)-(\S+)/) {

--- a/root/curs/modules/ontology.mhtml
+++ b/root/curs/modules/ontology.mhtml
@@ -59,7 +59,8 @@ Annotation extensions
       <extension-builder extension="data.extension"
                          feature-display-name='<% $feature_display_name %>'
                          term-id="{{currentTerm()}}"
-                         is-valid="extensionBuilderIsValid"></extension-builder>
+                         is-valid="extensionBuilderIsValid"
+                         annotation-type-name="{{annotation_type_name}}"></extension-builder>
     </div>
   </div>
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2141,7 +2141,7 @@ function extensionConfFilter(allConfigs, subsetIds, role, annotationTypeName) {
       if (conf.annotation_type_name &&
           conf.annotation_type_name !== annotationTypeName) {
         var found = false;
-        var parts = conf.annotation_type_name.split(/|/);
+        var parts = conf.annotation_type_name.split(/\|/);
 
         $.map(parts, function(part) {
           if (part.match(/\w/) && annotationTypeName === part) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2130,8 +2130,8 @@ function arrayIntersection(arr1, arr2) {
 // Filter the extension_configuration results from the server and return
 // only those where the "domain" term ID in the configuration matches one of
 // subsetIds.  Also ignore any configs where the "role" is "admin" and the
-// current, logged in user isn't an admin.
-function extensionConfFilter(allConfigs, subsetIds, annotationTypeName, role) {
+// current, logged in user isn't an admin.  
+function extensionConfFilter(allConfigs, subsetIds, role) {
   return $.map(allConfigs,
     function (conf) {
       if (conf.role == 'admin' &&

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2131,12 +2131,26 @@ function arrayIntersection(arr1, arr2) {
 // only those where the "domain" term ID in the configuration matches one of
 // subsetIds.  Also ignore any configs where the "role" is "admin" and the
 // current, logged in user isn't an admin.  
-function extensionConfFilter(allConfigs, subsetIds, role) {
+function extensionConfFilter(allConfigs, subsetIds, role, annotationTypeName) {
   return $.map(allConfigs,
     function (conf) {
       if (conf.role == 'admin' &&
         role != 'admin') {
         return;
+      }
+      if (conf.annotation_type_name &&
+          conf.annotation_type_name !== annotationTypeName) {
+        var found = false;
+        var parts = conf.annotation_type_name.split(/|/);
+
+        $.map(parts, function(part) {
+          if (part.match(/\w/) && annotationTypeName === part) {
+            found = true;
+          }
+        });
+        if (!found) {
+          return;
+        }
       }
       var matched =
         $.grep(conf.subset_rel,
@@ -2184,7 +2198,7 @@ canto.controller('ExtensionBuilderDialogCtrl',
   ]);
 
 
-function openExtensionBuilderDialog($uibModal, extension, termId, featureDisplayName) {
+function openExtensionBuilderDialog($uibModal, extension, termId, featureDisplayName, annotationTypeName) {
   return $uibModal.open({
     templateUrl: app_static_path + 'ng_templates/extension_builder_dialog.html',
     controller: 'ExtensionBuilderDialogCtrl',
@@ -2197,6 +2211,7 @@ function openExtensionBuilderDialog($uibModal, extension, termId, featureDisplay
           extension: angular.copy(extension),
           termId: termId,
           featureDisplayName: featureDisplayName,
+          annotationTypeName: annotationTypeName,
         };
       },
     },
@@ -2622,6 +2637,7 @@ var extensionBuilder =
         termId: '@',
         featureDisplayName: '@',
         isValid: '=',
+        annotationTypeName: '@',
       },
       restrict: 'E',
       replace: true,
@@ -2652,7 +2668,8 @@ var extensionBuilder =
             subset_ids && subset_ids.length > 0) {
             var newConf =
               extensionConfFilter($scope.extensionConfiguration, subset_ids,
-                CantoGlobals.current_user_is_admin ? 'admin' : 'user');
+                                  CantoGlobals.current_user_is_admin ? 'admin' : 'user',
+                                  $scope.annotationTypeName);
             copyObject(newConf, $scope.matchingConfigurations);
             return;
           }
@@ -3075,7 +3092,8 @@ var ontologyWorkflowCtrl =
       if (subset_ids && subset_ids.length > 0) {
         $scope.matchingExtensionConfigs =
           extensionConfFilter($scope.extensionConfiguration, subset_ids,
-            CantoGlobals.current_user_is_admin ? 'admin' : 'user');
+                              CantoGlobals.current_user_is_admin ? 'admin' : 'user',
+                              $scope.annotationTypeName);
         return;
       }
 
@@ -7035,7 +7053,8 @@ var annotationEditDialogCtrl =
                 subset_ids && subset_ids.length > 0) {
               $scope.matchingConfigurations =
                 extensionConfFilter(extensionConfiguration, subset_ids,
-                                    CantoGlobals.current_user_is_admin ? 'admin' : 'user');
+                                    CantoGlobals.current_user_is_admin ? 'admin' : 'user',
+                                    $scope.annotationTypeName);
             } else {
               $scope.matchingConfigurations = [];
             }
@@ -7083,8 +7102,9 @@ var annotationEditDialogCtrl =
     $scope.editExtension = function () {
       var editPromise =
         openExtensionBuilderDialog($uibModal, $scope.annotation.extension,
-          $scope.annotation.term_ontid,
-          $scope.currentFeatureDisplayName);
+                                   $scope.annotation.term_ontid,
+                                   $scope.currentFeatureDisplayName,
+                                   $scope.annotationTypeName);
 
       editPromise.then(function (result) {
         angular.copy(result.extension, $scope.annotation.extension);

--- a/root/static/ng_templates/extension_builder_dialog.html
+++ b/root/static/ng_templates/extension_builder_dialog.html
@@ -7,7 +7,8 @@
   <div class="modal-body">
     <extension-builder extension="data.extension" term-id="{{data.termId}}"
                        feature-display-name="{{data.featureDisplayName}}"
-                       is-valid="extensionBuilderIsValid"></extension-builder>
+                       is-valid="extensionBuilderIsValid"
+                       annotation-type-name="{{data.annotationTypeName}}"></extension-builder>
   </div>
   <div class="modal-footer">
     <button class="btn btn-warning" ng-click="cancel()">Cancel</button>

--- a/t/50_config.t
+++ b/t/50_config.t
@@ -104,9 +104,10 @@ cmp_deeply($config_with_suffix->{extension_configuration},
               'help_text' => '',
               'domain' => 'GO:0016023',
               'role' => 'user',
+              'annotation_type_name' => undef,
               'subset_rel' => [
                                 'is_a'
-                              ]
+                        ]
             },
             {
               'subset_rel' => [
@@ -127,7 +128,8 @@ cmp_deeply($config_with_suffix->{extension_configuration},
               'cardinality' => [
                                  '*'
                                ],
-              'display_text' => 'Something that happens during'
+              'display_text' => 'Something that happens during',
+              'annotation_type_name' => undef,
             },
             {
               'subset_rel' => [
@@ -146,7 +148,8 @@ cmp_deeply($config_with_suffix->{extension_configuration},
                                  '0',
                                  '1'
                                ],
-              'allowed_relation' => 'localizes'
+              'allowed_relation' => 'localizes',
+              'annotation_type_name' => undef,
             },
             {
               'cardinality' => [
@@ -168,7 +171,8 @@ cmp_deeply($config_with_suffix->{extension_configuration},
               'role' => 'user',
               'subset_rel' => [
                                 'is_a'
-                              ]
+                              ],
+              'annotation_type_name' => 'biological_process',
             },
             {
               'allowed_relation' => 'modifies_residue',
@@ -188,7 +192,8 @@ cmp_deeply($config_with_suffix->{extension_configuration},
               'role' => 'user',
               'subset_rel' => [
                                 'is_a'
-                              ]
+                              ],
+              'annotation_type_name' => undef,
             },
             {
               'exclude_subset_ids' => ['is_a(GO:0055085)'],
@@ -208,10 +213,11 @@ cmp_deeply($config_with_suffix->{extension_configuration},
                              'type' => 'Gene'
                            }
                          ],
-              'display_text' => 'localizes'
+              'display_text' => 'localizes',
+              'annotation_type_name' => undef,
             },
             {
-              'help_text' => '',
+             'help_text' => '',
               'range' => [
                            {
                              'type' => 'Gene'
@@ -227,7 +233,8 @@ cmp_deeply($config_with_suffix->{extension_configuration},
               'subset_rel' => [
                                 'is_a'
                               ],
-              'role' => 'user'
+              'role' => 'user',
+             'annotation_type_name' => undef,
             },
             {
               'role' => 'user',
@@ -246,7 +253,8 @@ cmp_deeply($config_with_suffix->{extension_configuration},
                            {
                              'type' => 'Gene'
                            }
-                         ]
+                         ],
+              'annotation_type_name' => undef,
             },
             {
               'subset_rel' => [
@@ -271,7 +279,8 @@ cmp_deeply($config_with_suffix->{extension_configuration},
                                  '0',
                                  '1'
                                ],
-              'display_text' => 'penetrance'
+              'display_text' => 'penetrance',
+              'annotation_type_name' => undef,
             }
           ]);
 

--- a/t/50_extension_conf.t
+++ b/t/50_extension_conf.t
@@ -22,6 +22,7 @@ cmp_deeply($conf[0],
              'cardinality' => [0,1],
              'allowed_relation' => 'has_substrate',
              'role' => 'user',
+             'annotation_type_name' => undef,
            });
 
 cmp_deeply($conf[1]->{cardinality}, ['*']);

--- a/t/data/extension_config.tsv
+++ b/t/data/extension_config.tsv
@@ -1,7 +1,7 @@
 GO:0016023	is_a	has_substrate	GENE	kinase substrate		0,1	user
 GO:0016023	is_a	happens_during	GO:0005215	Something that happens during		*	user
 GO:0022857	is_a	localizes	GENE	localizes		0,1	user
-GO:0022857	is_a	occurs_at	SO:0001799	occurs at		0,1	user
+GO:0022857	is_a	occurs_at	SO:0001799	occurs at		0,1	user	biological_process
 GO:0022857	is_a	modifies_residue	TEXT	occurs at		0,1	user
 GO:0006810-is_a(GO:0055085)	is_a	localizes	GENE	localizes		0,1	user
 GO:0034762	is_a	occurs_at	GENE	occurs at		0,1	user


### PR DESCRIPTION
This is on a branch for now to allow for testing.  It works for me.  :-)

I've added the new column to the right of the table and it's optional so no changes are need to existing configuration file.

As an example, here's how to restrict has_input for GO:0016485 to biological_process only:

```
GO:0016485    is_a   has_input    ProteinID    processes    0,1    user    biological_process
```

There can be multiple annotation type names separated by "|".  eg.

```
GO:0016485    is_a   has_input    ProteinID    processes    0,1    user    biological_process|molecular_function
```