### PR TITLE
Be explicit about what the 'Add another [gene] ...' link does

### DIFF
--- a/root/static/ng_templates/extension_relation_edit.html
+++ b/root/static/ng_templates/extension_relation_edit.html
@@ -6,7 +6,7 @@
                      chosen-feature-uniquename="extensionRelation.rangeValue"
                      chosen-feature-display-name="extensionRelation.rangeDisplayName"
                      chosen-feature-id="rangeGeneId"></feature-chooser>
-    <a ng-click="openSingleGeneAddDialog()">Add another ...</a>
+    <a ng-click="openSingleGeneAddDialog()">Add new gene to this session…</a>
   </span>
   <span ng-if="rangeConfig.type == 'Metagenotype'">
     <span ng-if="disabled">Metagenotype</span>


### PR DESCRIPTION
(See #2369)

This pull request amends the link text in the extension editing modal so that it clearly indicates that the link adds another gene to the session, rather than adding another feature to the extension (in the case of extensions with a range of GeneID and a cardinality greater than one).

**Before**

![extension-gene-link-before](https://user-images.githubusercontent.com/37659591/100601103-15917880-32fa-11eb-8deb-90aec9265b91.PNG)

**After**

![extension-gene-link-after](https://user-images.githubusercontent.com/37659591/100601251-42459000-32fa-11eb-8d4b-0b97662aa05b.png)


@kimrutherford I'd like some feedback on the following points:

* There are two other templates that share the 'Add another ...' wording: `annotation_edit.html` and `annotation_evidence.html`. In both cases it looks like these links mean 'Add another gene to this session'. Do you want me to amend all of these links to use the same text as `extension_relation_edit.html`?

* I've changed the three consecutive full-stops (at the end of the link text) to an actual ellipsis character. I chose not to entity-encode this as `&hellip;` for the sake of keeping the template clean (since my editor font can display the ellipsis), and because we seem to be serving our templates as UTF-8, so there shouldn't be any encoding issues. Please let me know if you have any problems with this approach.
