### PR TITLE
Refactor GenotypeGeneList directive and controller

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4726,27 +4726,15 @@ var GenotypeGeneListCtrl =
         $scope.curs_root_uri = CantoGlobals.curs_root_uri;
         $scope.read_only_curs = CantoGlobals.read_only_curs;
         $scope.multiOrganismMode = CantoGlobals.multi_organism_mode;
-
         $scope.showQuickDeletionButtons = CantoGlobals.show_quick_deletion_buttons;
 
         var hasDeletionHash = {};
+        var selectedStrain = '';
 
         $scope.$watch('genotypes', makeHasDeletionHash, true);
 
         $scope.hasDeletionGenotype = function(geneId) {
           return !$scope.multiOrganismMode && !!hasDeletionHash[geneId];
-        };
-
-        function makeHasDeletionHash() {
-          hasDeletionHash = {};
-          $scope.genotypes.map(function (genotype) {
-            if (genotype.alleles.length === 1) {
-              var allele = genotype.alleles[0];
-              if (allele.type === 'deletion') {
-                hasDeletionHash[allele.gene_id] = true;
-              }
-            }
-          });
         };
 
         $scope.singleAlleleQuick = function (geneDisplayName, geneSystematicId, geneId) {
@@ -4791,7 +4779,17 @@ var GenotypeGeneListCtrl =
           });
         };
 
-        var selectedStrain = '';
+        $scope.quickDeletion = CantoGlobals.strains_mode ?
+          deleteSelectStrainPicker :
+          makeDeletionAllele;
+
+        $scope.deletionButtonTitle = function (geneId) {
+          if (hasDeletionHash[geneId]) {
+            return 'A deletion genotype already exists for this gene';
+          } else {
+            return 'Add a deletion genotype for this gene';
+          }
+        };
 
         function deleteSelectStrainPicker(geneId) {
           var gene = getGeneById(geneId);
@@ -4861,16 +4859,16 @@ var GenotypeGeneListCtrl =
           });
         };
 
-        $scope.quickDeletion = CantoGlobals.strains_mode ?
-          deleteSelectStrainPicker :
-          makeDeletionAllele;
-
-        $scope.deletionButtonTitle = function (geneId) {
-          if (hasDeletionHash[geneId]) {
-            return 'A deletion genotype already exists for this gene';
-          } else {
-            return 'Add a deletion genotype for this gene';
-          }
+        function makeHasDeletionHash() {
+          hasDeletionHash = {};
+          $scope.genotypes.map(function (genotype) {
+            if (genotype.alleles.length === 1) {
+              var allele = genotype.alleles[0];
+              if (allele.type === 'deletion') {
+                hasDeletionHash[allele.gene_id] = true;
+              }
+            }
+          });
         };
       }
     };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4731,9 +4731,7 @@ var GenotypeGeneListCtrl =
 
         $scope.hasDeletionHash = {};
 
-        $scope.$watch('genotypes', function () {
-          $scope.makeHasDeletionHash();
-        }, true);
+        $scope.$watch('genotypes', $scope.makeHasDeletionHash, true);
 
         $scope.hasDeletionGenotype = function(geneId) {
           return !$scope.multiOrganismMode && !!$scope.hasDeletionHash[geneId];

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4714,7 +4714,7 @@ var GenotypeGeneListCtrl =
     CantoConfig, toaster) {
     return {
       scope: {
-        genotypes: '=',
+        genotypes: '<',
         genes: '<',
         genotypeType: '<'
       },

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4735,8 +4735,8 @@ var GenotypeGeneListCtrl =
           $scope.makeHasDeletionHash();
         }, true);
 
-        $scope.hasDeletionGenotype = function(gene_id) {
-          return !$scope.multiOrganismMode && !!$scope.hasDeletionHash[gene_id];
+        $scope.hasDeletionGenotype = function(geneId) {
+          return !$scope.multiOrganismMode && !!$scope.hasDeletionHash[geneId];
         };
 
         $scope.makeHasDeletionHash = function () {
@@ -4751,8 +4751,8 @@ var GenotypeGeneListCtrl =
           });
         };
 
