### PR TITLE
Allow configuration of gene confirmation page message 

### DIFF
--- a/canto.yaml
+++ b/canto.yaml
@@ -2362,6 +2362,9 @@ curs_config:
   follow_inverse_cv_names:
     - fission_yeast_phenotype
 
+  # A message for curators, shown at the top of the gene confirmation page.
+  # gene_page_top_message: SET_ME
+
   finish_form:
     # the "extra_text" is always shown on the finish form, the
     # extra_text_gene_information is only shown if the user added some genes to

--- a/root/curs/gene_list_edit.mhtml
+++ b/root/curs/gene_list_edit.mhtml
@@ -24,8 +24,8 @@ var hostsWithNoGenes = <% $hosts_with_no_genes_js |n %>;
 <% $title %>
   </div>
   <div class="curs-box-body">
-% if ($pathogen_host_mode) {
     <% $gene_page_top_message | n %>
+% if ($pathogen_host_mode) {
     <edit-organisms></edit-organisms>
 % } else {
 

--- a/root/curs/gene_list_edit.mhtml
+++ b/root/curs/gene_list_edit.mhtml
@@ -25,7 +25,7 @@ var hostsWithNoGenes = <% $hosts_with_no_genes_js |n %>;
   </div>
   <div class="curs-box-body">
 % if ($pathogen_host_mode) {
-    <p><b>Note:</b> PHI-Canto does not use UniProt identifiers at taxonomic ranks lower than species. If you have entered UniProt identifiers that are at the strain or subspecies level, their corresponding NCBI Taxonomy identifiers will have been reassigned to the nearest species-level identifier (the UniProt identifier itself is not modified). Please use the 'experimental strains' field to specify lower taxonomic ranks (such as strains, pathovars, and subspecies).</p>
+    <% $gene_page_top_message | n %>
     <edit-organisms></edit-organisms>
 % } else {
 
@@ -69,6 +69,8 @@ if ($c->config()->{pathogen_host_mode}) {
   $add_more_genes_message =
     'Add more genes from ' . $pub->uniquename();
 }
+
+my $gene_page_top_message = $c->config()->{curs_config}->{gene_page_top_message};
 
 my @col_names = ("Systematic identifier", "Name", "Synonyms", "Product");
 


### PR DESCRIPTION
Commit c142437a5c756eac24196424292cf9b1b0b8fc4a added a message to the top of `gene_list_edit.mhtml` in pathogen-host mode, explaining our remapping of NCBI Taxonomy IDs to species rank. At the time, I hard-coded the message into the template (and only enabled it in pathogen-host mode) because I didn't know any better. This PR extracts the message into a variable that is loaded from the configuration file.

The new configuration variable is called `gene_page_top_message`. Since the message is still only applicable to pathogen-host mode, I've added a placeholder to `canto.yaml` that is commented out by default.

Note that the substitution uses the `n` escape flag because the configuration value contains HTML markup (this was needed because the previous hard-coded message used rich formatting).