### PR TITLE
Allow optional help text or tooltip for conditions

### DIFF
--- a/canto.yaml
+++ b/canto.yaml
@@ -2381,8 +2381,11 @@ curs_config:
     - fission_yeast_phenotype
 
   # Help text shown above the experimental conditions picker
-  experimental_conditions_help_text: >
-    Please add experimental conditions. Conditions are the aspects of the 
+  experimental_conditions_help_text: ~
+
+  # Text for help tooltip for the experimental conditions picker
+  experimental_conditions_help_tooltip_text: >
+    Conditions are the aspects of the
     experimental setup that are independent of what cells (strain, genotype,
     constructs, etc.) are used.
 

--- a/root/curs/modules/ontology.mhtml
+++ b/root/curs/modules/ontology.mhtml
@@ -99,5 +99,6 @@ if ($feature_type eq 'gene') {
 } else {
   $feature_display_name = $feature->display_name($c->config());
 }
-my $conditions_help_text = $c->config()->{curs_config}->{experimental_conditions_help_text};
+my $conditions_help_text =
+  $c->config()->{curs_config}->{experimental_conditions_help_text} // 'Please add experimental conditions:';
 </%init>

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -568,7 +568,6 @@ td.table-row-actions div {
 }
 .curs-evidence-conditions .tagit {
   font-size: 80%;
-  max-width: 50em;
 }
 .curs-evidence-conditions-help {
   color: #111;
@@ -1912,4 +1911,16 @@ a:not([href]) {
 
 .curs-annotation-transfer-all-select-annotation table {
   display: inline-table;
+}
+
+.tagit-new {
+  width: 25em;
+}
+
+.curs-conditions-help-icon {
+  padding: 0.3em;
+}
+
+.curs-allele-condition-buttons-help {
+  margin-right: 0.8em;
 }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3583,7 +3583,7 @@ canto.directive('annotationEvidence',
                  annotationEvidence]);
 
 var conditionPicker =
-  function (CursConditionList, toaster) {
+  function (CursConditionList, CantoConfig, CantoGlobals, toaster) {
     var directive = {
       scope: {
         conditions: '=',
@@ -3602,7 +3602,18 @@ var conditionPicker =
       },
       templateUrl: app_static_path + 'ng_templates/condition_picker.html',
       link: function ($scope, elem) {
+        $scope.cursConfigPromise = CantoConfig.get('curs_config');
+        $scope.conditionsHelpTooltipText = '';
+
         var $field = elem.find('.curs-allele-conditions');
+
+        $scope.cursConfigPromise.then(function(data) {
+          var conditionsHelpTooltipText = data['experimental_conditions_help_tooltip_text'];
+          $scope.conditionsHelpTooltipText = conditionsHelpTooltipText;
+        });
+
+        $scope.helpIconUrl = CantoGlobals.app_static_path +
+          '/images/help.png';
 
         if (typeof ($scope.conditions) != 'undefined') {
           CursConditionList.conditionList().then(function (results) {
@@ -3625,7 +3636,7 @@ var conditionPicker =
               minLength: 2,
               fieldName: 'curs-allele-condition-names',
               allowSpaces: true,
-              placeholderText: 'Type a condition',
+              placeholderText: 'Start typing to add a condition',
               tagSource: fetch_conditions,
               autocomplete: {
                 focus: ferret_choose.show_autocomplete_def,
@@ -3654,7 +3665,8 @@ var conditionPicker =
     return directive;
   };
 
-canto.directive('conditionPicker', ['CursConditionList', 'toaster', conditionPicker]);
+canto.directive('conditionPicker',
+                ['CursConditionList', 'CantoConfig', 'CantoGlobals', 'toaster', conditionPicker]);
 
 var alleleNameComplete =
   function (CursAlleleList, toaster) {
@@ -6653,7 +6665,7 @@ var annotationEditDialogCtrl =
           return [];
         }
       });
-    
+
     $scope.cursConfigPromise.then(function(data) {
       var conditionsHelpText = data['experimental_conditions_help_text'];
       $scope.conditionsHelpText = conditionsHelpText;

--- a/root/static/ng_templates/annotation_edit.html
+++ b/root/static/ng_templates/annotation_edit.html
@@ -181,8 +181,8 @@
         <td class="title">Conditions</td>
         <td class="curs-evidence-conditions">
           <div ng-if="filteredFeatures && filteredFeatures.length != 0">
-            {{conditionsHelpText}}
-          <condition-picker conditions="annotation.conditions"></condition-picker>
+            <span ng-if="conditionsHelpText">{{conditionsHelpText}}</span>
+            <condition-picker conditions="annotation.conditions"></condition-picker>
           </div>
         </td>
       </tr>

--- a/root/static/ng_templates/condition_picker.html
+++ b/root/static/ng_templates/condition_picker.html
@@ -1,15 +1,21 @@
 <span>
   <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-8">
       <ul class="curs-allele-conditions">
       </ul>
+    </div>
+    <div ng-if="conditionsHelpTooltipText" class="curs-conditions-help-icon">
+      <span class="curs-inline-help-icon">
+        <img ng-src="{{helpIconUrl}}"
+             alt="help" title="{{conditionsHelpTooltipText}}"/>
+      </span>
     </div>
   </div>
   <div class="curs-allele-condition-buttons row">
     <div class="col-md-11" ng-if="usedConditions.length > 0">
-      <div>
+      <span class="curs-allele-condition-buttons-help">
 Previously used conditions (click to add to list):
-      </div>
+      </span>
       <span ng-repeat="cond in usedConditions">
         <button type="button" class="btn btn-default btn-sm"
                 ng-click="addCondition(cond.name)">


### PR DESCRIPTION
This conditions picker will now show help text at the top if the `experimental_conditions_help_text` config is set.  If `experimental_conditions_help_tooltip_text` is set then the configured text is show in a tooltip.  

Refs #2428