-        $scope.singleAlleleQuick = function (gene_display_name, gene_systematic_id, gene_id) {
-          var gene = $scope.geneById(gene_id);
+        $scope.singleAlleleQuick = function (geneDisplayName, geneSystematicId, geneId) {
+          var gene = $scope.geneById(geneId);
 
           if (!gene) {
             return;
@@ -4762,9 +4762,9 @@ var GenotypeGeneListCtrl =
           var editInstance = makeAlleleEditInstance(
             $uibModal,
             {
-              gene_display_name: gene_display_name,
-              gene_systematic_id: gene_systematic_id,
-              gene_id: gene_id,
+              gene_display_name: geneDisplayName,
+              gene_systematic_id: geneSystematicId,
+              gene_id: geneId,
             },
             taxonId
           );
@@ -4795,14 +4795,14 @@ var GenotypeGeneListCtrl =
 
         $scope.selectedStrain = '';
 
-        $scope.deleteSelectStrainPicker = function (gene_id) {
-          var gene = $scope.geneById(gene_id);
+        $scope.deleteSelectStrainPicker = function (geneId) {
+          var gene = $scope.geneById(geneId);
           var taxonId = gene.organism.taxonid;
           var deleteInstance = selectStrainPicker($uibModal, taxonId);
 
           deleteInstance.result.then(function (strain) {
             $scope.selectedStrain = strain.strain.strain_name;
-            $scope.makeDeletionAllele(gene_id);
+            $scope.makeDeletionAllele(geneId);
           });
         };
 
@@ -4867,8 +4867,8 @@ var GenotypeGeneListCtrl =
           $scope.deleteSelectStrainPicker :
           $scope.makeDeletionAllele;
 
-        $scope.deletionButtonTitle = function (gene_id) {
-          if ($scope.hasDeletionHash[gene_id]) {
+        $scope.deletionButtonTitle = function (geneId) {
+          if ($scope.hasDeletionHash[geneId]) {
             return 'A deletion genotype already exists for this gene';
           } else {
             return 'Add a deletion genotype for this gene';

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4740,7 +4740,7 @@ var GenotypeGeneListCtrl =
         $scope.makeHasDeletionHash = function () {
           $scope.hasDeletionHash = {};
           $.map($scope.genotypes, function (genotype) {
-            if (genotype.alleles.length == 1) {
+            if (genotype.alleles.length === 1) {
               var allele = genotype.alleles[0];
               if (allele.type === 'deletion') {
                 $scope.hasDeletionHash[allele.gene_id] = true;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4750,7 +4750,7 @@ var GenotypeGeneListCtrl =
         };
 
         $scope.singleAlleleQuick = function (geneDisplayName, geneSystematicId, geneId) {
-          var gene = $scope.geneById(geneId);
+          var gene = $scope.getGeneById(geneId);
 
           if (!gene) {
             return;
@@ -4794,7 +4794,7 @@ var GenotypeGeneListCtrl =
         $scope.selectedStrain = '';
 
         $scope.deleteSelectStrainPicker = function (geneId) {
-          var gene = $scope.geneById(geneId);
+          var gene = $scope.getGeneById(geneId);
           var taxonId = gene.organism.taxonid;
           var deleteInstance = selectStrainPicker($uibModal, taxonId);
 
@@ -4804,7 +4804,7 @@ var GenotypeGeneListCtrl =
           });
         };
 
-        $scope.geneById = function (geneId) {
+        $scope.getGeneById = function (geneId) {
           if ($scope.genes) {
             for (var i = 0, len = $scope.genes.length; i < len; i++) {
               // find gene by ID
@@ -4817,7 +4817,7 @@ var GenotypeGeneListCtrl =
         };
 
         $scope.makeDeletionAllele = function (geneId) {
-          var gene = $scope.geneById(geneId);
+          var gene = $scope.getGeneById(geneId);
 
           if (!gene) {
             return;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4739,7 +4739,7 @@ var GenotypeGeneListCtrl =
 
         $scope.makeHasDeletionHash = function () {
           $scope.hasDeletionHash = {};
-          $.map($scope.genotypes, function (genotype) {
+          $scope.genotypes.map(function (genotype) {
             if (genotype.alleles.length === 1) {
               var allele = genotype.alleles[0];
               if (allele.type === 'deletion') {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4731,10 +4731,9 @@ var GenotypeGeneListCtrl =
 
         $scope.hasDeletionHash = {};
 
-        $scope.$watch('genotypes',
-          function () {
-            $scope.makeHasDeletionHash();
-          }, true);
+        $scope.$watch('genotypes', function () {
+          $scope.makeHasDeletionHash();
+        }, true);
 
         $scope.hasDeletionGenotype = function(gene_id) {
           return !$scope.multiOrganismMode && !!$scope.hasDeletionHash[gene_id];
@@ -4742,15 +4741,14 @@ var GenotypeGeneListCtrl =
 
         $scope.makeHasDeletionHash = function () {
           $scope.hasDeletionHash = {};
-          $.map($scope.genotypes,
-            function (genotype) {
-              if (genotype.alleles.length == 1) {
-                var allele = genotype.alleles[0];
-                if (allele.type === 'deletion') {
-                  $scope.hasDeletionHash[allele.gene_id] = true;
-                }
+          $.map($scope.genotypes, function (genotype) {
+            if (genotype.alleles.length == 1) {
+              var allele = genotype.alleles[0];
+              if (allele.type === 'deletion') {
+                $scope.hasDeletionHash[allele.gene_id] = true;
               }
-            });
+            }
+          });
         };
 
         $scope.singleAlleleQuick = function (gene_display_name, gene_systematic_id, gene_id) {
@@ -4761,22 +4759,33 @@ var GenotypeGeneListCtrl =
           }
 
           var taxonId = gene.organism.taxonid;
-          var editInstance = makeAlleleEditInstance($uibModal, {
+          var editInstance = makeAlleleEditInstance(
+            $uibModal,
+            {
               gene_display_name: gene_display_name,
               gene_systematic_id: gene_systematic_id,
               gene_id: gene_id,
             },
-            taxonId);
+            taxonId
+          );
 
           editInstance.result.then(function (editResults) {
             var alleleData = editResults.alleleData;
             var strainName = editResults.strainName;
-            var storePromise =
-                CursGenotypeList.storeGenotype(toaster, $http, undefined, undefined, undefined, [alleleData], taxonId, strainName, undefined);
+            var storePromise = CursGenotypeList.storeGenotype(
+              toaster,
+              $http,
+              undefined,
+              undefined,
+              undefined,
+              [alleleData],
+              taxonId,
+              strainName,
+              undefined
+            );
 
             storePromise.then(function (data) {
-              window.location.href =
-                CantoGlobals.curs_root_uri +
+              window.location.href = CantoGlobals.curs_root_uri +
                 '/' + getGenotypeManagePath($scope.genotypeType) +
                 '#/select/' +
                 data.genotype_id;
@@ -4799,7 +4808,7 @@ var GenotypeGeneListCtrl =
 
         $scope.geneById = function (geneId) {
           if ($scope.genes) {
-            for (var i=0, len=$scope.genes.length; i < len; i++) {
+            for (var i = 0, len = $scope.genes.length; i < len; i++) {
               // find gene by ID
               if ($scope.genes[i].gene_id == geneId) {
                 return $scope.genes[i];
@@ -4830,16 +4839,23 @@ var GenotypeGeneListCtrl =
           };
 
           var taxonId = gene.organism.taxonid;
-          var storePromise =
-              CursGenotypeList.storeGenotype(toaster, $http, undefined, undefined, undefined, [deletionAllele],
-                                             taxonId, $scope.selectedStrain, undefined);
+          var storePromise = CursGenotypeList.storeGenotype(
+            toaster,
+            $http,
+            undefined,
+            undefined,
+            undefined,
+            [deletionAllele],
+            taxonId,
+            $scope.selectedStrain,
+            undefined
+          );
 
           storePromise.then(function (data) {
             if (data.status === "existing") {
               toaster.pop('info', "Using existing genotype: " + data.genotype_display_name);
             } else {
-              window.location.href =
-                CantoGlobals.curs_root_uri +
+              window.location.href = CantoGlobals.curs_root_uri +
                 '/' + getGenotypeManagePath($scope.genotypeType) +
                 '#/select/' +
                 data.genotype_id;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4729,28 +4729,28 @@ var GenotypeGeneListCtrl =
 
         $scope.showQuickDeletionButtons = CantoGlobals.show_quick_deletion_buttons;
 
-        $scope.hasDeletionHash = {};
+        var hasDeletionHash = {};
 
-        $scope.$watch('genotypes', $scope.makeHasDeletionHash, true);
+        $scope.$watch('genotypes', makeHasDeletionHash, true);
 
         $scope.hasDeletionGenotype = function(geneId) {
-          return !$scope.multiOrganismMode && !!$scope.hasDeletionHash[geneId];
+          return !$scope.multiOrganismMode && !!hasDeletionHash[geneId];
         };
 
-        $scope.makeHasDeletionHash = function () {
-          $scope.hasDeletionHash = {};
+        function makeHasDeletionHash() {
+          hasDeletionHash = {};
           $scope.genotypes.map(function (genotype) {
             if (genotype.alleles.length === 1) {
               var allele = genotype.alleles[0];
               if (allele.type === 'deletion') {
-                $scope.hasDeletionHash[allele.gene_id] = true;
+                hasDeletionHash[allele.gene_id] = true;
               }
             }
           });
         };
 
         $scope.singleAlleleQuick = function (geneDisplayName, geneSystematicId, geneId) {
-          var gene = $scope.getGeneById(geneId);
+          var gene = getGeneById(geneId);
 
           if (!gene) {
             return;
@@ -4791,20 +4791,20 @@ var GenotypeGeneListCtrl =
           });
         };
 
-        $scope.selectedStrain = '';
+        var selectedStrain = '';
 
-        $scope.deleteSelectStrainPicker = function (geneId) {
-          var gene = $scope.getGeneById(geneId);
+        function deleteSelectStrainPicker(geneId) {
+          var gene = getGeneById(geneId);
           var taxonId = gene.organism.taxonid;
           var deleteInstance = selectStrainPicker($uibModal, taxonId);
 
           deleteInstance.result.then(function (strain) {
-            $scope.selectedStrain = strain.strain.strain_name;
-            $scope.makeDeletionAllele(geneId);
+            selectedStrain = strain.strain.strain_name;
+            makeDeletionAllele(geneId);
           });
         };
 
-        $scope.getGeneById = function (geneId) {
+        function getGeneById(geneId) {
           if ($scope.genes) {
             for (var i = 0, len = $scope.genes.length; i < len; i++) {
               // find gene by ID
@@ -4816,8 +4816,8 @@ var GenotypeGeneListCtrl =
           return null;
         };
 
-        $scope.makeDeletionAllele = function (geneId) {
-          var gene = $scope.getGeneById(geneId);
+        function makeDeletionAllele(geneId) {
+          var gene = getGeneById(geneId);
 
           if (!gene) {
             return;
@@ -4845,7 +4845,7 @@ var GenotypeGeneListCtrl =
             undefined,
             [deletionAllele],
             taxonId,
-            $scope.selectedStrain,
+            selectedStrain,
             undefined
           );
 
@@ -4862,11 +4862,11 @@ var GenotypeGeneListCtrl =
         };
 
         $scope.quickDeletion = CantoGlobals.strains_mode ?
-          $scope.deleteSelectStrainPicker :
-          $scope.makeDeletionAllele;
+          deleteSelectStrainPicker :
+          makeDeletionAllele;
 
         $scope.deletionButtonTitle = function (geneId) {
-          if ($scope.hasDeletionHash[geneId]) {
+          if (hasDeletionHash[geneId]) {
             return 'A deletion genotype already exists for this gene';
           } else {
             return 'Add a deletion genotype for this gene';

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -20,12 +20,13 @@
                     title="{{deletionButtonTitle(gene.gene_id)}}"
                     ng-disabled="hasDeletionGenotype(gene.gene_id)"
                     ng-click="quickDeletion(gene.gene_id)">
-                Deletion</button>
+              Deletion
+            </button>
           </td>
           <td>
             <button class="btn btn-primary btn-xs"
                     ng-click="singleAlleleQuick(gene.primary_name || gene.primary_identifier, gene.primary_identifier, gene.gene_id)">
-{{showQuickDeletionButtons ? 'Other genotype' : 'New genotype'}}
+              {{showQuickDeletionButtons ? 'Other genotype' : 'New genotype'}}
             </button>
           </td>
         </tr>


### PR DESCRIPTION
This PR has some preparatory refactoring to GenotypeGeneListCtrl that will hopefully make the changes required by issue #2415 easier to manage. The main change is extracting the controller from the directive definition and registering it with AngularJS separately (as I've done for other directives in the past). The other changes are mostly just code style and naming conventions.

@kimrutherford I haven't checked this in single organism mode, but it seems to work fine in pathogen-host mode (although note that pathogen-host mode doesn't exercise all of the code's functionality, such as disabling the deletion button when a deletion allele for a gene already exists). If you're happy to defer testing until the PR for #2415 is ready, then I'm fine with this being merged now. 