### PR TITLE
Add section for metagenotype annotation links on summary page

### DIFF
--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -3,108 +3,112 @@ $pub
 </%args>
 
 <script language="javascript" type="text/javascript">
-var organismsAndGenes = <% $organisms_and_genes_js |n %>;
+  var organismsAndGenes = <% $organisms_and_genes_js |n %>;
 </script>
 
 <div class="curs-box">
   <div class="curs-box-title">
     <div>
-
-% if ($read_only_curs) {
-Genes from this publication
-% } else {
-Annotate genes
-% }
-    <help-icon key="choose_gene"></help-icon>
+%     if ($read_only_curs) {
+        Genes from this publication
+%     } else {
+        Annotate genes
+%     }
+      <help-icon key="choose_gene"></help-icon>
     </div>
   </div>
   <div class="curs-box-body">
-% if ($pathogen_host_mode) {
-  <summary-page-gene-list> </summary-page-gene-list>
-% } else {
-% for my $org_and_gene_hashes (@gene_hashes_by_organism) {
-%   my @gene_hashes = @{$org_and_gene_hashes->{gene_hashes}};
-
-<div class="curs-front-page-gene-table">
-%   if (@gene_hashes) {
-<& /curs/front_gene_table.mhtml, gene_hashes => \@gene_hashes &>
-%   }
-</div>
-% }
-%   if ($no_genes) {
-  <div class="no-genes-message">
-    [No genes]
-  </div>
-%   }
-% }
-  <div style="margin-top: 20px;">
-% if (!$read_only_curs) {
-  <div class="feature-list-action" style="margin-bottom: 20px;">
-    <a href="<% $edit_path %>">
-%   if ($multi_organism_mode) {
-Delete or edit genes and organisms
-%   } else {
-Edit gene list
-%   }
-    </a>
-  </div>
-% }
-
-% if ($pathogen_host_mode && $read_only_curs) {
-  <div class="feature-list-action" style="margin-bottom: 20px;">
-    <a href="<% $view_genes_and_strains_path %>">
-View genes, organisms and strains from this session
-    </a>
-  </div>
-% }
-
-% if ($genotype_annotation_configured) {
-  <div class="curs-box-title">
-    <div>
-% if ($read_only_curs) {
-Genotypes from this publication
-% } else {
-Annotate genotypes
-% }
-    <help-icon key="choose_genotype"></help-icon>
-    </div>
-  </div>
 %   if ($pathogen_host_mode) {
-  <div class="feature-list-action">
-% if ($has_pathogen_genes) {
-    <a href="<% $pathogen_genotype_manage_url %>"><% $read_only_curs ? 'View pathogen genotypes' : 'Pathogen genotype management' %></a>
-% } else {
-    <span style="color: #888" title="Add at least one pathogen gene to the session to make a pathogen genotype">
-      <% $read_only_curs ? 'View pathogen genotypes' : 'Pathogen genotype management' %>
-    </span>
-% }
-  </div>
-  <div class="feature-list-action">
-% if ($show_host_genotype_link) {
-    <a href="<% $host_genotype_manage_url %>"><% $read_only_curs ? 'View host genotypes' : 'Host genotype management' %></a>
-% } else {
-    <span style="color: #888" title="Add at least one host gene to make a host genotype">
-      <% $read_only_curs ? 'View host genotypes' : 'Host genotype management' %>
-    </span>
-% }
-  </div>
-  <div class="feature-list-action">
-% if ($show_metagenotype_links) {
-    <a href="<% $metagenotype_manage_url %>"><% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %></a>
-% } else {
-    <span style="color: #888" title="Add at least one host organism and at least one pathogen genotype to make a metagenotype">
-      <% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %>
-    </span>
-% }
-  </div>
+      <summary-page-gene-list></summary-page-gene-list>
 %   } else {
-  <div class="feature-list-action">
-    <a href="<% $genotype_manage_url %>"><% $read_only_curs ? 'View genotypes' : 'Genotype management' %></a>
-  </div>
+%     for my $org_and_gene_hashes (@gene_hashes_by_organism) {
+%       my @gene_hashes = @{$org_and_gene_hashes->{gene_hashes}};
+
+        <div class="curs-front-page-gene-table">
+%       if (@gene_hashes) {
+          <& /curs/front_gene_table.mhtml, gene_hashes => \@gene_hashes &>
+%       }
+        </div>
+%     }
+%     if ($no_genes) {
+        <div class="no-genes-message">
+          [No genes]
+        </div>
+%     }
 %   }
-% }
+  </div>
 </div>
