### PR TITLE
Fix centring of loading spinner

### DIFF
--- a/root/static/js/canto.js
+++ b/root/static/js/canto.js
@@ -35,12 +35,7 @@ $(function () {
     .position({
       my: 'center',
       at: 'center',
-      of: $('#content')
-    })
-  loadingDiv
-    .offset({
-      top: 0,
-      left: 200
+      of: $(window)
     })
     .hide()  // hide it initially
     .on('ajaxStart.canto', loadingStart)


### PR DESCRIPTION
I noticed that on the webpack branch, the loading spinner was positioned near the top left of the screen.  This seems to fix it.