### PR TITLE
Make conditions picker compatible with help icon directive 

### DIFF
--- a/canto.yaml
+++ b/canto.yaml
@@ -2242,6 +2242,10 @@ help_text:
   genetic_interaction_definition:
     inline: Annotate interaction type and interacting genes.
     docs_path: "genetic_interaction_annotation"
+  experimental_conditions_definition:
+    inline: >
+      Conditions are the aspects of the experimental setup that are independent
+      of what cells (strain, genotype, constructs, etc.) are used.
 
 contact_email:
   address: "set_me@localhost"
@@ -2382,12 +2386,6 @@ curs_config:
 
   # Help text shown above the experimental conditions picker
   experimental_conditions_help_text: ~
-
-  # Text for help tooltip for the experimental conditions picker
-  experimental_conditions_help_tooltip_text: >
-    Conditions are the aspects of the
-    experimental setup that are independent of what cells (strain, genotype,
-    constructs, etc.) are used.
 
   # A message for curators, shown at the top of the gene confirmation page.
   # gene_page_top_message: SET_ME

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1387,6 +1387,15 @@ form label.error {
   color: red;
 }
 
+.curs-allele-conditions {
+  float: left;
+  width: 500px;
+}
+
+.curs-used-conditions {
+  clear: left;
+}
+
 .curs-allele-condition-button span.ui-button-text {
   font-size: 80%;
 }

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1916,7 +1916,3 @@ a:not([href]) {
 .tagit-new {
   width: 25em;
 }
-
-.curs-allele-condition-buttons-help {
-  margin-right: 0.8em;
-}

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1917,10 +1917,6 @@ a:not([href]) {
   width: 25em;
 }
 
-.curs-conditions-help-icon {
-  padding: 0.3em;
-}
-
 .curs-allele-condition-buttons-help {
   margin-right: 0.8em;
 }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -3583,7 +3583,7 @@ canto.directive('annotationEvidence',
                  annotationEvidence]);
 
 var conditionPicker =
