### PR TITLE
Use Bootstrap UI tooltips for help icons

### DIFF
--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -15,7 +15,7 @@ Genes from this publication
 % } else {
 Annotate genes
 % }
-    <& /curs/inline_help.mhtml, key => 'choose_gene' &>
+    <help-icon key="choose_gene"></help-icon>
     </div>
   </div>
   <div class="curs-box-body">
@@ -66,7 +66,7 @@ Genotypes from this publication
 % } else {
 Annotate genotypes
 % }
-    <& /curs/inline_help.mhtml, key => 'choose_genotype' &>
+    <help-icon key="choose_genotype"></help-icon>
     </div>
   </div>
 %   if ($pathogen_host_mode) {

--- a/root/curs/gene_page.mhtml
+++ b/root/curs/gene_page.mhtml
@@ -14,7 +14,7 @@ var genes_in_session = <% $genes_in_session_js |n %>;
 <div class="curs-box curs-half-width-section">
   <div class="curs-box-title">
 Choose curation type for <% $gene->display_name() %>:
-    <& /curs/inline_help.mhtml, key => 'gene_page_choose_curation_type' &>
+    <help-icon key="gene_page_choose_curation_type"></help-icon>
   </div>
   <div class="curs-box-body">
   <ul class="annotation-start">

--- a/root/curs/modules/interaction.mhtml
+++ b/root/curs/modules/interaction.mhtml
@@ -9,7 +9,7 @@ $feature
   <div ng-show="data.evidenceConfirmed" class="curs-box">
     <div class="curs-box-title">
       Select the gene or genes that interact with <% $feature_display_name %>
-<& /curs/inline_help.mhtml, key => "${annotation_type_name}_select_gene" &>
+      <help-icon key="<% $annotation_type_name . '_select_gene' %>"></help-icon>
     </div>
     <div class="curs-box-body">
       <multi-feature-chooser feature-type="gene" selected-feature-ids="selectedFeatureIds">

--- a/root/curs/modules/interaction_evidence.mhtml
+++ b/root/curs/modules/interaction_evidence.mhtml
@@ -7,7 +7,7 @@ $current_component
 <div class="curs-box evidence-select">
   <div class="curs-box-title">
 Choose evidence for this <% $current_component_display_name %>
-    <& /curs/inline_help.mhtml, key => "${current_component}_evidence" &>
+    <help-text key="<% $current_component . '_evidence' %>"></help-text>
   </div>
   <div class="curs-box-body">
 Some experiments have an inherent directionality. For these experiments, the

--- a/root/docs/md/canto_admin/configuration_file.md
+++ b/root/docs/md/canto_admin/configuration_file.md
@@ -199,12 +199,11 @@ all annotation types from `available_annotation_type_list` will be enabled.
 The path to the extra configuration file needed while testing.
 
 ### help_text
-The keys under `help_text` identify a page in Canto and under the key is one
-or both of `inline` or `url`. The help text and link is rendered by the
-`inline_help.mhtml` template. If a `url` is given, the text under `inline`
-will be `title` attribute of a link with that URL. Without a `url` a help link
-(a "?" icon) will be shown and the `inline` text will be displayed in a pop-up
-DIV.
+The keys under `help_text` identify a part of Canto's user interface for which
+the help text should apply. Under the key is one or both of `inline` or `url`.
+The help text and link are rendered as a help icon with a tooltip that appears
+on mouse-over. If a `url` is given, clicking the help icon will send the user
+to the page specified by the `url`.
 
 ### contact_email
 This email address is shown anytime a contact address is needed. See the


### PR DESCRIPTION
(Fixes #2403)

I've changed all of the help icons to use UI Bootstrap tooltips instead of jQuery UI dialogs. I've tested the changes on the curation summary page (`front_gene_section.mhtml`) and the gene page (`gene_page.mhtml`), and they seem to work fine, although loading the `helpIcon` directive on the summary page seems to make Canto more laggy than before, based on my local copy.

@kimrutherford I can't find the pages in Canto that correspond to the following MHTML documents, so I can't test them.

* `root/curs/modules/interaction.mhtml`
* `root/curs/modules/interaction_evidence.mhtml`

I've switched them to Bootstrap UI tooltips anyway, but if these pages are unused, it might be better to remove the templates instead.

- - -

We might also want to update the technical documentation in `root\docs\md\canto_admin\configuration_file.md`, since the current text could be obsolete with regards to the new implementation:

> The keys under `help_text` identify a page in Canto and under the key is one or both of `inline` or `url`. The help text and link is rendered by the `inline_help.mhtml` template. If a `url` is given, the text under `inline` will be `title` attribute of a link with that URL. Without a `url` a help link (a "?" icon) will be shown and the `inline` text will be displayed in a pop-up DIV.

I'd propose the following (revisions in bold):

> The keys under `help_text` identify a **part of Canto's user interface;** under the key is one or both of `inline` or `url`. The help text and link **are** rendered **as a help icon with the text in a Bootstrap UI tooltip**. If a `url` is given, **clicking the icon will send the user to the page specified by the `url`.**