### PR TITLE
Allow annotation extensions to be restricted by feature type

### DIFF
--- a/lib/Canto/Config/ExtensionConf.pm
+++ b/lib/Canto/Config/ExtensionConf.pm
@@ -70,7 +70,7 @@ sub parse {
       next if $line =~ /^#/;
 
       my ($domain, $subset_rel, $allowed_relation, $range, $display_text, $help_text,
-          $cardinality, $role, $annotation_type_name) =
+          $cardinality, $role, $annotation_type_name, $feature_type) =
             split (/\t/, $line);
 
       if ($domain =~ /^\s*domain/i) {
@@ -176,6 +176,7 @@ sub parse {
         cardinality => \@cardinality,
         role => $role,
         annotation_type_name => $annotation_type_name,
+        feature_type => $feature_type,
       );
 
       if ($domain =~ /(\S+)-(\S+)/) {

--- a/root/curs/modules/ontology.mhtml
+++ b/root/curs/modules/ontology.mhtml
@@ -58,7 +58,8 @@ Annotation extensions
                          feature-display-name='<% $feature_display_name %>'
                          term-id="{{currentTerm()}}"
                          is-valid="extensionBuilderIsValid"
-                         annotation-type-name="<% $annotation_type_name %>"></extension-builder>
+                         annotation-type-name="<% $annotation_type_name %>"
+                         feature-type="finalFeatureType"></extension-builder>
     </div>
   </div>
 

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7244,15 +7244,23 @@ var annotationEditDialogCtrl =
           .then(function (data) {
             var extensionConfiguration = data[0];
             var termDetails = data[1];
-
             var subset_ids = termDetails.subset_ids;
+            var featureType = $scope.featureSubtype || $scope.annotation.feature_type;
 
-            if (extensionConfiguration.length > 0 &&
-                subset_ids && subset_ids.length > 0) {
-              $scope.matchingConfigurations =
-                extensionConfFilter(extensionConfiguration, subset_ids,
-                                    CantoGlobals.current_user_is_admin ? 'admin' : 'user',
-                                    $scope.annotationTypeName);
+            var hasExtensionsAndSubsets = (
+              extensionConfiguration.length > 0 &&
+              subset_ids &&
+              subset_ids.length > 0
+            );
+
+            if (hasExtensionsAndSubsets) {
+              $scope.matchingConfigurations = extensionConfFilter(
+                extensionConfiguration,
+                subset_ids,
+                CantoGlobals.current_user_is_admin ? 'admin' : 'user',
+                $scope.annotationTypeName,
+                featureType,
+              );
             } else {
               $scope.matchingConfigurations = [];
             }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -585,6 +585,21 @@ canto.service('CursGeneList', function ($q, Curs) {
 
     return q.promise;
   };
+
+  this.getGeneById = function (geneId) {
+    var genesPromise = this.geneList();
+    return genesPromise.then(function (genes) {
+      var filteredGenes = genes.filter(function (gene) {
+        return gene.gene_id === geneId;
+      });
+
+      if (filteredGenes.length === 1) {
+        return filteredGenes[0];
+      } else {
+        return null;
+      }
+    });
+  };
 });
 
 canto.service('CursGenotypeList', function ($q, Curs) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2700,6 +2700,7 @@ var extensionBuilder =
         featureDisplayName: '@',
         isValid: '=',
         annotationTypeName: '@',
+        featureType: '<',
       },
       restrict: 'E',
       replace: true,
@@ -2729,9 +2730,13 @@ var extensionBuilder =
           if ($scope.extensionConfiguration.length > 0 &&
             subset_ids && subset_ids.length > 0) {
             var newConf =
-              extensionConfFilter($scope.extensionConfiguration, subset_ids,
-                                  CantoGlobals.current_user_is_admin ? 'admin' : 'user',
-                                  $scope.annotationTypeName);
+              extensionConfFilter(
+                $scope.extensionConfiguration,
+                subset_ids,
+                CantoGlobals.current_user_is_admin ? 'admin' : 'user',
+                $scope.annotationTypeName,
+                $scope.featureType
+              );
             copyObject(newConf, $scope.matchingConfigurations);
             return;
           }

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2166,7 +2166,12 @@ function extensionConfFilter(allConfigs, subsetIds, userRole, annotationTypeName
       !! config.annotation_type_name &&
       config.annotation_type_name !== annotationTypeName
     );
-    if (userNotPermitted) {
+    var wrongFeatureType = (
+      !! featureType && !! config.feature_type &&  
+      config.feature_type != featureType
+    );
+
+    if (userNotPermitted || wrongFeatureType) {
       return false;
     }
     if (noAnnotationTypeMatch) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6667,6 +6667,7 @@ var annotationEditDialogCtrl =
     $scope.featureEditable = args.featureEditable;
     $scope.matchingConfigurations = [];
     $scope.termSuggestionVisible = false;
+    $scope.featureSubtype = null;
 
     if (args.annotation.term_suggestion_name ||
         args.annotation.term_suggestion_definition) {
@@ -6701,6 +6702,12 @@ var annotationEditDialogCtrl =
       $scope.selectedOrganism = args.annotation.organism.taxonid;
       if (!$scope.initialSelectedOrganismId) {
         $scope.initialSelectedOrganismId = args.annotation.organism.taxonid;
+      }
+      if (CantoGlobals.pathogen_host_mode) {
+        $scope.featureSubtype = setFeatureSubtype(
+          args.annotation.feature_type,
+          args.annotation.organism
+        );
       }
     }
 
@@ -7013,6 +7020,12 @@ var annotationEditDialogCtrl =
 
     $scope.organismSelected = function (organism) {
       $scope.selectedOrganism = organism;
+      if (CantoGlobals.pathogen_host_mode) {
+        $scope.featureSubtype = setFeatureSubtype(
+          $scope.annotation.feature_type,
+          organism
+        );
+      }
       $scope.allPromise.then(function () {
         setFilteredFeatures();
       });
@@ -7140,6 +7153,16 @@ var annotationEditDialogCtrl =
                     };
                   });
         });
+    }
+
+    function setFeatureSubtype(featureType, organism) {
+      if (organism) {
+        if (featureType == 'gene') {
+          var organismRole = organism.pathogen_or_host;
+          return organismRole + '_gene';
+        }
+      }
+      return null;
     }
 
     function featureIdWatcher(featureId) {
@@ -7275,11 +7298,14 @@ var annotationEditDialogCtrl =
       };
 
     $scope.editExtension = function () {
-      var editPromise =
-        openExtensionBuilderDialog($uibModal, $scope.annotation.extension,
-                                   $scope.annotation.term_ontid,
-                                   $scope.currentFeatureDisplayName,
-                                   $scope.annotationTypeName);
+      var editPromise = openExtensionBuilderDialog(
+        $uibModal,
+        $scope.annotation.extension,
+        $scope.annotation.term_ontid,
+        $scope.currentFeatureDisplayName,
+        $scope.annotationTypeName,
+        $scope.featureSubtype
+      );
 
       editPromise.then(function (result) {
         angular.copy(result.extension, $scope.annotation.extension);

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2241,7 +2241,7 @@ canto.controller('ExtensionBuilderDialogCtrl',
   ]);
 
 
-function openExtensionBuilderDialog($uibModal, extension, termId, featureDisplayName, annotationTypeName) {
+function openExtensionBuilderDialog($uibModal, extension, termId, featureDisplayName, annotationTypeName, featureType) {
   return $uibModal.open({
     templateUrl: app_static_path + 'ng_templates/extension_builder_dialog.html',
     controller: 'ExtensionBuilderDialogCtrl',
@@ -2255,6 +2255,7 @@ function openExtensionBuilderDialog($uibModal, extension, termId, featureDisplay
           termId: termId,
           featureDisplayName: featureDisplayName,
           annotationTypeName: annotationTypeName,
+          featureType: featureType,
         };
       },
     },

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -2145,7 +2145,7 @@ function arrayIntersection(arr1, arr2) {
 // only those where the "domain" term ID in the configuration matches one of
 // subsetIds.  Also ignore any configs where the "role" is "admin" and the
 // current, logged in user isn't an admin.
-function extensionConfFilter(allConfigs, subsetIds, userRole, annotationTypeName) {
+function extensionConfFilter(allConfigs, subsetIds, userRole, annotationTypeName, featureType) {
   return allConfigs.filter(isValidExtension).map(getProperties);
   
   function getProperties(config) {

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -6704,7 +6704,7 @@ var annotationEditDialogCtrl =
         $scope.initialSelectedOrganismId = args.annotation.organism.taxonid;
       }
       if (CantoGlobals.pathogen_host_mode) {
-        $scope.featureSubtype = setFeatureSubtype(
+        $scope.featureSubtype = getFeatureSubtype(
           args.annotation.feature_type,
           args.annotation.organism
         );
@@ -7021,7 +7021,7 @@ var annotationEditDialogCtrl =
     $scope.organismSelected = function (organism) {
       $scope.selectedOrganism = organism;
       if (CantoGlobals.pathogen_host_mode) {
-        $scope.featureSubtype = setFeatureSubtype(
+        $scope.featureSubtype = getFeatureSubtype(
           $scope.annotation.feature_type,
           organism
         );
@@ -7155,7 +7155,7 @@ var annotationEditDialogCtrl =
         });
     }
 
-    function setFeatureSubtype(featureType, organism) {
+    function getFeatureSubtype(featureType, organism) {
       if (organism) {
         if (featureType == 'gene') {
           var organismRole = organism.pathogen_or_host;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -7298,13 +7298,14 @@ var annotationEditDialogCtrl =
       };
 
     $scope.editExtension = function () {
+      var featureType = $scope.featureSubtype || $scope.annotation.feature_type;
       var editPromise = openExtensionBuilderDialog(
         $uibModal,
         $scope.annotation.extension,
         $scope.annotation.term_ontid,
         $scope.currentFeatureDisplayName,
         $scope.annotationTypeName,
-        $scope.featureSubtype
+        featureType
       );
 
       editPromise.then(function (result) {

--- a/root/static/ng_templates/extension_builder_dialog.html
+++ b/root/static/ng_templates/extension_builder_dialog.html
@@ -8,7 +8,8 @@
     <extension-builder extension="data.extension" term-id="{{data.termId}}"
                        feature-display-name="{{data.featureDisplayName}}"
                        is-valid="extensionBuilderIsValid"
-                       annotation-type-name="{{data.annotationTypeName}}"></extension-builder>
+                       annotation-type-name="{{data.annotationTypeName}}"
+                       feature-type="data.featureType"></extension-builder>
   </div>
   <div class="modal-footer">
     <button class="btn btn-warning" ng-click="cancel()">Cancel</button>

--- a/t/50_config.t
+++ b/t/50_config.t
@@ -87,203 +87,134 @@ is($config_with_suffix->{extra_css}, '/static/css/test_style.css');
 ok ($config_with_suffix->{extension_configuration});
 
 
-cmp_deeply($config_with_suffix->{extension_configuration},
-          [
-            {
-              'allowed_relation' => 'has_substrate',
-              'cardinality' => [
-                                 '0',
-                                 '1'
-                               ],
-              'display_text' => 'kinase substrate',
-              'range' => [
-                           {
-                             'type' => 'Gene'
-                           }
-                         ],
-              'help_text' => '',
-              'domain' => 'GO:0016023',
-              'role' => 'user',
-              'annotation_type_name' => undef,
-              'subset_rel' => [
-                                'is_a'
-                        ]
-            },
-            {
-              'subset_rel' => [
-                                'is_a'
-                              ],
-              'role' => 'user',
-              'domain' => 'GO:0016023',
-              'range' => [
-                           {
-                             'type' => 'Ontology',
-                             'scope' => [
-                                          'GO:0005215'
-                                        ]
-                           }
-                         ],
-              'help_text' => '',
-              'allowed_relation' => 'happens_during',
-              'cardinality' => [
-                                 '*'
-                               ],
-              'display_text' => 'Something that happens during',
-              'annotation_type_name' => undef,
-            },
-            {
-              'subset_rel' => [
-                                'is_a'
-                              ],
-              'role' => 'user',
-              'domain' => 'GO:0022857',
-              'help_text' => '',
-              'range' => [
-                           {
-                             'type' => 'Gene'
-                           }
-                         ],
-              'display_text' => 'localizes',
-              'cardinality' => [
-                                 '0',
-                                 '1'
-                               ],
-              'allowed_relation' => 'localizes',
-              'annotation_type_name' => undef,
-            },
-            {
-              'cardinality' => [
-                                 '0',
-                                 '1'
-                               ],
-              'allowed_relation' => 'occurs_at',
-              'display_text' => 'occurs at',
-              'help_text' => '',
-              'range' => [
-                           {
-                             'scope' => [
-                                          'SO:0001799'
-                                        ],
-                             'type' => 'Ontology'
-                           }
-                         ],
-              'domain' => 'GO:0022857',
-              'role' => 'user',
-              'subset_rel' => [
-                                'is_a'
-                              ],
-              'annotation_type_name' => 'biological_process',
-            },
-            {
-              'allowed_relation' => 'modifies_residue',
-              'cardinality' => [
-                                 '0',
-                                 '1'
-                               ],
-              'display_text' => 'occurs at',
-              'range' => [
-                           {
-                             'type' => 'Text',
-                             'input_type' => 'text'
-                           }
-                         ],
-              'help_text' => '',
-              'domain' => 'GO:0022857',
-              'role' => 'user',
-              'subset_rel' => [
-                                'is_a'
-                              ],
-              'annotation_type_name' => undef,
-            },
-            {
-              'exclude_subset_ids' => ['is_a(GO:0055085)'],
-              'domain' => 'GO:0006810',
-              'role' => 'user',
-              'allowed_relation' => 'localizes',
-              'subset_rel' => [
-                                'is_a'
-                              ],
-              'help_text' => '',
-              'cardinality' => [
-                                 '0',
-                                 '1'
-                               ],
-              'range' => [
-                           {
-                             'type' => 'Gene'
-                           }
-                         ],
-              'display_text' => 'localizes',
-              'annotation_type_name' => undef,
-            },
-            {
-             'help_text' => '',
-              'range' => [
-                           {
-                             'type' => 'Gene'
-                           }
-                         ],
-              'domain' => 'GO:0034762',
-              'display_text' => 'occurs at',
-              'cardinality' => [
-                                 '0',
-                                 '1'
-                               ],
-              'allowed_relation' => 'occurs_at',
-              'subset_rel' => [
-                                'is_a'
-                              ],
-              'role' => 'user',
-             'annotation_type_name' => undef,
-            },
-            {
-              'role' => 'user',
-              'subset_rel' => [
-                                'is_a'
-                              ],
-              'cardinality' => [
-                                 '0',
-                                 '2'
-                               ],
-              'allowed_relation' => 'assayed_using',
-              'display_text' => 'assayed using',
-              'domain' => 'FYPO:0000002',
-              'help_text' => '',
-              'range' => [
-                           {
-                             'type' => 'Gene'
-                           }
-                         ],
-              'annotation_type_name' => undef,
-            },
-            {
-              'subset_rel' => [
-                                'is_a'
-                              ],
-              'role' => 'user',
-              'range' => [
-                           {
-                             'scope' => [
-                                          'FYPO_EXT:1000000'
-                                        ],
-                             'type' => 'Ontology'
-                           },
-                           {
-                             'type' => '%'
-                           }
-                         ],
-              'help_text' => '',
-              'domain' => 'FYPO:0000002',
-              'allowed_relation' => 'has_penetrance',
-              'cardinality' => [
-                                 '0',
-                                 '1'
-                               ],
-              'display_text' => 'penetrance',
-              'annotation_type_name' => undef,
-            }
-          ]);
-
+cmp_deeply(
+  $config_with_suffix->{extension_configuration},
+  [
+    {
+      'domain' => 'GO:0016023',
+      'subset_rel' => ['is_a'],
+      'allowed_relation' => 'has_substrate',
+      'range' => [{ 'type' => 'Gene' }],
+      'display_text' => 'kinase substrate',
+      'help_text' => '',
+      'cardinality' => ['0', '1'],
+      'role' => 'user',
+      'annotation_type_name' => undef,
+    },
+    {
+      'domain' => 'GO:0016023',
+      'subset_rel' => ['is_a'],
+      'allowed_relation' => 'happens_during',
+      'range' => [
+        {
+          'type' => 'Ontology',
+          'scope' => ['GO:0005215']
+        }
+      ],
+      'display_text' => 'Something that happens during',
+      'help_text' => '',
+      'cardinality' => ['*'],
+      'role' => 'user',
+      'annotation_type_name' => undef,
+    },
+    {
+      'domain' => 'GO:0022857',
+      'subset_rel' => ['is_a'],
+      'allowed_relation' => 'localizes',
+      'range' => [{'type' => 'Gene'}],
+      'display_text' => 'localizes',
+      'help_text' => '',
+      'cardinality' => ['0', '1'],
+      'role' => 'user',
+      'annotation_type_name' => undef,
+    },
+    {
+      'domain' => 'GO:0022857',
+      'subset_rel' => ['is_a'],
+      'allowed_relation' => 'occurs_at',
+      'range' => [
+        {
+          'scope' => ['SO:0001799'],
+          'type' => 'Ontology'
+        }
+      ],
+      'display_text' => 'occurs at',
+      'help_text' => '',
+      'cardinality' => ['0', '1'],
+      'role' => 'user',
+      'annotation_type_name' => 'biological_process',
+    },
+    {
+      'domain' => 'GO:0022857',
+      'subset_rel' => ['is_a'],
+      'allowed_relation' => 'modifies_residue',
+      'range' => [
+        {
+          'type' => 'Text',
+          'input_type' => 'text'
+        }
+      ],
+      'display_text' => 'occurs at',
+      'help_text' => '',
+      'cardinality' => ['0', '1'],
+      'role' => 'user',
+      'annotation_type_name' => undef,
+    },
+    {
+      'domain' => 'GO:0006810',
+      'exclude_subset_ids' => ['is_a(GO:0055085)'],
+      'subset_rel' => ['is_a'],
+      'allowed_relation' => 'localizes',
+      'range' => [{'type' => 'Gene'}],
+      'display_text' => 'localizes',
+      'help_text' => '',
+      'cardinality' => ['0', '1'],
+      'role' => 'user',
+      'annotation_type_name' => undef,
+    },
+    {
+      'domain' => 'GO:0034762',
+      'subset_rel' => ['is_a'],
+      'allowed_relation' => 'occurs_at',
+      'range' => [{'type' => 'Gene'}],
+      'display_text' => 'occurs at',
+      'help_text' => '',
+      'cardinality' => ['0', '1'],
+      'role' => 'user',
+      'annotation_type_name' => undef,
+    },
+    {
+      'domain' => 'FYPO:0000002',
+      'subset_rel' => ['is_a'],
+      'allowed_relation' => 'assayed_using',
+      'range' => [{'type' => 'Gene'}],
+      'display_text' => 'assayed using',
+      'help_text' => '',
+      'cardinality' => ['0', '2'],
+      'role' => 'user',
+      'annotation_type_name' => undef,
+    },
+    {
+      'domain' => 'FYPO:0000002',
+      'subset_rel' => ['is_a'],
+      'allowed_relation' => 'has_penetrance',
+      'range' => [
+        {
+          'scope' => ['FYPO_EXT:1000000'],
+          'type' => 'Ontology'
+        },
+        {
+          'type' => '%'
+        }
+      ],
+      'display_text' => 'penetrance',
+      'help_text' => '',
+      'cardinality' => ['0', '1'],
+      'role' => 'user',
+      'annotation_type_name' => undef,
+    }
+  ]
+);
 
 use JSON;
 

--- a/t/50_config.t
+++ b/t/50_config.t
@@ -99,7 +99,7 @@ cmp_deeply(
       'help_text' => '',
       'cardinality' => ['0', '1'],
       'role' => 'user',
-      'annotation_type_name' => undef,
+      'annotation_type_name' => 'cellular_component',
     },
     {
       'domain' => 'GO:0016023',
@@ -115,7 +115,7 @@ cmp_deeply(
       'help_text' => '',
       'cardinality' => ['*'],
       'role' => 'user',
-      'annotation_type_name' => undef,
+      'annotation_type_name' => 'cellular_component',
     },
     {
       'domain' => 'GO:0022857',
@@ -126,7 +126,7 @@ cmp_deeply(
       'help_text' => '',
       'cardinality' => ['0', '1'],
       'role' => 'user',
-      'annotation_type_name' => undef,
+      'annotation_type_name' => 'biological_process',
     },
     {
       'domain' => 'GO:0022857',
@@ -158,7 +158,7 @@ cmp_deeply(
       'help_text' => '',
       'cardinality' => ['0', '1'],
       'role' => 'user',
-      'annotation_type_name' => undef,
+      'annotation_type_name' => 'biological_process',
     },
     {
       'domain' => 'GO:0006810',
@@ -170,7 +170,7 @@ cmp_deeply(
       'help_text' => '',
       'cardinality' => ['0', '1'],
       'role' => 'user',
-      'annotation_type_name' => undef,
+      'annotation_type_name' => 'biological_process',
     },
     {
       'domain' => 'GO:0034762',
@@ -181,7 +181,7 @@ cmp_deeply(
       'help_text' => '',
       'cardinality' => ['0', '1'],
       'role' => 'user',
-      'annotation_type_name' => undef,
+      'annotation_type_name' => 'biological_process',
     },
     {
       'domain' => 'FYPO:0000002',
@@ -192,7 +192,7 @@ cmp_deeply(
       'help_text' => '',
       'cardinality' => ['0', '2'],
       'role' => 'user',
-      'annotation_type_name' => undef,
+      'annotation_type_name' => 'phenotype',
     },
     {
       'domain' => 'FYPO:0000002',
@@ -211,7 +211,7 @@ cmp_deeply(
       'help_text' => '',
       'cardinality' => ['0', '1'],
       'role' => 'user',
-      'annotation_type_name' => undef,
+      'annotation_type_name' => 'phenotype',
     }
   ]
 );

--- a/t/50_config.t
+++ b/t/50_config.t
@@ -100,6 +100,7 @@ cmp_deeply(
       'cardinality' => ['0', '1'],
       'role' => 'user',
       'annotation_type_name' => 'cellular_component',
+      'feature_type' => 'gene',
     },
     {
       'domain' => 'GO:0016023',
@@ -116,6 +117,7 @@ cmp_deeply(
       'cardinality' => ['*'],
       'role' => 'user',
       'annotation_type_name' => 'cellular_component',
+      'feature_type' => 'gene',
     },
     {
       'domain' => 'GO:0022857',
@@ -127,6 +129,7 @@ cmp_deeply(
       'cardinality' => ['0', '1'],
       'role' => 'user',
       'annotation_type_name' => 'biological_process',
+      'feature_type' => 'gene',
     },
     {
       'domain' => 'GO:0022857',
@@ -143,6 +146,7 @@ cmp_deeply(
       'cardinality' => ['0', '1'],
       'role' => 'user',
       'annotation_type_name' => 'biological_process',
+      'feature_type' => 'gene',
     },
     {
       'domain' => 'GO:0022857',
@@ -159,6 +163,7 @@ cmp_deeply(
       'cardinality' => ['0', '1'],
       'role' => 'user',
       'annotation_type_name' => 'biological_process',
+      'feature_type' => 'gene',
     },
     {
       'domain' => 'GO:0006810',
@@ -171,6 +176,7 @@ cmp_deeply(
       'cardinality' => ['0', '1'],
       'role' => 'user',
       'annotation_type_name' => 'biological_process',
+      'feature_type' => 'gene',
     },
     {
       'domain' => 'GO:0034762',
@@ -182,6 +188,7 @@ cmp_deeply(
       'cardinality' => ['0', '1'],
       'role' => 'user',
       'annotation_type_name' => 'biological_process',
+      'feature_type' => 'gene',
     },
     {
       'domain' => 'FYPO:0000002',
@@ -193,6 +200,7 @@ cmp_deeply(
       'cardinality' => ['0', '2'],
       'role' => 'user',
       'annotation_type_name' => 'phenotype',
+      'feature_type' => 'genotype',
     },
     {
       'domain' => 'FYPO:0000002',
@@ -212,6 +220,7 @@ cmp_deeply(
       'cardinality' => ['0', '1'],
       'role' => 'user',
       'annotation_type_name' => 'phenotype',
+      'feature_type' => 'genotype',
     }
   ]
 );

--- a/t/50_extension_conf.t
+++ b/t/50_extension_conf.t
@@ -23,6 +23,7 @@ cmp_deeply($conf[0],
              'allowed_relation' => 'has_substrate',
              'role' => 'user',
              'annotation_type_name' => 'cellular_component',
+             'feature_type' => 'gene',
            });
 
 cmp_deeply($conf[1]->{cardinality}, ['*']);

--- a/t/50_extension_conf.t
+++ b/t/50_extension_conf.t
@@ -22,7 +22,7 @@ cmp_deeply($conf[0],
              'cardinality' => [0,1],
              'allowed_relation' => 'has_substrate',
              'role' => 'user',
-             'annotation_type_name' => undef,
+             'annotation_type_name' => 'cellular_component',
            });
 
 cmp_deeply($conf[1]->{cardinality}, ['*']);

--- a/t/data/extension_config.tsv
+++ b/t/data/extension_config.tsv
@@ -1,9 +1,9 @@
-GO:0016023	is_a	has_substrate	GENE	kinase substrate		0,1	user	cellular_component
-GO:0016023	is_a	happens_during	GO:0005215	Something that happens during		*	user	cellular_component
-GO:0022857	is_a	localizes	GENE	localizes		0,1	user	biological_process
-GO:0022857	is_a	occurs_at	SO:0001799	occurs at		0,1	user	biological_process
-GO:0022857	is_a	modifies_residue	TEXT	occurs at		0,1	user	biological_process
-GO:0006810-is_a(GO:0055085)	is_a	localizes	GENE	localizes		0,1	user	biological_process
-GO:0034762	is_a	occurs_at	GENE	occurs at		0,1	user	biological_process
-FYPO:0000002	is_a	assayed_using	GENE	assayed using		0,2	user	phenotype
-FYPO:0000002	is_a	has_penetrance	FYPO_EXT:1000000|%	penetrance		0,1	user	phenotype
+GO:0016023	is_a	has_substrate	GENE	kinase substrate		0,1	user	cellular_component	gene
+GO:0016023	is_a	happens_during	GO:0005215	Something that happens during		*	user	cellular_component	gene
+GO:0022857	is_a	localizes	GENE	localizes		0,1	user	biological_process	gene
+GO:0022857	is_a	occurs_at	SO:0001799	occurs at		0,1	user	biological_process	gene
+GO:0022857	is_a	modifies_residue	TEXT	occurs at		0,1	user	biological_process	gene
+GO:0006810-is_a(GO:0055085)	is_a	localizes	GENE	localizes		0,1	user	biological_process	gene
+GO:0034762	is_a	occurs_at	GENE	occurs at		0,1	user	biological_process	gene
+FYPO:0000002	is_a	assayed_using	GENE	assayed using		0,2	user	phenotype	genotype
+FYPO:0000002	is_a	has_penetrance	FYPO_EXT:1000000|%	penetrance		0,1	user	phenotype	genotype

--- a/t/data/extension_config.tsv
+++ b/t/data/extension_config.tsv
@@ -1,9 +1,9 @@
-GO:0016023	is_a	has_substrate	GENE	kinase substrate		0,1	user
-GO:0016023	is_a	happens_during	GO:0005215	Something that happens during		*	user
-GO:0022857	is_a	localizes	GENE	localizes		0,1	user
+GO:0016023	is_a	has_substrate	GENE	kinase substrate		0,1	user	cellular_component
+GO:0016023	is_a	happens_during	GO:0005215	Something that happens during		*	user	cellular_component
+GO:0022857	is_a	localizes	GENE	localizes		0,1	user	biological_process
 GO:0022857	is_a	occurs_at	SO:0001799	occurs at		0,1	user	biological_process
-GO:0022857	is_a	modifies_residue	TEXT	occurs at		0,1	user
-GO:0006810-is_a(GO:0055085)	is_a	localizes	GENE	localizes		0,1	user
-GO:0034762	is_a	occurs_at	GENE	occurs at		0,1	user
-FYPO:0000002	is_a	assayed_using	GENE	assayed using		0,2	user
-FYPO:0000002	is_a	has_penetrance	FYPO_EXT:1000000|%	penetrance		0,1	user
+GO:0022857	is_a	modifies_residue	TEXT	occurs at		0,1	user	biological_process
+GO:0006810-is_a(GO:0055085)	is_a	localizes	GENE	localizes		0,1	user	biological_process
+GO:0034762	is_a	occurs_at	GENE	occurs at		0,1	user	biological_process
+FYPO:0000002	is_a	assayed_using	GENE	assayed using		0,2	user	phenotype
+FYPO:0000002	is_a	has_penetrance	FYPO_EXT:1000000|%	penetrance		0,1	user	phenotype


### PR DESCRIPTION
References #2335; replaces #2460 due to the downstream branch being renamed.

In PHI-Canto, we have some annotation extensions for gene annotation types that should be hidden if the organism of the gene is a pathogen or a host. Currently, Canto can't restrict extensions in this way. I'm trying to change that by adding a new column to the extension configuration, called `feature_type`, that will restrict the extension to the specified feature type when set (otherwise, the restriction is ignored). This is similar to the restriction by annotation type added by PR #2367.

Unfortunately, even being able to restrict by feature type doesn't fully solve the problem, because the 'gene' feature type is too broad. What I really need is to restrict by the hypothetical feature types pathogen_gene and host_gene. I imagined these as some sort of feature subtype, analogous to the `feature_subtype` property in our `canto_deploy.yaml`:

```yaml
  - name: host_phenotype
    feature_type: 'genotype'
    feature_subtype: 'host'
```
But as far as I can tell, this doesn't exist on the actual feature objects provided by the server.

So far, I've gotten `ontologyWorkflowCtrl` working by adding the relevant feature types to the extension configuration table, then in order to generate the right feature type on the front-end, I fetched the organism data for the gene via the feature ID, and faked the correct feature type by passing a string value to `extensionBuilder`. The process of generating the feature type is shown below:

```js
        } else if (featureType == 'gene' && CantoGlobals.pathogen_host_mode) {
          CursGeneList
            .getGeneById(Number(featureId))
            .then(function (gene) {
              var organismRole = gene.organism.pathogen_or_host;
              $scope.finalFeatureType = organismRole + '_gene';
            });
```
This is already pretty convoluted, but the situation is even worse for the modal-based workflow. Firstly, there's a big stack of components to go through just to get to `extensionBuilder` (as shown below); and secondly, there are multiple entry points to the modal creation, meaning I'll probably have to compute the correct feature type in multiple locations. That might not be so bad if I extract the code into a global function, but it may mean having to inject more AngularJS services everywhere (in order to get the gene from a feature ID).

![edit_modal_component_hierarchy](https://user-images.githubusercontent.com/37659591/116253105-18d54700-a768-11eb-905c-9e6a2da64b49.png)

It would be ideal if the server could provide more details about the feature type (perhaps as a separate subtype property, so it doesn't risk breaking everything that relies on the more general types), but I can carry on trying to work around this on the front-end for now. Even if the feature type were provided by the server, there would still probably be a lot of work passing the data around (assuming the feature type is not there already).

@kimrutherford Can you think of a better solution to this problem?

- - -

Note that this PR also updates the tests relating to extension configuration, so now every row in `extension_config.tsv` has a correct value for `annotation_type_name` and `feature_type`. Previously, most of the `annotation_type_name` values were `undef`.