### PR TITLE
Use flex display mode for Metagenotype Management page

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1727,6 +1727,17 @@ a:not([href]) {
   font-weight: 700;
   margin-bottom: 10px;
 }
+.curs-metagenotype-picker-columns {
+  display: flex;
+  flex-wrap: wrap;
+}
+.curs-metagenotype-picker-column-pathogen {
+  flex-basis: 530px;
+  padding-right: 30px;
+}
+.curs-metagenotype-picker-column-host {
+  flex-shrink: 1;
+}
 
 .curs-warning-container {
   display: flex;

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1600,11 +1600,6 @@ a:not([href]) {
   margin-top: 10px;
 }
 
-.curs-metagenotype-manage-pathogen, .curs-metagenotype-manage-host {
-  width: 49%;
-  float: left;
-}
-
 .gene-button-delete-text-disabled {
   color: whitesmoke;
 }

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -13,7 +13,7 @@
                 is-host="false"
                 selected-organism="selectedPathogen"
                 genotypes="selectedPathogenGenotypes"
-                on-genotype-select="onPathogenGenotypeSelect(genotype)"
+                on-genotype-select="onPathogenGenotypeSelect(genotype)">
             </metagenotype-genotype-picker>
         </div>
         <div class="col-md-6">
@@ -27,7 +27,7 @@
                 selected-organism="selectedHost"
                 genotypes="selectedHostGenotypes"
                 on-genotype-select="onHostGenotypeSelect(genotype)"
-                on-strain-select="onHostStrainSelect(strain)"
+                on-strain-select="onHostStrainSelect(strain)">
             </metagenotype-genotype-picker>
         </div>
     </div>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -1,34 +1,36 @@
 <div id="curs-genotype-manage" class="genotype-list ng-cloak container">
     <div class="row" ng-if="display">
-        <div class="col-md-12">
+        <div>
             <p>Choose a pathogen and host genotype to combine into a metagenotype.</p>
         </div>
-        <div class="col-md-6">
-            <div class="curs-metagenotype-picker-heading">Pathogen</div>
-            <organism-selector
-                organisms="pathogenOrganisms"
-                organism-selected="onPathogenSelected(organism)">
-            </organism-selector>
-            <metagenotype-genotype-picker
-                is-host="false"
-                selected-organism="selectedPathogen"
-                genotypes="selectedPathogenGenotypes"
-                on-genotype-select="onPathogenGenotypeSelect(genotype)">
-            </metagenotype-genotype-picker>
-        </div>
-        <div class="col-md-6">
-            <div class="curs-metagenotype-picker-heading">Host</div>
-            <organism-selector
-                organisms="hostOrganisms"
-                organism-selected="onHostSelected(organism)">
-            </organism-selector>
-            <metagenotype-genotype-picker
-                is-host="true"
-                selected-organism="selectedHost"
-                genotypes="selectedHostGenotypes"
-                on-genotype-select="onHostGenotypeSelect(genotype)"
-                on-strain-select="onHostStrainSelect(strain)">
-            </metagenotype-genotype-picker>
+        <div class="curs-metagenotype-picker-columns">
+            <div class="curs-metagenotype-picker-column-pathogen">
+                <div class="curs-metagenotype-picker-heading">Pathogen</div>
+                <organism-selector
+                    organisms="pathogenOrganisms"
+                    organism-selected="onPathogenSelected(organism)">
+                </organism-selector>
+                <metagenotype-genotype-picker
+                    is-host="false"
+                    selected-organism="selectedPathogen"
+                    genotypes="selectedPathogenGenotypes"
+                    on-genotype-select="onPathogenGenotypeSelect(genotype)">
+                </metagenotype-genotype-picker>
+            </div>
+            <div class="curs-metagenotype-picker-column-host">
+                <div class="curs-metagenotype-picker-heading">Host</div>
+                <organism-selector
+                    organisms="hostOrganisms"
+                    organism-selected="onHostSelected(organism)">
+                </organism-selector>
+                <metagenotype-genotype-picker
+                    is-host="true"
+                    selected-organism="selectedHost"
+                    genotypes="selectedHostGenotypes"
+                    on-genotype-select="onHostGenotypeSelect(genotype)"
+                    on-strain-select="onHostStrainSelect(strain)">
+                </metagenotype-genotype-picker>
+            </div>
         </div>
     </div>
     <div class="row">


### PR DESCRIPTION
Fixes #2409

This pull request changes the container for the genotype pickers on the Metagenotype Management page so that their layout is controlled with flexbox rather than Bootstrap column rules. This seems to stop one column overflowing under the other when the table gets too wide, as seen here:

<img width="600" alt="overlay" src="https://user-images.githubusercontent.com/7359272/107125343-53ce8980-68a1-11eb-8a46-42ebbd29cc2e.png">

Under the new layout system, the genotype picker columns will use use roughly half of the available horizontal space each. If the pathogen table grows wider than half the space, the host column shrinks (horizontally) to compensate. If the host column runs out of space for the host table, the whole column wraps below the pathogen column. This should keep both tables readable even in extreme cases.

@ValWood I'm not sure if you prefer to have the columns wrap under each other when the tables get too wide to fit on the screen. It's not ideal, but I hope that more vertical scrolling will be less annoying than horizontal scrolling.

- - -

@kimrutherford Note that as a consequence of the flex rules (mainly `flex-basis`), the pathogen table doesn't shrink to accommodate the host table; if the host table gets too wide, all it can do is wrap under the pathogen column. Trying to use `flex-grow: 1` on both columns led to behaviour that wasn't consistent with the previous layout, since the host column would shift around whenever the pathogen column changed size.

I'm not too keen on mixing Bootstrap columns with flexbox layouts (it would probably be better to choose one or the other) but I decided not to change everything in one go in favour of a faster fix. The only stuff that is still sized with Bootstrap columns seems to be max width anyway (`col-md-12`), so we might be able to use flexbox for everything on this page.