### PR TITLE
Load tag-it from versioned copy instead of node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "jquery": "^3.5.1",
     "jquery-form": "^4.3.0",
     "jquery-ui": "^1.12.1",
-    "pnotify": "^5.1.2",
-    "tag-it": "2.0.0"
+    "pnotify": "^5.1.2"
   }
 }

--- a/root/static/js/tag-it.js
+++ b/root/static/js/tag-it.js
@@ -121,7 +121,7 @@
                 this.options.singleFieldNode = this.element;
                 this.element.addClass('tagit-hidden-field');
             } else {
-                this.tagList = this.element.find('ul, ol').andSelf().last();
+                this.tagList = this.element.find('ul, ol').addBack().last();
             }
 
             this.tagInput = $('<input type="text" />').addClass('ui-widget-content');

--- a/root/static/js/tag-it.js
+++ b/root/static/js/tag-it.js
@@ -267,7 +267,7 @@
 
                         // Autocomplete will create its own tag from a selection and close automatically.
                         if (!(that.options.autocomplete.autoFocus && that.tagInput.data('autocomplete-open'))) {
-                            var focusedItem = that.tagInput.autocomplete('widget').find('.ui-menu-item > .ui-state-focus');
+                            var focusedItem = that.tagInput.autocomplete('widget').find('.ui-menu-item > .ui-state-active');
                             if (focusedItem.length > 0) {
                                 that.createTag(focusedItem[0].innerText);
                             } else {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
   mode: 'development',
   resolve: {
     alias: {
-      'tag-it': path.resolve(__dirname, 'node_modules/tag-it/js/tag-it.js')
+      'tag-it': path.resolve(__dirname, 'root/static/js/tag-it.js')
     }
   },
   plugins: [


### PR DESCRIPTION
(Fixes #2376)

This pull request has webpack load tag-it from a locally versioned script file (root/static/tag-it.js) instead of loading the file from node_modules, so that we can apply patches to tag-it more easily. We were already using a custom resolver to load the unminified version of tag-it, so the changes are minimal.

Our versioned copy of tag-it already contains a bunch of fixes that still aren't in the version from npm (and there's no newer version on npm as far as I can see), so I think using the patched versioned copy is definitely a better solution.

Included in the PR is a fix for an obsolete jQuery method, plus an additional fix to allow auto-completion of focused entries using the keyboard, since it seems the original fix from commit 2f19a53a18d4e1dc561eb07c81c1d1054a7dc06d broke due to a difference in selector class names (see #2163).

@kimrutherford I've tested the changes and everything seems to work as it should. If you don't think you need to test it yourself, feel free to merge.