### PR TITLE
Prevent metagenotypes being deleted when used in extensions

### DIFF
--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -3189,6 +3189,11 @@ sub ws_annotation_create : Chained('top') PathPart('ws/annotation/create')
 
   my $json_data = $c->req()->body_data();
 
+  use Data::Dumper;
+$Data::Dumper::Maxdepth = 3;
+warn Dumper([$json_data]);
+
+
   $c->stash->{json_data} = $service_utils->create_annotation($json_data);
 
   $c->forward('View::JSON');

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -757,10 +757,10 @@ canto.service('Metagenotype', function ($rootScope, $http, toaster, Curs) {
 
       }).catch(function (message) {
         if (message.match('metagenotype .* has annotations')) {
-          toaster.pop('warning', "couldn't delete the metagenotype: " +
+          toaster.pop('error', "couldn't delete the metagenotype: " +
             "delete the annotations that use it first");
         } else if (message.match('metagenotype .* used in extensions')) {
-              toaster.pop('warning', "couldn't delete the metagenotype: " +
+              toaster.pop('error', "couldn't delete the metagenotype: " +
                 "delete the annotation extensions that use it first");
         } else {
           toaster.pop('error', "couldn't delete the metagenotype: " + message);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -759,6 +759,9 @@ canto.service('Metagenotype', function ($rootScope, $http, toaster, Curs) {
         if (message.match('metagenotype .* has annotations')) {
           toaster.pop('warning', "couldn't delete the metagenotype: " +
             "delete the annotations that use it first");
+        } else if (message.match('metagenotype .* used in extensions')) {
+              toaster.pop('warning', "couldn't delete the metagenotype: " +
+                "delete the annotation extensions that use it first");
         } else {
           toaster.pop('error', "couldn't delete the metagenotype: " + message);
         }

--- a/t/70_gaf_formatter.t
+++ b/t/70_gaf_formatter.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 19;
+use Test::More tests => 20;
 use MooseX::Test::Role;
 use IO::String;
 

--- a/t/70_gaf_formatter.t
+++ b/t/70_gaf_formatter.t
@@ -68,6 +68,7 @@ my $mock_formatter = consumer_of('Canto::Role::GAFFormatter');
     'wt_protein_expression.tsv' => 0,
     'physical_interaction.tsv' => 0,
     'genetic_interaction.tsv' => 0,
+    'disease_formation_phenotype.tsv' => 0,
   );
 
   my $member_count = 0;
@@ -97,5 +98,5 @@ my $mock_formatter = consumer_of('Canto::Role::GAFFormatter');
 
   is(keys %expected_filenames, 0);
 
-  is($member_count, 9);
+  is($member_count, 10);
 }

--- a/t/85_genotype_manager.t
+++ b/t/85_genotype_manager.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 35;
+use Test::More tests => 42;
 
 use Try::Tiny;
 
@@ -92,6 +92,8 @@ ok(!defined $found_genotype);
 
 $found_genotype = $genotype_manager->find_genotype($pombe_taxonid, undef, undef, [$ssm4_allele_details, $cdc11_allele_details]);
 ok(defined $found_genotype);
+
+my $ssm4_genotype = $found_genotype;
 
 is($found_genotype->name(), $genotype_name);
 
@@ -244,3 +246,43 @@ $found_cdc11_delta_diplod_genotype =
                                    $curs_schema, $curs_key);
 
 ok(!defined $found_cdc11_delta_diplod_genotype);
+
+
+# test creating and deleting metagenotypes
+
+my $genotype_rs = $curs_schema->resultset('Genotype');
+
+my $first_genotype = $genotype_rs->next();
+my $second_genotype = $genotype_rs->next();
+my $third_genotype = $genotype_rs->next();
+
+ok (defined $third_genotype);
+
+my $metagenotype_1 =
+  $genotype_manager->make_metagenotype(interactor_a => $first_genotype,
+                                       interactor_b => $second_genotype);
+
+ok (defined $metagenotype_1);
+
+is ($metagenotype_1->identifier(), 'aaaa0007-metagenotype-1');
+
+$genotype_manager->delete_metagenotype($metagenotype_1->metagenotype_id());
+
+# re-create the same metagenotype
+$metagenotype_1 =
+  $genotype_manager->make_metagenotype(interactor_a => $first_genotype,
+                                       interactor_b => $second_genotype);
+
+ok (defined $metagenotype_1);
+
+is ($metagenotype_1->identifier(), 'aaaa0007-metagenotype-1');
+
+my $metagenotype_2 =
+  $genotype_manager->make_metagenotype(interactor_a => $first_genotype,
+                                       interactor_b => $third_genotype);
+
+ok (defined $metagenotype_2);
+
+is ($metagenotype_2->identifier(), 'aaaa0007-metagenotype-2');
+
+

--- a/t/85_genotype_manager.t
+++ b/t/85_genotype_manager.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 42;
+use Test::More tests => 43;
 
 use Try::Tiny;
 
@@ -286,3 +286,30 @@ ok (defined $metagenotype_2);
 is ($metagenotype_2->identifier(), 'aaaa0007-metagenotype-2');
 
 
+my $service_utils = Canto::Curs::ServiceUtils->new(curs_schema => $curs_schema,
+                                                   config => $config);
+
+my $res = $service_utils->create_annotation({
+  key => $curs_key,
+  feature_id => $metagenotype_1->metagenotype_id(),
+  feature_type => 'metagenotype',
+  annotation_type => 'disease_formation_phenotype',
+  term_ontid => 'FYPO:0002060',
+  evidence_code => 'Microscopy',
+  extension =>
+    [
+      [
+        {
+          'relation' => 'depends_on_metagenoype',
+          'rangeType' => 'Metagenotype',
+          'rangeValue' => $metagenotype_2->metagenotype_id(),
+        }
+      ]
+    ],
+});
+
+
+my $delete_result =
+  $genotype_manager->delete_metagenotype($metagenotype_2->metagenotype_id());
+
+ok ($delete_result =~ /delete failed/);

--- a/t/test_config.yaml
+++ b/t/test_config.yaml
@@ -314,3 +314,15 @@ extension_conf_files:
 
 email:
   from_address: DO_NOT_EMAIL
+
+enabled_annotation_type_list:
+  - disease_formation_phenotype
+  - molecular_function
+  - biological_process
+  - cellular_component
+  - phenotype
+  - post_translational_modification
+  - wt_rna_expression
+  - wt_protein_expression
+  - genetic_interaction
+  - physical_interaction


### PR DESCRIPTION
(Fixes #2427)

I've had a go at fixing the bug that allowed metagenotypes to be deleted even when they were referenced in annotation extensions.

I've modified `Canto::Curs::GenotypeManager::delete_metagenotype` so that in addition to checking for any annotations that use the metagenotype, it also checks for any annotation extensions that use the metagenotype (specifically, extensions where the `rangeType` is 'Metagenotype' and the `rangeValue` is the ID of the selected metagenotype). If it finds any matching extensions, the method returns early with a relevant error message (similar to the existing implementation for annotations). I've also amended the error handling in the `Metagenotype` service on the front-end so that it shows a personalised error message when it receives the extension error.

One downside of the solution is that any annotation that has a matching extension usually doesn't belong to the metagenotype, so `delete_metagenotype` has to query all the annotations in the session. I adapted the code from `change-annotation-type-example.pl` to handle querying all extensions. The solution seems inefficient, but I can't see any way to improve it without some sort of caching when an extension referencing a metagenotype is created (and that means more complicated state management).

One optimisation that would make sense is to disable the check when `MetagenotypeID` isn't used as a range type in the annotation extension configuration, because then it's impossible for this situation to occur (so the check is redundant). If there's already a configuration flag for enabling Metagenotype Management (or metagenotype curation in general), that could be a reliable indicator, because having no metagenotypes also precludes the bug.

I've tested this manually on my local version and it seems to work fine: deleting a metagenotype is blocked when the metagenotype is referenced in an extension, and allowed otherwise. I haven't updated any unit tests to exercise this new functionality, mostly because I don't even know where the relevant test is.

@kimrutherford Could you review my changes to `delete_metagenotype` and let me know if there are any tests that need amending? Also whether we should bother making the optimisation of disabling the check when it's not needed? 