+
+<div class="curs-box">
+  <div class="curs-box-body">
+%   if (!$read_only_curs) {
+      <div class="feature-list-action">
+        <a href="<% $edit_path %>">
+%         if ($multi_organism_mode) {
+            Delete or edit genes and organisms
+%         } else {
+            Edit gene list
+%         }
+        </a>
+      </div>
+%   }
+  </div>
 </div>
+
+<div class="curs-box">
+%   if ($genotype_annotation_configured) {
+      <div class="curs-box-title">
+%       if ($read_only_curs) {
+          Genotypes from this publication
+%       } else {
+          Annotate genotypes
+%       }
+        <help-icon key="choose_genotype"></help-icon>
+      </div>
+      <div class="curs-box-body">
+%       if ($pathogen_host_mode) {
+          <div class="feature-list-action">
+%           if ($has_pathogen_genes) {
+              <a href="<% $pathogen_genotype_manage_url %>">
+                <% $read_only_curs ? 'View pathogen genotypes' : 'Pathogen genotype management' %>
+              </a>
+%           } else {
+              <span style="color: #888" title="Add at least one pathogen gene to the session to make a pathogen genotype">
+                <% $read_only_curs ? 'View pathogen genotypes' : 'Pathogen genotype management' %>
+              </span>
+%           }
+          </div>
+          <div class="feature-list-action">
+%           if ($show_host_genotype_link) {
+              <a href="<% $host_genotype_manage_url %>">
+                <% $read_only_curs ? 'View host genotypes' : 'Host genotype management' %>
+              </a>
+%           } else {
+              <span style="color: #888" title="Add at least one host gene to make a host genotype">
+                <% $read_only_curs ? 'View host genotypes' : 'Host genotype management' %>
+              </span>
+%           }
+          </div>
+          <div class="feature-list-action">
+%           if ($show_metagenotype_links) {
+              <a href="<% $metagenotype_manage_url %>">
+                <% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %>
+              </a>
+%           } else {
+              <span style="color: #888" title="Add at least one host organism and at least one pathogen genotype to make a metagenotype">
+                <% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %>
+              </span>
+%           }
+          </div>
+%       } else {
+          <div class="feature-list-action">
+            <a href="<% $genotype_manage_url %>">
+              <% $read_only_curs ? 'View genotypes' : 'Genotype management' %>
+            </a>
+          </div>
+%       }
+      </div>
+%   }
 </div>
 
 <%init>

--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -89,17 +89,6 @@ $pub
               </span>
 %           }
           </div>
-          <div class="feature-list-action">
-%           if ($show_metagenotype_links) {
-              <a href="<% $metagenotype_manage_url %>">
-                <% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %>
-              </a>
-%           } else {
-              <span style="color: #888" title="Add at least one host organism and at least one pathogen genotype to make a metagenotype">
-                <% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %>
-              </span>
-%           }
-          </div>
 %       } else {
           <div class="feature-list-action">
             <a href="<% $genotype_manage_url %>">
@@ -109,6 +98,30 @@ $pub
 %       }
       </div>
 %   }
+</div>
+
+<div class="curs-box">
+  <div class="curs-box-title">
+%   if ($read_only_curs) {
+      Metagenotypes from this publication
+%   } else {
+      Annotate metagenotypes
+%   }
+    <help-icon key="choose_metagenotype"></help-icon>
+  </div>
+  <div class="curs-box-body">
+    <div class="feature-list-action">
+%     if ($show_metagenotype_links) {
+        <a href="<% $metagenotype_manage_url %>">
+          <% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %>
+        </a>
+%     } else {
+        <span style="color: #888" title="Add at least one host organism and at least one pathogen genotype to make a metagenotype">
+          <% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %>
+        </span>
+%     }
+    </div>
+  </div>
 </div>
 
 <%init>

