### PR TITLE
Show genotype background for metagenotypes in feature chooser

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -1696,7 +1696,7 @@ function featureChooserControlHelper($scope, $uibModal, CursGeneList,
 
 
 var multiFeatureChooser =
-  function ($uibModal, CursGeneList, CursGenotypeList, Curs, toaster) {
+  function ($uibModal, CantoGlobals, CursGeneList, CursGenotypeList, Curs, toaster) {
     return {
       scope: {
         features: '=',
@@ -1708,6 +1708,8 @@ var multiFeatureChooser =
       controller: function ($scope) {
         featureChooserControlHelper($scope, $uibModal, CursGeneList,
           CursGenotypeList, Curs, toaster);
+
+        $scope.showOrganism = CantoGlobals.multi_organism_mode;
 
         $scope.toggleSelection = function toggleSelection(featureId) {
           var idx = $scope.selectedFeatureIds.indexOf(featureId);
@@ -1728,7 +1730,7 @@ var multiFeatureChooser =
   };
 
 canto.directive('multiFeatureChooser',
-  ['$uibModal', 'CursGeneList', 'CursGenotypeList', 'Curs', 'toaster',
+  ['$uibModal', 'CantoGlobals', 'CursGeneList', 'CursGenotypeList', 'Curs', 'toaster',
     multiFeatureChooser
   ]);
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -391,18 +391,14 @@ function symbolEncoder() {
 canto.filter('encodeAlleleSymbols', symbolEncoder);
 canto.filter('encodeGeneSymbols', symbolEncoder);
 
-canto.filter('featureChooserFilter', ['CantoGlobals', function (CantoGlobals) {
+canto.filter('featureChooserFilter', function () {
   return function (feature, showOrganism) {
-    var showOrganismName = (
-      CantoGlobals.multi_organism_mode &&
-      (feature.gene_id || feature.genotype_id && showOrganism)
-    );
     if (feature.metagenotype_id) {
-      var pathogenPart = formatGenotype(feature.pathogen_genotype, showOrganismName);
-      var hostPart = formatGenotype(feature.host_genotype, showOrganismName);
+      var pathogenPart = formatGenotype(feature.pathogen_genotype, showOrganism);
+      var hostPart = formatGenotype(feature.host_genotype, showOrganism);
       return pathogenPart + ' / ' + hostPart;
     }
-    return formatGenotype(feature, showOrganismName);
+    return formatGenotype(feature, showOrganism);
 
     function formatGenotype(genotype, showOrganism) {
       var displayName = genotype.display_name;
@@ -423,7 +419,7 @@ canto.filter('featureChooserFilter', ['CantoGlobals', function (CantoGlobals) {
       return '(bkg: ' + background.substr(0, 15) + (truncated ? '...' : '') + ')';
     }
   };
-}]);
+});
 
 canto.filter('renameGenotypeType', function () {
   return function (type) {
@@ -1751,6 +1747,7 @@ var featureChooser =
       replace: true,
       controller: function ($scope) {
         $scope.app_static_path = CantoGlobals.app_static_path;
+        $scope.showOrganism = CantoGlobals.multi_organism_mode;
         $scope.showCompleter = false;
 
         $scope.search = function() {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -393,29 +393,35 @@ canto.filter('encodeGeneSymbols', symbolEncoder);
 
 canto.filter('featureChooserFilter', ['CantoGlobals', function (CantoGlobals) {
   return function (feature, showOrganism) {
-    var ret = feature.display_name;
     var showOrganismName = (
       CantoGlobals.multi_organism_mode &&
       (feature.gene_id || feature.genotype_id && showOrganism)
     );
-    if (showOrganismName) {
-      ret += " (" + feature.organism.full_name + ")";
+    if (feature.metagenotype_id) {
+      var pathogenPart = formatGenotype(feature.pathogen_genotype, showOrganismName);
+      var hostPart = formatGenotype(feature.host_genotype, showOrganismName);
+      return pathogenPart + ' / ' + hostPart;
     }
-    if (feature.background) {
-      ret += "  (bkg: " + feature.background.substr(0, 15);
-      if (feature.background.length > 15) {
-        ret += "...";
+    return formatGenotype(feature, showOrganismName);
+
+    function formatGenotype(genotype, showOrganism) {
+      var displayName = genotype.display_name;
+      if (showOrganism) {
+        displayName += ' ' + genotype.organism.full_name;
       }
-      ret += ")";
-    }
-    if (feature.strain_name) {
-      ret += "  (strain: " + feature.strain_name.substr(0, 15);
-      if (feature.strain_name.length > 15) {
-        ret += " ...";
+      if (genotype.strain_name) {
+        displayName += ' (' + genotype.strain_name + ')';
       }
-      ret += ")";
+      if (genotype.background) {
+        displayName += ' ' + formatBackground(genotype.background);
+      }
+      return displayName;
     }
-    return ret;
+
+    function formatBackground(background) {
+      var truncated = background.length > 15;
+      return '(bkg: ' + background.substr(0, 15) + (truncated ? '...' : '') + ')';
+    }
   };
 }]);
 

--- a/root/static/ng_templates/feature_chooser.html
+++ b/root/static/ng_templates/feature_chooser.html
@@ -9,7 +9,7 @@ Loading ...
       <option value="">Choose a {{featureType}} ...</option>
       <option ng-repeat="feature in features track by feature.feature_id"
               ng-value="{{feature.feature_id}}"
-              ng-bind-html="feature | featureChooserFilter | encodeAlleleSymbols | toTrusted">
+              ng-bind-html="feature | featureChooserFilter:showOrganism | encodeAlleleSymbols | toTrusted">
       </option>
     </select>
 

--- a/root/static/ng_templates/multi_feature_chooser.html
+++ b/root/static/ng_templates/multi_feature_chooser.html
@@ -5,7 +5,7 @@
       <input type="checkbox" name="selectedFeatureIds[]"
              ng-checked="selectedFeatureIds.indexOf(featurere.feature_id) > -1"
              ng-click="toggleSelection(feature.feature_id)" />
-      <span ng-bind-html="feature | featureChooserFilter:true | encodeAlleleSymbols | toTrusted"></span>
+      <span ng-bind-html="feature | featureChooserFilter:showOrganism | encodeAlleleSymbols | toTrusted"></span>
     </label>
   </div>
 </div>


### PR DESCRIPTION
(Fixes #2435)

I've made some changes to `featureChooserFilter` so that it's able to display the genotype background for both genotypes in a metagenotype. Here's an example of the new system:

![image](https://user-images.githubusercontent.com/37659591/111165403-e516d700-8596-11eb-98d2-5422e45c35e2.png)

I've extracted all of the old code into functions so that it can be reused when formatting metagenotypes, since the metagenotype formatting in the new system effectively reduces to formatting two genotypes and concatenating them. The metagenotype display name is now effectively redundant in the metagenotype feature chooser, but that's not really a problem considering it's still used elsewhere (like annotation table rows).

Due to the genotype and metagenotype formatting sharing code, the genotype display name no longer prefixes its strain name with 'strain: '. The previous formatting wasn't consistent with how strains were displayed metagenotypes or feature tables. It's still possible to distinguish the background from the strain name because the background uses the 'bkg: ' prefix.

I've tested the new code under various feature types (including genes, even though I'm not sure if this filter is used for genes) and with certain properties set or undefined, and it seems to work well. The only problem is the fact that the logic for displaying organism names doesn't work as expected under the new system: as you can see from the image above, the organism names aren't showing here because the calling code doesn't specify that they should be shown, and the code only checks for `gene_id` and `genotype_id` properties when deciding whether to show the organism name. I'm marking this pull request as a draft until I've resolved the organism display issue.