### PR TITLE
Fix missing autocomplete results in dialogs

### DIFF
--- a/root/static/ng_templates/allele_edit.html
+++ b/root/static/ng_templates/allele_edit.html
@@ -1,5 +1,5 @@
 <div class="curs-allele-edit">
-  <form name="cursAlleleEdit" class="curs-allele-edit-dialog modal-content">
+  <form name="cursAlleleEdit" class="ui-front curs-allele-edit-dialog modal-content">
     <div class="modal-header">
       <h4 class="modal-title">
         <span ng-if="alleleData.display_name && !isCopied">

--- a/root/static/ng_templates/annotation_edit.html
+++ b/root/static/ng_templates/annotation_edit.html
@@ -1,4 +1,4 @@
-<div class="curs-annotation-edit" ng-if="annotationType">
+<div class="ui-front curs-annotation-edit" ng-if="annotationType">
   <div class="modal-header">
     <h4 ng-show="newlyAdded" class="modal-title">
       Edit fields to create a new {{annotationType.display_name}} annotation <span ng-show="annotation.feature_display_name">for {{annotation.feature_display_name}}</span>

--- a/root/static/ng_templates/extension_relation_dialog.html
+++ b/root/static/ng_templates/extension_relation_dialog.html
@@ -1,4 +1,4 @@
-<div class="modal-content">
+<div class="ui-front modal-content">
   <div class="modal-body">
     <div>{{relationConfig.displayText}}</span>
     <div ng-if="relationConfig.range.length == 1">


### PR DESCRIPTION
(Replaces #2373)

After a bunch of Google searching I found a better solution, documented here: https://api.jqueryui.com/autocomplete/#option-appendTo

I've added a "ui-front" class to the dialog HTML and that seems to do the trick.   For now I've just added it to the two dialog templates that I think need it, but there might be other places.
