### PR TITLE
Add more features to metagenotype filter

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -4637,7 +4637,8 @@ var organismSelector = function () {
       organismSelected: '&',
       organisms: '<',
       initialSelectionTaxonId: '@',
-      label: '@'
+      label: '@',
+      allowUnset: '<',
     },
     restrict: 'E',
     templateUrl: app_static_path + 'ng_templates/organism_selector.html',
@@ -4657,6 +4658,11 @@ var organismSelectorCtrl = function ($scope, CantoGlobals) {
     $scope.organismSelected({
       organism: $scope.data.selectedOrganism
     });
+  };
+
+  $scope.unsetOrganism = function () {
+    $scope.data.selectedOrganism = null;
+    $scope.organismChanged();
   };
 
   $scope.$watch('organisms', function () {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -9743,10 +9743,14 @@ var metagenotypeManage = function ($q, CantoGlobals, Curs, CursGenotypeList, Met
       $scope.display = (!CantoGlobals.read_only_curs);
 
       $scope.onPathogenSelected = function (organism) {
-        var taxonId = organism.taxonid;
         $scope.selectedPathogen = organism;
         $scope.selectedGenotypePathogen = null;
-        $scope.selectedPathogenGenotypes = $scope.taxonGenotypeMap[taxonId];
+        if (organism) {
+          var taxonId = organism.taxonid;
+          $scope.selectedPathogenGenotypes = $scope.taxonGenotypeMap[taxonId];
+        } else {
+          $scope.selectedPathogenGenotypes = null;
+        }
         $scope.filteredMetagenotypes = filterMetagenotypesBySelectedOrganisms(
           $scope.selectedPathogen, $scope.selectedHost, $scope.metagenotypes
         );
@@ -9757,13 +9761,22 @@ var metagenotypeManage = function ($q, CantoGlobals, Curs, CursGenotypeList, Met
       };
 
       $scope.onHostSelected = function (organism) {
-        var taxonId = organism.taxonid;
         $scope.selectedHost = organism;
         $scope.selectedGenotypeHost = null;
         $scope.selectedHostStrain = null;
-        $scope.selectedHostGenotypes = taxonId in $scope.taxonGenotypeMap ?
-          $scope.taxonGenotypeMap[taxonId] :
-          {'single': [], 'multi': []};
+        if (organism) {
+          var taxonId = organism.taxonid;
+          if (taxonId in $scope.taxonGenotypeMap) {
+            $scope.selectedHostGenotypes = $scope.taxonGenotypeMap[taxonId];
+          } else {
+            $scope.selectedHostGenotypes = {
+              'single': [],
+              'multi': []
+            };
+          }
+        } else {
+          $scope.selectedHostGenotypes = null;
+        }
         $scope.filteredMetagenotypes = filterMetagenotypesBySelectedOrganisms(
           $scope.selectedPathogen, $scope.selectedHost, $scope.metagenotypes
         );

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -9894,14 +9894,26 @@ var metagenotypeManage = function ($q, CantoGlobals, Curs, CursGenotypeList, Met
       }
 
       function filterMetagenotypesBySelectedOrganisms(selectedPathogen, selectedHost, metagenotypes) {
+        var selectedPathogenId;
+        var selectedHostId;
         function filterByOrganisms(metagenotype) {
           var pathogenId = metagenotype.pathogen_genotype.organism.taxonid;
           var hostId = metagenotype.host_genotype.organism.taxonid;
-          return pathogenId == selectedPathogenId && hostId == selectedHostId;
+          if (!selectedHostId) {
+            return pathogenId == selectedPathogenId;
+          } else if (!selectedPathogenId) {
+            return hostId == selectedHostId;
+          } else {
+            return pathogenId == selectedPathogenId && hostId == selectedHostId;
+          }
         }
-        if (selectedPathogen && selectedHost) {
-          var selectedPathogenId = selectedPathogen.taxonid;
-          var selectedHostId = selectedHost.taxonid;
+        if (selectedPathogen) {
+          selectedPathogenId = selectedPathogen.taxonid;
+        }
+        if (selectedHost) {
+          selectedHostId = selectedHost.taxonid;
+        }
+        if (selectedPathogenId || selectedHostId) {
           return metagenotypes.filter(filterByOrganisms);
         }
         return metagenotypes;

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -8,7 +8,8 @@
                 <div class="curs-metagenotype-picker-heading">Pathogen</div>
                 <organism-selector
                     organisms="pathogenOrganisms"
-                    organism-selected="onPathogenSelected(organism)">
+                    organism-selected="onPathogenSelected(organism)"
+                    allow-unset="true">
                 </organism-selector>
                 <metagenotype-genotype-picker
                     is-host="false"
@@ -21,7 +22,8 @@
                 <div class="curs-metagenotype-picker-heading">Host</div>
                 <organism-selector
                     organisms="hostOrganisms"
-                    organism-selected="onHostSelected(organism)">
+                    organism-selected="onHostSelected(organism)"
+                    allow-unset="true">
                 </organism-selector>
                 <metagenotype-genotype-picker
                     is-host="true"

--- a/root/static/ng_templates/organism_selector.html
+++ b/root/static/ng_templates/organism_selector.html
@@ -12,5 +12,12 @@
       ng-options="o as o.full_name for o in organisms track by o.taxonid">
     <option value="" disabled>Select an organism...</option>
   </select>
+  <button
+      class="btn btn-default"
+      ng-if="allowUnset && organisms.length > 1"
+      ng-click="unsetOrganism()"
+      title="Clear selected organism">
+    <span class="glyphicon glyphicon-remove"></span>
+  </button>
   <span ng-if="organisms.length === 1">{{organisms[0].full_name}}</span>
 </div>


### PR DESCRIPTION
(References #2411)

This PR adds the ability to filter the metagenotype list on the Metagenotype Management page by _either_ the selected pathogen or the selected host: for example, if a pathogen is selected but a host isn't, then the list will only show the metagenotypes that include that pathogen, and will include all hosts (and vice versa).

I've also added a button to `organismSelector` that will unset the selected organism. This is needed to allow the curator to cancel the filter (to see all metagenotypes again after selecting an organism). The button is only shown if the binding `allowUnset` is true (or truthy). Here's how it looks:

![image](https://user-images.githubusercontent.com/37659591/112002540-e789ab80-8b17-11eb-9ee3-92ee1f340c97.png)

@kimrutherford Note that allowing the organism to be unset means that any callback passed to `organismSelected` where `allowUnset` is true will have to handle a null value. That wasn't required before, since the value wasn't expected to become null after initially being set. I've amended the callbacks in the `metagenotypeManage` controller to handle this, but not anywhere else. I think this is safe for now since no other controller has `allowUnset` set to true, but I'm happy to fix it everywhere if needed.