-  function (CursConditionList, CantoConfig, CantoGlobals, toaster) {
+  function (CursConditionList, toaster) {
     var directive = {
       scope: {
         conditions: '=',
@@ -3602,18 +3602,7 @@ var conditionPicker =
       },
       templateUrl: app_static_path + 'ng_templates/condition_picker.html',
       link: function ($scope, elem) {
-        $scope.cursConfigPromise = CantoConfig.get('curs_config');
-        $scope.conditionsHelpTooltipText = '';
-
         var $field = elem.find('.curs-allele-conditions');
-
-        $scope.cursConfigPromise.then(function(data) {
-          var conditionsHelpTooltipText = data['experimental_conditions_help_tooltip_text'];
-          $scope.conditionsHelpTooltipText = conditionsHelpTooltipText;
-        });
-
-        $scope.helpIconUrl = CantoGlobals.app_static_path +
-          '/images/help.png';
 
         if (typeof ($scope.conditions) != 'undefined') {
           CursConditionList.conditionList().then(function (results) {
@@ -3665,8 +3654,7 @@ var conditionPicker =
     return directive;
   };
 
-canto.directive('conditionPicker',
-                ['CursConditionList', 'CantoConfig', 'CantoGlobals', 'toaster', conditionPicker]);
+canto.directive('conditionPicker', ['CursConditionList', 'toaster', conditionPicker]);
 
 var alleleNameComplete =
   function (CursAlleleList, toaster) {

--- a/root/static/ng_templates/condition_picker.html
+++ b/root/static/ng_templates/condition_picker.html
@@ -4,7 +4,7 @@
     <help-icon key="experimental_conditions_definition"></help-icon>
   </div>
   <div ng-if="usedConditions.length > 0" class="curs-used-conditions" >
-    <span>Previously used conditions (click to add to list):</span>
+    <span>Previously used (click to add):</span>
     <span ng-repeat="cond in usedConditions">
       <button type="button" class="btn btn-default btn-sm"
               ng-click="addCondition(cond.name)">

--- a/root/static/ng_templates/condition_picker.html
+++ b/root/static/ng_templates/condition_picker.html
@@ -4,9 +4,7 @@
     <help-icon key="experimental_conditions_definition"></help-icon>
   </div>
   <div ng-if="usedConditions.length > 0">
-    <span class="curs-allele-condition-buttons-help">
-      Previously used conditions (click to add to list):
-    </span>
+    <span>Previously used conditions (click to add to list):</span>
     <span ng-repeat="cond in usedConditions">
       <button type="button" class="btn btn-default btn-sm"
               ng-click="addCondition(cond.name)">

--- a/root/static/ng_templates/condition_picker.html
+++ b/root/static/ng_templates/condition_picker.html
@@ -3,7 +3,7 @@
     <ul class="curs-allele-conditions"></ul>
     <help-icon key="experimental_conditions_definition"></help-icon>
   </div>
-  <div ng-if="usedConditions.length > 0">
+  <div ng-if="usedConditions.length > 0" class="curs-used-conditions" >
     <span>Previously used conditions (click to add to list):</span>
     <span ng-repeat="cond in usedConditions">
       <button type="button" class="btn btn-default btn-sm"

--- a/root/static/ng_templates/condition_picker.html
+++ b/root/static/ng_templates/condition_picker.html
@@ -1,22 +1,18 @@
-<span>
-  <div class="row">
-    <div class="col-md-8">
-      <ul class="curs-allele-conditions"></ul>
-      <help-icon key="experimental_conditions_definition"></help-icon>
-    </div>
+<div>
+  <div>
+    <ul class="curs-allele-conditions"></ul>
+    <help-icon key="experimental_conditions_definition"></help-icon>
   </div>
-  <div class="curs-allele-condition-buttons row">
-    <div class="col-md-11" ng-if="usedConditions.length > 0">
-      <span class="curs-allele-condition-buttons-help">
-        Previously used conditions (click to add to list):
-      </span>
-      <span ng-repeat="cond in usedConditions">
-        <button type="button" class="btn btn-default btn-sm"
-                ng-click="addCondition(cond.name)">
-          <i class="glyphicon glyphicon-plus"></i> {{cond.name}}
-        </button>
-      </span>
-    </div>
+  <div ng-if="usedConditions.length > 0">
+    <span class="curs-allele-condition-buttons-help">
+      Previously used conditions (click to add to list):
+    </span>
+    <span ng-repeat="cond in usedConditions">
+      <button type="button" class="btn btn-default btn-sm"
+              ng-click="addCondition(cond.name)">
+        <i class="glyphicon glyphicon-plus"></i> {{cond.name}}
+      </button>
+    </span>
   </div>
   <div class="voffset2"></div>
-</span>
+</div>

--- a/root/static/ng_templates/condition_picker.html
+++ b/root/static/ng_templates/condition_picker.html
@@ -1,15 +1,14 @@
 <span>
   <div class="row">
     <div class="col-md-8">
-      <ul class="curs-allele-conditions">
-      </ul>
+      <ul class="curs-allele-conditions"></ul>
       <help-icon key="experimental_conditions_definition"></help-icon>
     </div>
   </div>
   <div class="curs-allele-condition-buttons row">
     <div class="col-md-11" ng-if="usedConditions.length > 0">
       <span class="curs-allele-condition-buttons-help">
-Previously used conditions (click to add to list):
+        Previously used conditions (click to add to list):
       </span>
       <span ng-repeat="cond in usedConditions">
         <button type="button" class="btn btn-default btn-sm"

--- a/root/static/ng_templates/condition_picker.html
+++ b/root/static/ng_templates/condition_picker.html
@@ -3,12 +3,7 @@
     <div class="col-md-8">
       <ul class="curs-allele-conditions">
       </ul>
-    </div>
-    <div ng-if="conditionsHelpTooltipText" class="curs-conditions-help-icon">
-      <span class="curs-inline-help-icon">
-        <img ng-src="{{helpIconUrl}}"
-             alt="help" title="{{conditionsHelpTooltipText}}"/>
-      </span>
+      <help-icon key="experimental_conditions_definition"></help-icon>
     </div>
   </div>
   <div class="curs-allele-condition-buttons row">


### PR DESCRIPTION
This PR makes some more changes to the experimental conditions picker, on top of what's been done in https://github.com/pombase/canto/pull/2438.

The most significant change is replacing the existing implementation of the help icon with the `helpIcon` directive, since the previous solution just seemed to be re-implementing existing code. I moved the help icon text from `curs_config` to `help_text` in `canto.yaml`, so now this is the only markup that's needed:

```html
<help-icon key="experimental_conditions_definition"></help-icon>
```

As part of those changes, I had to rework the CSS layout for the conditions picker:

* I switched to a layout based on `float` because that was the only one that seemed to cooperate with the styling of the help icon and tag-it (`display: inline-block` just broke the layout). I looked at using `display: flex` but I was struggling to make anything work with that, so I just went with what was already working. The conditions picker has a fixed width now (close to what it used to have), the help icon has enough space to render its tooltip in the correct place, and the 'previous conditions' section clears to the left so that it stays below the floated condition picker input.

* I removed the Bootstrap row and column style classes from the conditions picker, because they were interfering with the float-based layout. As far as I could tell, the conditions picker isn't used in isolation, so it should probably be inheriting its layout from other components anyway.

I've also implemented a request from Val about shortening the 'Previously used conditions (click to add to list)' to 'Previously used conditions (click to add)'. We could shorten this further to 'Previously used', because the plus symbols on the condition buttons might be enough for the curator to infer that clicking the button will add the condition.

Here's how it looks in PHI-Canto, where we'll be using both help text features:

<img alt="slim_condition_picker" src="https://user-images.githubusercontent.com/37659591/111627450-f8b87c80-87e6-11eb-94ed-285ff919ea6f.PNG">