### PR TITLE
Add shortcut buttons for wild type alleles

### DIFF
--- a/root/curs/autohandler
+++ b/root/curs/autohandler
@@ -27,6 +27,7 @@ var diploid_mode = <% $diploid_mode ? 'true' : 'false' %>;
 var flybase_mode = <% $flybase_mode ? 'true' : 'false' %>;
 var max_term_name_select_count = <% $max_term_name_select_count %>;
 var show_quick_deletion_buttons = <% $show_quick_deletion_buttons %>;
+var show_quick_wild_type_buttons = <% $show_quick_wild_type_buttons %>;
 </script>
 
 <div id="disabled-overlay"></div>
@@ -84,4 +85,5 @@ my $diploid_mode = $c->config()->{diploid_mode} || 0;
 my $flybase_mode = $c->config()->{flybase_mode} || 0;
 my $max_term_name_select_count = $c->config()->{max_term_name_select_count} || 20;
 my $show_quick_deletion_buttons = $c->config()->{show_quick_deletion_buttons} || 0;
+my $show_quick_wild_type_buttons = $c->config()->{show_quick_wild_type_buttons} || 0;
 </%init>

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4802,6 +4802,11 @@ function GenotypeGeneListCtrl(
     });
   };
 
+  $scope.quickWildType = function (geneDisplayName, geneSystematicId, geneId) {
+    var alleleType = 'wild type';
+    $scope.singleAlleleQuick(geneDisplayName, geneSystematicId, geneId, alleleType);
+  };
+
   $scope.quickDeletion = CantoGlobals.strains_mode ?
     deleteSelectStrainPicker :
     makeDeletionAllele;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -851,6 +851,7 @@ canto.service('CantoGlobals', function ($window) {
   this.flybase_mode = $window.flybase_mode;
   this.max_term_name_select_count = $window.max_term_name_select_count;
   this.show_quick_deletion_buttons = $window.show_quick_deletion_buttons;
+  this.show_quick_wild_type_buttons = $window.show_quick_wild_type_buttons;
   this.organismsAndGenes = $window.organismsAndGenes;
   this.confirmGenes = $window.confirmGenes;
   this.highlightTerms = $window.highlightTerms;
@@ -4732,6 +4733,7 @@ function GenotypeGeneListCtrl(
   $scope.read_only_curs = CantoGlobals.read_only_curs;
   $scope.multiOrganismMode = CantoGlobals.multi_organism_mode;
   $scope.showQuickDeletionButtons = CantoGlobals.show_quick_deletion_buttons;
+  $scope.showQuickWildTypeButtons = CantoGlobals.show_quick_wild_type_buttons;
 
   var hasDeletionHash = {};
   var selectedStrain = '';

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3778,7 +3778,7 @@ var alleleEditDialogCtrl =
     copyObject(args.allele, $scope.alleleData);
     $scope.taxonId = args.taxonId;
     $scope.isCopied = args.isCopied;
-    $scope.alleleType = args.alleleType;
+    $scope.lockedAlleleType = args.lockedAlleleType;
     $scope.alleleData.primary_identifier = $scope.alleleData.primary_identifier || '';
     $scope.alleleData.name = $scope.alleleData.name || '';
     $scope.alleleData.description = $scope.alleleData.description || '';
@@ -3796,7 +3796,7 @@ var alleleEditDialogCtrl =
     $scope.pathogenHostMode = CantoGlobals.pathogen_host_mode;
     
     $scope.showAlleleTypeField = (
-      ! args.alleleType && (
+      ! $scope.lockedAlleleType && (
         $scope.alleleData.type != 'aberration' ||
         $scope.alleleData.type != 'aberration wild type'
       )
@@ -3845,8 +3845,8 @@ var alleleEditDialogCtrl =
     $scope.env.allele_type_names_promise = CantoConfig.get('allele_type_names');
     $scope.env.allele_types_promise = CantoConfig.get('allele_types');
 
-    if (args.alleleType) {
-      $scope.alleleData.type = args.alleleType;
+    if ($scope.lockedAlleleType) {
+      $scope.alleleData.type = $scope.lockedAlleleType;
       updateAlleleType('wild type', '');
     }
 
@@ -4089,7 +4089,7 @@ function storeGenotypeHelper(toaster, $http, genotype_id, genotype_name, genotyp
     });
 }
 
-function makeAlleleEditInstance($uibModal, allele, taxonId, isCopied, alleleType) {
+function makeAlleleEditInstance($uibModal, allele, taxonId, isCopied, lockedAlleleType) {
   return $uibModal.open({
     templateUrl: app_static_path + 'ng_templates/allele_edit.html',
     controller: 'AlleleEditDialogCtrl',
@@ -4103,7 +4103,7 @@ function makeAlleleEditInstance($uibModal, allele, taxonId, isCopied, alleleType
           allele: allele,
           taxonId: taxonId,
           isCopied: isCopied,
-          alleleType: alleleType
+          lockedAlleleType: lockedAlleleType
         };
       }
     },
@@ -4760,7 +4760,7 @@ function GenotypeGeneListCtrl(
     return !$scope.multiOrganismMode && !!hasDeletionHash[geneId];
   };
 
-  $scope.singleAlleleQuick = function (geneDisplayName, geneSystematicId, geneId, alleleType) {
+  $scope.singleAlleleQuick = function (geneDisplayName, geneSystematicId, geneId, lockedAlleleType) {
     var gene = getGeneById(geneId);
     var isCopied = false;
 
@@ -4778,7 +4778,7 @@ function GenotypeGeneListCtrl(
       },
       taxonId,
       isCopied,
-      alleleType
+      lockedAlleleType
     );
 
     editInstance.result.then(function (editResults) {
@@ -4806,8 +4806,8 @@ function GenotypeGeneListCtrl(
   };
 
   $scope.quickWildType = function (geneDisplayName, geneSystematicId, geneId) {
-    var alleleType = 'wild type';
-    $scope.singleAlleleQuick(geneDisplayName, geneSystematicId, geneId, alleleType);
+    var lockedAlleleType = 'wild type';
+    $scope.singleAlleleQuick(geneDisplayName, geneSystematicId, geneId, lockedAlleleType);
   };
 
   $scope.quickDeletion = CantoGlobals.strains_mode ?

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3871,31 +3871,7 @@ var alleleEditDialogCtrl =
       return this.alleleData.name;
     };
 
-    $scope.$watch('alleleData.type',
-      function (newType, oldType) {
-        $scope.env.allele_types_promise.then(function (data) {
-          $scope.current_type_config = data[newType];
-
-          if (newType === oldType) {
-            return;
-          }
-
-          if ($scope.alleleData.primary_identifier) {
-            return;
-          }
-
-          if ($scope.name_autopopulated) {
-            if ($scope.name_autopopulated == $scope.alleleData.name) {
-              $scope.alleleData.name = '';
-            }
-            $scope.name_autopopulated = '';
-          }
-
-          $scope.name_autopopulated = $scope.maybe_autopopulate();
-          $scope.alleleData.description = '';
-          $scope.alleleData.expression = '';
-        });
-      });
+    $scope.$watch('alleleData.type', updateAlleleType);
 
     $scope.nameSelectedCallback = function(alleleData) {
       $scope.alleleData.primary_identifier = alleleData.primaryIdentifier;
@@ -3996,6 +3972,31 @@ var alleleEditDialogCtrl =
         $scope.strainData.strains = filterStrainsByTaxonId(strains, taxonId);
       }).catch(function () {
         toaster.pop('error', 'failed to get strain list from server');
+      });
+    }
+
+    function updateAlleleType(newType, oldType) {
+      $scope.env.allele_types_promise.then(function (data) {
+        $scope.current_type_config = data[newType];
+
+        if (newType === oldType) {
+          return;
+        }
+
+        if ($scope.alleleData.primary_identifier) {
+          return;
+        }
+
+        if ($scope.name_autopopulated) {
+          if ($scope.name_autopopulated == $scope.alleleData.name) {
+            $scope.alleleData.name = '';
+          }
+          $scope.name_autopopulated = '';
+        }
+
+        $scope.name_autopopulated = $scope.maybe_autopopulate();
+        $scope.alleleData.description = '';
+        $scope.alleleData.expression = '';
       });
     }
   };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3794,10 +3794,6 @@ var alleleEditDialogCtrl =
 
     $scope.userIsAdmin = CantoGlobals.current_user_is_admin;
     $scope.pathogenHostMode = CantoGlobals.pathogen_host_mode;
-
-    if (args.alleleType) {
-      $scope.alleleData.type = args.alleleType;
-    }
     
     $scope.showAlleleTypeField = (
       ! args.alleleType && (
@@ -3848,6 +3844,11 @@ var alleleEditDialogCtrl =
 
     $scope.env.allele_type_names_promise = CantoConfig.get('allele_type_names');
     $scope.env.allele_types_promise = CantoConfig.get('allele_types');
+
+    if (args.alleleType) {
+      $scope.alleleData.type = args.alleleType;
+      updateAlleleType('wild type', '');
+    }
 
     $scope.env.allele_type_names_promise.then(function (data) {
       $scope.env.allele_type_names = data;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4747,6 +4747,7 @@ function GenotypeGeneListCtrl(
   $scope.multiOrganismMode = CantoGlobals.multi_organism_mode;
   $scope.showQuickDeletionButtons = CantoGlobals.show_quick_deletion_buttons;
   $scope.showQuickWildTypeButtons = CantoGlobals.show_quick_wild_type_buttons;
+  $scope.columnCount = getColumnCount();
 
   var hasDeletionHash = {};
   var selectedStrain = '';
@@ -4898,6 +4899,17 @@ function GenotypeGeneListCtrl(
       }
     });
   };
+
+  function getColumnCount() {
+    var columnCount = 1;
+    if ($scope.showQuickDeletionButtons) {
+      columnCount += 1;
+    }
+    if ($scope.showQuickWildTypeButtons) {
+      columnCount += 1;
+    }
+    return columnCount;
+  }
 }
 
 canto.controller('genotypeGeneListCtrl', [

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3778,6 +3778,7 @@ var alleleEditDialogCtrl =
     copyObject(args.allele, $scope.alleleData);
     $scope.taxonId = args.taxonId;
     $scope.isCopied = args.isCopied;
+    $scope.alleleType = args.alleleType;
     $scope.alleleData.primary_identifier = $scope.alleleData.primary_identifier || '';
     $scope.alleleData.name = $scope.alleleData.name || '';
     $scope.alleleData.description = $scope.alleleData.description || '';
@@ -3793,6 +3794,17 @@ var alleleEditDialogCtrl =
 
     $scope.userIsAdmin = CantoGlobals.current_user_is_admin;
     $scope.pathogenHostMode = CantoGlobals.pathogen_host_mode;
+
+    if (args.alleleType) {
+      $scope.alleleData.type = args.alleleType;
+    }
+    
+    $scope.showAlleleTypeField = (
+      ! args.alleleType && (
+        $scope.alleleData.type != 'aberration' ||
+        $scope.alleleData.type != 'aberration wild type'
+      )
+    );
 
     function processSynonyms() {
       $.map($scope.alleleData.synonyms || [],
@@ -4075,7 +4087,7 @@ function storeGenotypeHelper(toaster, $http, genotype_id, genotype_name, genotyp
     });
 }
 
-function makeAlleleEditInstance($uibModal, allele, taxonId, isCopied) {
+function makeAlleleEditInstance($uibModal, allele, taxonId, isCopied, alleleType) {
   return $uibModal.open({
     templateUrl: app_static_path + 'ng_templates/allele_edit.html',
     controller: 'AlleleEditDialogCtrl',
@@ -4089,6 +4101,7 @@ function makeAlleleEditInstance($uibModal, allele, taxonId, isCopied) {
           allele: allele,
           taxonId: taxonId,
           isCopied: isCopied,
+          alleleType: alleleType
         };
       }
     },
@@ -4744,8 +4757,9 @@ function GenotypeGeneListCtrl(
     return !$scope.multiOrganismMode && !!hasDeletionHash[geneId];
   };
 
-  $scope.singleAlleleQuick = function (geneDisplayName, geneSystematicId, geneId) {
+  $scope.singleAlleleQuick = function (geneDisplayName, geneSystematicId, geneId, alleleType) {
     var gene = getGeneById(geneId);
+    var isCopied = false;
 
     if (!gene) {
       return;
@@ -4759,7 +4773,9 @@ function GenotypeGeneListCtrl(
         gene_systematic_id: geneSystematicId,
         gene_id: geneId,
       },
-      taxonId
+      taxonId,
+      isCopied,
+      alleleType
     );
 
     editInstance.result.then(function (editResults) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3847,7 +3847,7 @@ var alleleEditDialogCtrl =
 
     if ($scope.lockedAlleleType) {
       $scope.alleleData.type = $scope.lockedAlleleType;
-      updateAlleleType('wild type', '');
+      updateAlleleType($scope.alleleData.type, '');
     }
 
     $scope.env.allele_type_names_promise.then(function (data) {

--- a/root/static/ng_templates/allele_edit.html
+++ b/root/static/ng_templates/allele_edit.html
@@ -81,7 +81,7 @@
         </tr>
 
         <tr class="curs-allele-type-select">
-          <td>
+          <td ng-if="showAlleleTypeField">
             Allele type
           </td>
           <td ng-if="alleleData.type == 'aberration'">
@@ -90,7 +90,7 @@
           <td ng-if="alleleData.type == 'aberration wild type'">
             Wild type for aberration
           </td>
-          <td ng-if="alleleData.type != 'aberration' && alleleData.type != 'aberration wild type'"
+          <td ng-if="showAlleleTypeField"
               ng-class="{ 'has-error': !isValidType() }">
             <select class="form-control"
                     ng-model="alleleData.type" name="curs-allele-type"

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -4,7 +4,7 @@
       <thead>
         <tr>
           <th>Gene</th>
-          <th colspan="{{showQuickDeletionButtons ? 2 : 1}}">Actions</th>
+          <th colspan="{{columnCount}}">Actions</th>
         </tr>
       </thead>
       <tbody>

--- a/root/static/ng_templates/genotype_gene_list.html
+++ b/root/static/ng_templates/genotype_gene_list.html
@@ -23,6 +23,12 @@
               Deletion
             </button>
           </td>
+          <td ng-if="showQuickWildTypeButtons">
+            <button class="btn btn-primary btn-xs"
+                    ng-click="quickWildType(gene.primary_name || gene.primary_identifier, gene.primary_identifier, gene.gene_id)">
+              Wild type
+            </button>
+          </td>
           <td>
             <button class="btn btn-primary btn-xs"
                     ng-click="singleAlleleQuick(gene.primary_name || gene.primary_identifier, gene.primary_identifier, gene.gene_id)">


### PR DESCRIPTION
(References #2415)

This PR adds more shortcut buttons to the gene list on the Genotype Management page. The buttons allow creating a wild type allele for a given gene without having to specify the allele type.

![image](https://user-images.githubusercontent.com/37659591/109011564-f14ef900-76a8-11eb-9b5b-04c1872a7fef.png)

After the button is clicked, a modal is shown with the Allele Type field hidden (the type is set to 'wild type' behind the scenes). The allele name, strain, and expression level can be set as normal.

![image](https://user-images.githubusercontent.com/37659591/109012200-a4b7ed80-76a9-11eb-852e-a94e5789c650.png)

- - -

@kimrutherford To implement this, I've added a flag to the configuration called `show_quick_wild_type_buttons` that controls whether the shortcut buttons are shown. I've also added an additional argument `alleleType` to the `makeAlleleEditInstance` function. When `alleleType` is set to any allele type (valid or not), the controller effectively locks the allele type field by setting its value to the specified allele type and then hiding the field with `ng-if`.

I chose this solution over creating a whole new dialog because **a)** it avoids re-implementing a lot of code and **b)** I thought the existing controller would take care of wild type allele naming conventions – although looking at the code, I'm not entirely sure if this is the case. Please let me know if you'd prefer a different approach (such as a dedicated modal), or if there's any extra handling needed.

Thankfully, JavaScript seems able to cope gracefully with functions that have undefined trailing arguments, so my change shouldn't break any existing function calls.

Some specific questions:

* Do you think that the `alleleType` argument name is obvious enough? I was considering renaming it to something more explicit, like `lockedAlleleType` or `lockToAlleleType`, so that it doesn't get confused with `alleleData.type`.

* Should `showAlleleTypeField` be a function instead of a variable? I've opted for a variable on `$scope` since I'm assuming that the value will only need to be evaluated once. Basically, the question reduces to whether or not `alleleData.type` can change after the modal is loaded. Here's the relevant code:

  ```js
  $scope.showAlleleTypeField = (
    ! args.alleleType && (
      $scope.alleleData.type != 'aberration' ||
      $scope.alleleData.type != 'aberration wild type'
    )
  );