--- a/root/curs/front_gene_section.mhtml
+++ b/root/curs/front_gene_section.mhtml
@@ -100,29 +100,31 @@ $pub
 %   }
 </div>
 
-<div class="curs-box">
-  <div class="curs-box-title">
-%   if ($read_only_curs) {
-      Metagenotypes from this publication
-%   } else {
-      Annotate metagenotypes
-%   }
-    <help-icon key="choose_metagenotype"></help-icon>
-  </div>
-  <div class="curs-box-body">
-    <div class="feature-list-action">
-%     if ($show_metagenotype_links) {
-        <a href="<% $metagenotype_manage_url %>">
-          <% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %>
-        </a>
+% if ($pathogen_host_mode) {
+  <div class="curs-box">
+    <div class="curs-box-title">
+%     if ($read_only_curs) {
+        Metagenotypes from this publication
 %     } else {
-        <span style="color: #888" title="Add at least one host organism and at least one pathogen genotype to make a metagenotype">
-          <% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %>
-        </span>
+        Annotate metagenotypes
 %     }
+      <help-icon key="choose_metagenotype"></help-icon>
+    </div>
+    <div class="curs-box-body">
+      <div class="feature-list-action">
+%       if ($show_metagenotype_links) {
+          <a href="<% $metagenotype_manage_url %>">
+            <% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %>
+          </a>
+%       } else {
+          <span style="color: #888" title="Add at least one host organism and at least one pathogen genotype to make a metagenotype">
+            <% $read_only_curs ? 'View metagenotypes' : 'Metagenotype management' %>
+          </span>
+%       }
+      </div>
     </div>
   </div>
-</div>
+% }
 
 <%init>
 use Canto::Curs;

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1713,7 +1713,6 @@ a:not([href]) {
 .curs-summary-gene-column {
   margin-right: 10px;
   padding-right: 10px;
-  margin-top: 10px;
 }
 .curs-summary-organism-container {
   margin-bottom: 8px;


### PR DESCRIPTION
Fixes #2452

I've added a dedicated heading and section for the link to the Metagenotype Management page on the Curation Summary page. Previously, this link was part of the 'Annotate genotypes' section, which didn't make sense. I've also tried to clean up the markup a bit by making the Mason markup follow the indentation of the HTML, and I've added some extra containing elements so that the layout of the sections is consistent (see below for more details).

The diff is a bit chaotic due to all the indentation changes, so it's simpler to just show an image of the changes:

![image](https://user-images.githubusercontent.com/37659591/114684563-f0c9fa80-9d08-11eb-9f74-79f8551e6856.png)

- - -

### Markup changes

In terms of the markup changes, I added a `curs-box` around each section of the list, so that each of the four sections are in their own containers.  For reference, the four sections (in order) are: 

1. Annotate genes
2. Delete or edit genes and organisms ('Edit gene list' in single organism mode)
3. Annotate genotypes
4. Annotate metagenotypes

Previously, the 'Annotate genotypes' section was actually nested in the container for 'Annotate genes', and because of a quirk in the styling rules, that meant it was indented further than the 'Annotate genes' section, giving the impression that it was somehow subordinate to that section when it shouldn't have been:

<img width=200px src="https://user-images.githubusercontent.com/37659591/114685370-b2810b00-9d09-11eb-83a2-76fa4f1d7897.png">

One side effect of the extra `curs-box-body` containers is that there's slightly more vertical spacing around the sections, but at least they're all using the same style rules now. I think most of the extra spacing is due to styling on the `feature-list-action` class, and I could adjust that if needed.

### Indentation and formatting

As previously mentioned, I've added indentation to the Mason markup in `front_gene_section.mhtml` so that it's easier to follow the structure of the HTML. The Mason still works fine as long as you don't indent the percent sign at the start of the line; unfortunately, that makes it very tedious to fix the indentation because you have to manually indent all the text past the first character. I'm not aware of any workaround for this, but I still think the benefits of readability are worth the extra effort. Here's an example of the markup with new indentation:

```
  <div class="curs-box-title">
    <div>
%     if ($read_only_curs) {
        Genes from this publication
%     } else {
        Annotate genes
%     }
      <help-icon key="choose_gene"></help-icon>
    </div>
  </div>
```
