### PR TITLE
Indicate number of required or available annotation extensions

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1569,6 +1569,14 @@ a:not([href]) {
   color: grey;
 }
 
+.curs-cardinality-required {
+  color: #8C0000;
+}
+
+.curs-cardinality-available {
+  color: #4F4F4F;
+}
+
 .curs-extension-name-complete-hint {
   white-space: nowrap;
   padding-left: 1em;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2550,35 +2550,41 @@ var extensionOrGroupBuilder =
         };
 
         $scope.cardinalityStatus = function (extensionRelConf) {
-          var count = $scope.getCardinalityCount(extensionRelConf);
+          var extensionCount = $scope.getCardinalityCount(extensionRelConf);
           var cardinalityConf = extensionRelConf.cardinality;
-
-          if (cardinalityConf.length == 1) {
-            if (cardinalityConf[0] == '*') {
-              return 'MORE_POSSIBLE';
-            }
-
-            if (cardinalityConf[0] == count) {
+          var minCardinality = cardinalityConf[0];
+          if (minCardinality == 0) {
+            if (cardinalityConf.length === 1) {
               return 'MAX_REACHED';
             }
-
-            return 'MORE_REQUIRED';
+            if (extensionCount == 0) {
+              return 'OPTIONAL';
+            }
           }
-
-          if (cardinalityConf.length == 2) {
-            if ((cardinalityConf[0] == 0 &&
-                cardinalityConf[1] == 1) ||
-              (cardinalityConf[1] == 0 &&
-                cardinalityConf[0] == 1)) {
-              if (count == 1) {
+          var i, cardinality, isLastCardinality;
+          for (i = 0; i < cardinalityConf.length; i += 1) {
+            cardinality = cardinalityConf[i];
+            if (cardinality == '*') {
+              return 'OPTIONAL';
+            }
+            isLastCardinality = (i == cardinalityConf.length - 1);
+            if (extensionCount == cardinality) {
+              if (isLastCardinality) {
                 return 'MAX_REACHED';
               }
-              // fall through
+              if (cardinalityConf[i + 1] == '*') {
+                return 'MORE_OPTIONAL'
+              }
+              return 'MORE_AVAILABLE';
             }
-            // fall through
+            if (extensionCount < cardinality) {
+              return 'MORE_REQUIRED';
+            }
+            if (extensionCount > cardinality) {
+              continue;
+            }
           }
-
-          return 'MORE_POSSIBLE';
+          return 'OPTIONAL';
         };
 
         $scope.setIsValid = function () {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2567,7 +2567,7 @@ var extensionOrGroupBuilder =
             if (cardinality == '*') {
               return 'OPTIONAL';
             }
-            isLastCardinality = (i == cardinalityConf.length - 1);
+            isLastCardinality = (i === cardinalityConf.length - 1);
             if (extensionCount == cardinality) {
               if (isLastCardinality) {
                 return 'MAX_REACHED';

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2590,9 +2590,6 @@ var extensionOrGroupBuilder =
             if (extensionCount < cardinality) {
               return 'MORE_REQUIRED';
             }
-            if (extensionCount > cardinality) {
-              continue;
-            }
           }
           return 'OPTIONAL';
         };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2543,7 +2543,7 @@ var extensionOrGroupBuilder =
             if (cardinality == '*') {
               return Infinity;
             }
-            if (count <= cardinality) {
+            if (count < cardinality) {
               return cardinality - count;
             }
           }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2583,7 +2583,7 @@ var extensionOrGroupBuilder =
                 return 'MAX_REACHED';
               }
               if (cardinalityConf[i + 1] == '*') {
-                return 'MORE_OPTIONAL'
+                return 'OPTIONAL'
               }
               return 'MORE_AVAILABLE';
             }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2534,6 +2534,21 @@ var extensionOrGroupBuilder =
           return 0;
         };
 
+        $scope.getMaxCardinality = function (extensionRelConf) {
+          var cardinalityConf = extensionRelConf.cardinality;
+          var maxCardinality = cardinalityConf[cardinalityConf.length - 1];
+          if (maxCardinality == '*') {
+            return Infinity;
+          }
+          return maxCardinality;
+        };
+
+        $scope.getRemainingCardinality = function (extensionRelConf) {
+          var count = $scope.getCardinalityCount(extensionRelConf);
+          var maxCardinality = $scope.getMaxCardinality(extensionRelConf);
+          return maxCardinality - count;
+        };
+
         $scope.cardinalityStatus = function (extensionRelConf) {
           var count = $scope.getCardinalityCount(extensionRelConf);
           var cardinalityConf = extensionRelConf.cardinality;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2545,8 +2545,18 @@ var extensionOrGroupBuilder =
 
         $scope.getRemainingCardinality = function (extensionRelConf) {
           var count = $scope.getCardinalityCount(extensionRelConf);
-          var maxCardinality = $scope.getMaxCardinality(extensionRelConf);
-          return maxCardinality - count;
+          var cardinalityConf = extensionRelConf.cardinality;
+          var i, cardinality;
+          for (i = 0; i < cardinalityConf.length; i += 1) {
+            cardinality = cardinalityConf[i];
+            if (cardinality == '*') {
+              return Infinity;
+            }
+            if (count <= cardinality) {
+              return cardinality - count;
+            }
+          }
+          return 0;
         };
 
         $scope.cardinalityStatus = function (extensionRelConf) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2534,15 +2534,6 @@ var extensionOrGroupBuilder =
           return 0;
         };
 
-        $scope.getMaxCardinality = function (extensionRelConf) {
-          var cardinalityConf = extensionRelConf.cardinality;
-          var maxCardinality = cardinalityConf[cardinalityConf.length - 1];
-          if (maxCardinality == '*') {
-            return Infinity;
-          }
-          return maxCardinality;
-        };
-
         $scope.getRemainingCardinality = function (extensionRelConf) {
           var count = $scope.getCardinalityCount(extensionRelConf);
           var cardinalityConf = extensionRelConf.cardinality;

--- a/root/static/ng_templates/extension_or_group_builder.html
+++ b/root/static/ng_templates/extension_or_group_builder.html
@@ -3,17 +3,17 @@
     <ul>
     <li ng-repeat="extConf in matchingConfigurations">
       <span ng-switch="cardinalityStatus(extConf)">
-      <span class="curs-extension-already-used" ng-switch-when="MAX_REACHED"
-            tooltip="This extension relation type cannot be added more times for this annotation">
-        {{extConf.displayText}}
-      </span>
-      <span ng-switch-when="MORE_POSSIBLE" uib-tooltip="{{debugConfText(extConf)}}">
-        <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
-      </span>
-      <span ng-switch-when="MORE_REQUIRED" uib-tooltip="{{debugConfText(extConf)}}">
-        <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
-        <span style="color: red;">required</span>
-      </span>
+        <span class="curs-extension-already-used" ng-switch-when="MAX_REACHED"
+              tooltip="This extension relation type cannot be added more times for this annotation">
+          {{extConf.displayText}}
+        </span>
+        <span ng-switch-when="MORE_POSSIBLE" uib-tooltip="{{debugConfText(extConf)}}">
+          <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
+        </span>
+        <span ng-switch-when="MORE_REQUIRED" uib-tooltip="{{debugConfText(extConf)}}">
+          <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
+          <span style="color: red;">required</span>
+        </span>
       </span>
     </li>
     </ul>

--- a/root/static/ng_templates/extension_or_group_builder.html
+++ b/root/static/ng_templates/extension_or_group_builder.html
@@ -7,7 +7,7 @@
               tooltip="This extension relation type cannot be added more times for this annotation">
           {{extConf.displayText}}
         </span>
-        <span ng-switch-when="OPTIONAL|MORE_OPTIONAL" ng-switch-when-separator="|" uib-tooltip="{{debugConfText(extConf)}}">
+        <span ng-switch-when="OPTIONAL" uib-tooltip="{{debugConfText(extConf)}}">
           <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
         </span>
         <span ng-switch-when="MORE_AVAILABLE" uib-tooltip="{{debugConfText(extConf)}}">

--- a/root/static/ng_templates/extension_or_group_builder.html
+++ b/root/static/ng_templates/extension_or_group_builder.html
@@ -9,10 +9,19 @@
         </span>
         <span ng-switch-when="MORE_POSSIBLE" uib-tooltip="{{debugConfText(extConf)}}">
           <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
+          <span ng-if="getRemainingCardinality(extConf) !== Infinity">
+            ({{getRemainingCardinality(extConf)}} more available)
+          </span>
         </span>
         <span ng-switch-when="MORE_REQUIRED" uib-tooltip="{{debugConfText(extConf)}}">
           <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
-          <span style="color: red;">required</span>
+          <span ng-if="getCardinalityCount(extConf) == 0" style="color: red;">
+            ({{getRemainingCardinality(extConf)}} required)
+          </span>
+          <span ng-if="getCardinalityCount(extConf) > 0" style="color: red;">
+            ({{getRemainingCardinality(extConf)}} more required)
+          </span>
+        </span>
         </span>
       </span>
     </li>

--- a/root/static/ng_templates/extension_or_group_builder.html
+++ b/root/static/ng_templates/extension_or_group_builder.html
@@ -12,16 +12,16 @@
         </span>
         <span ng-switch-when="MORE_AVAILABLE" uib-tooltip="{{debugConfText(extConf)}}">
           <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
-          <span ng-if="getRemainingCardinality(extConf) !== Infinity">
+          <span class="curs-cardinality-available" ng-if="getRemainingCardinality(extConf) !== Infinity">
             ({{getRemainingCardinality(extConf)}} more available)
           </span>
         </span>
         <span ng-switch-when="MORE_REQUIRED" uib-tooltip="{{debugConfText(extConf)}}">
           <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
-          <span ng-if="getCardinalityCount(extConf) == 0" style="color: red;">
+          <span class="curs-cardinality-required" ng-if="getCardinalityCount(extConf) == 0">
             ({{getRemainingCardinality(extConf)}} required)
           </span>
-          <span ng-if="getCardinalityCount(extConf) > 0" style="color: red;">
+          <span class="curs-cardinality-required" ng-if="getCardinalityCount(extConf) > 0">
             ({{getRemainingCardinality(extConf)}} more required)
           </span>
         </span>

--- a/root/static/ng_templates/extension_or_group_builder.html
+++ b/root/static/ng_templates/extension_or_group_builder.html
@@ -7,7 +7,10 @@
               tooltip="This extension relation type cannot be added more times for this annotation">
           {{extConf.displayText}}
         </span>
-        <span ng-switch-when="MORE_POSSIBLE" uib-tooltip="{{debugConfText(extConf)}}">
+        <span ng-switch-when="OPTIONAL|MORE_OPTIONAL" ng-switch-when-separator="|" uib-tooltip="{{debugConfText(extConf)}}">
+          <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
+        </span>
+        <span ng-switch-when="MORE_AVAILABLE" uib-tooltip="{{debugConfText(extConf)}}">
           <a href="" ng-click="startAddRelation(extConf)">{{extConf.displayText}}</a>
           <span ng-if="getRemainingCardinality(extConf) !== Infinity">
             ({{getRemainingCardinality(extConf)}} more available)


### PR DESCRIPTION
(References https://github.com/pombase/canto/issues/2369)

This pull request adds more information to the extension picker list (extension_or_group_builder.html), such that the list now indicates, for each extension, how many instances of that extension are available or required.

The messages are initially hidden, except where the extension is required (that is, where the first cardinality in the range is greater than zero). This is because many extensions have cardinality ranges of [0,1] and it just clutters up the interface having messages of '1 more available' next to every extension.

For example, the following annotation extension has a range of [0,2], so the message is hidden:

![image](https://user-images.githubusercontent.com/37659591/103653555-99273080-4f5c-11eb-96c7-0de71e2e9a63.png)

If the range were to omit zero and just be [2], the code would treat the extension as required, and the message would change accordingly:

![image](https://user-images.githubusercontent.com/37659591/103653204-1aca8e80-4f5c-11eb-92f1-ff4b64676b61.png)

After one instance of the extension is added, the message changes to state that more instances are required (this would also happen if the range were [0,2] since 1 would not be valid in that case):

![image](https://user-images.githubusercontent.com/37659591/103653260-2c139b00-4f5c-11eb-9a04-29aafaf6756b.png)

When there are multiple valid cardinality intervals, for example [0,1,2], the code uses a different message to indicate this: '_n_ more available'. In the example below, one instance of the extension has been added, which is in the valid range, and the curator is informed that one more instance can be added before the maximum cardinality (or more generally, the next interval) is reached:

![image](https://user-images.githubusercontent.com/37659591/103653120-f5d61b80-4f5b-11eb-95c7-3ed70bd35be7.png)

## Implementation details

I added two cardinality status codes to enable this new functionality:

* **OPTIONAL**: Used when the cardinality range has a minimum of zero and no instances of the extension have yet been added. Also used whenever an asterisk is encountered in the cardinality range.

* **MORE_AVAILABLE**: Used when there are multiple consecutive intervals in the cardinality range (e.g. [0,1,2]) to prompt the curator that more extensions can be added, but they are not required.

The MORE_POSSIBLE status code has been removed, since its purpose is now handled by a combination of the two new status codes.

As part of the changes, it's now possible to define a range of '_n_ or more' with the syntax `n,*`, where _n_ is any number. I think the code even supports ranges of '_n_ or _m_ or more' with the syntax `n,m,*`, up to an arbitrary number of intervals.

Zero is also a valid range, both for the sake of completeness and because it seemed safer to handle zero explicitly. Zero cardinality [0] has the effect of disabling the extension, so it's not useful in practice.

Here's a table summarising which messages are shown (if any) under a number of possible extension ranges:

Cardinality range | Extension count | Message
-: | -: | --
`*` | _n_ | [none]
`0,1` | 0 | [none]
`0,1,2` | 0 | [none]
`0,1,2` | 1 | 1 more available
`1` | 0 | 1 required
`2` | 1 | 1 more required
`0,1,3` | 2 | 1 more required
`2,*` | 0 | 2 required
`2,*` | _n_ > 2 | [none]

The list of cases handled by the code isn't exhaustive, so its behaviour isn't defined in the case of nonsensical cardinality ranges like `0,0,0` or `7,3,1` or even redundant ranges like `0,*`. I think this would be better handled by validating the extension configuration on the server side.