### PR TITLE
Filter metagenotype list by selected organisms 

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -9323,7 +9323,7 @@ var metagenotypeListView = function () {
     replace: true,
     templateUrl: app_static_path + 'ng_templates/metagenotype_list_view.html',
     controller: function ($scope) {
-      $scope.metagenotypes = [];
+      $scope.metagenotypes = null;
       $scope.showBackground = {};
 
       $scope.$watchCollection('metagenotypes', setBackgroundColumnSettings);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -9377,9 +9377,11 @@ var metagenotypeManage = function ($q, CantoGlobals, Curs, CursGenotypeList, Met
       $scope.taxonGenotypeMap = null;
 
       $scope.metagenotypes = null;
+      $scope.filteredMetagenotypes = null;
 
       $scope.$on('metagenotype:updated', function (event, data) {
         $scope.metagenotypes = data;
+        $scope.filteredMetagenotypes = $scope.metagenotypes;
       });
       $scope.$on('metagenotype list changed', function () {
         Metagenotype.load();
@@ -9394,6 +9396,7 @@ var metagenotypeManage = function ($q, CantoGlobals, Curs, CursGenotypeList, Met
         $scope.selectedPathogen = organism;
         $scope.selectedGenotypePathogen = null;
         $scope.selectedPathogenGenotypes = $scope.taxonGenotypeMap[taxonId];
+        filterMetagenotypesBySelectedOrganisms();
       };
 
       $scope.onPathogenGenotypeSelect = function (genotype) {
@@ -9408,6 +9411,7 @@ var metagenotypeManage = function ($q, CantoGlobals, Curs, CursGenotypeList, Met
         $scope.selectedHostGenotypes = taxonId in $scope.taxonGenotypeMap ?
           $scope.taxonGenotypeMap[taxonId] :
           {'single': [], 'multi': []};
+        filterMetagenotypesBySelectedOrganisms();
       };
 
       $scope.onHostGenotypeSelect = function (genotype) {
@@ -9540,6 +9544,24 @@ var metagenotypeManage = function ($q, CantoGlobals, Curs, CursGenotypeList, Met
         });
       }
 
+      function filterMetagenotypesBySelectedOrganisms() {
+        function filterByOrganisms(metagenotype) {
+          var pathogenId = metagenotype.pathogen_genotype.organism.taxonid;
+          var hostId = metagenotype.host_genotype.organism.taxonid;
+          return pathogenId == selectedPathogenId && hostId == selectedHostId;
+        }
+        var selectedPathogenId = null;
+        var selectedHostId = null;
+        if ($scope.selectedPathogen) {
+          selectedPathogenId = $scope.selectedPathogen.taxonid;
+        }
+        if ($scope.selectedHost) {
+          selectedHostId = $scope.selectedHost.taxonid;
+        }
+        if (!! selectedPathogenId && !! selectedHostId) {
+          $scope.filteredMetagenotypes = $scope.metagenotypes.filter(filterByOrganisms);
+        }
+      }
     }
   };
 };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -9396,7 +9396,9 @@ var metagenotypeManage = function ($q, CantoGlobals, Curs, CursGenotypeList, Met
         $scope.selectedPathogen = organism;
         $scope.selectedGenotypePathogen = null;
         $scope.selectedPathogenGenotypes = $scope.taxonGenotypeMap[taxonId];
-        filterMetagenotypesBySelectedOrganisms();
+        $scope.filteredMetagenotypes = filterMetagenotypesBySelectedOrganisms(
+          $scope.selectedPathogen, $scope.selectedHost, $scope.metagenotypes
+        );
       };
 
       $scope.onPathogenGenotypeSelect = function (genotype) {
@@ -9411,7 +9413,9 @@ var metagenotypeManage = function ($q, CantoGlobals, Curs, CursGenotypeList, Met
         $scope.selectedHostGenotypes = taxonId in $scope.taxonGenotypeMap ?
           $scope.taxonGenotypeMap[taxonId] :
           {'single': [], 'multi': []};
-        filterMetagenotypesBySelectedOrganisms();
+        $scope.filteredMetagenotypes = filterMetagenotypesBySelectedOrganisms(
+          $scope.selectedPathogen, $scope.selectedHost, $scope.metagenotypes
+        );
       };
 
       $scope.onHostGenotypeSelect = function (genotype) {
@@ -9544,23 +9548,18 @@ var metagenotypeManage = function ($q, CantoGlobals, Curs, CursGenotypeList, Met
         });
       }
 
-      function filterMetagenotypesBySelectedOrganisms() {
+      function filterMetagenotypesBySelectedOrganisms(selectedPathogen, selectedHost, metagenotypes) {
         function filterByOrganisms(metagenotype) {
           var pathogenId = metagenotype.pathogen_genotype.organism.taxonid;
           var hostId = metagenotype.host_genotype.organism.taxonid;
           return pathogenId == selectedPathogenId && hostId == selectedHostId;
         }
-        var selectedPathogenId = null;
-        var selectedHostId = null;
-        if ($scope.selectedPathogen) {
-          selectedPathogenId = $scope.selectedPathogen.taxonid;
+        if (selectedPathogen && selectedHost) {
+          var selectedPathogenId = selectedPathogen.taxonid;
+          var selectedHostId = selectedHost.taxonid;
+          return metagenotypes.filter(filterByOrganisms);
         }
-        if ($scope.selectedHost) {
-          selectedHostId = $scope.selectedHost.taxonid;
-        }
-        if (!! selectedPathogenId && !! selectedHostId) {
-          $scope.filteredMetagenotypes = $scope.metagenotypes.filter(filterByOrganisms);
-        }
+        return metagenotypes;
       }
     }
   };

--- a/root/static/ng_templates/metagenotype_list_view.html
+++ b/root/static/ng_templates/metagenotype_list_view.html
@@ -22,9 +22,9 @@
                     </thead>
                     <tbody
                     metagenotype-list-row
-                    ng-repeat="meta in metagenotypes track by meta.metagenotype_id"
+                    ng-repeat="metagenotype in metagenotypes track by metagenotype.metagenotype_id"
                     show-background="showBackground"
-                    metagenotype="meta">
+                    metagenotype="metagenotype">
                   </tbody>
                 </table>
             </div>

--- a/root/static/ng_templates/metagenotype_list_view.html
+++ b/root/static/ng_templates/metagenotype_list_view.html
@@ -1,9 +1,12 @@
 <div>
-    <div ng-if="metagenotypes.length > 0">
+    <div ng-if="metagenotypes">
         <div class="row">
             <div class="col-md-12">
                 <h3>Metagenotypes</h3>
-                <table class="curs-genotype-list">
+                <p ng-if="metagenotypes.length == 0">
+                    No metagenotypes have been created for this pathogen and host species. 
+                </p>
+                <table ng-if="metagenotypes.length > 0" class="curs-genotype-list">
                     <thead>
                         <tr>
                             <th colspan="{{showBackground.pathogen ? 3 : 2}}">Pathogen</th>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -47,6 +47,6 @@
         </button>
     </div>
     <div class="row">
-      <metagenotype-list-view></metagenotype-list-view>
+      <metagenotype-list-view metagenotypes="metagenotypes"></metagenotype-list-view>
     </div>
 </div>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -47,6 +47,6 @@
         </button>
     </div>
     <div class="row">
-      <metagenotype-list-view metagenotypes="metagenotypes"></metagenotype-list-view>
+      <metagenotype-list-view metagenotypes="filteredMetagenotypes"></metagenotype-list-view>
     </div>
 </div>


### PR DESCRIPTION
References #2411 

This pull request adds filtering to the table of metagenotypes on the Metagenotype Management page, such that it shows only the metagenotypes that match both the selected pathogen and the selected host. This is in keeping with the behaviour of the Genotype Management page, where only the genotypes for the selected organism are shown.

![image](https://user-images.githubusercontent.com/37659591/107650961-e9d62b80-6c76-11eb-847e-37b25eb7cb22.png)

If the selected pathogen and host don't match any metagenotypes, a message is shown to the curator:

![image](https://user-images.githubusercontent.com/37659591/107649826-c2cb2a00-6c75-11eb-9acd-3ec0285073c3.png)

One thing that is different about this implementation is that _all_ metagenotypes are shown when the page is first loaded, and stay shown until both a pathogen and host are selected. I chose this just in case curators wanted a way to see all the annotations at once. Unfortunately there's no way to get back to this view after selecting a pathogen and a host, because the organisms can't be deselected. The original issue (#2411) suggested some control to disable the filters, but we need to decide on a specific design first.

- - -

As part of this change I moved almost all of the interaction with the `Metagenotype` service to the top of the directive hierarchy for the metagenotype management page, since I needed to access data that wasn't available except at the top of the hierarchy (the `metagenotypeManage` controller). I still don't really understand how the `Metagenotype` service works (it seems to be using different design patterns from our other services, namely event passing with `$rootScope`), but at least it's in a more useful location now.

@kimrutherford If you think everything looks okay, I'm happy for this to be merged now so we can get feedback from curators. I can open new pull requests for any follow-up issues.