### PR TITLE
Fix 'Restart approval' button to respect state of curation session

### DIFF
--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -1465,6 +1465,7 @@ var pubmedIdStart =
           results: null,
         };
         $scope.userIsAdmin = CantoGlobals.is_admin_user == "1";
+        $scope.allowRestartApproval = false;
         $scope.publicationPageUrl = "";
 
         CantoConfig.get('public_mode')

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -1487,6 +1487,7 @@ var pubmedIdStart =
               $scope.data.results = results;
             }
             $scope.publicationPageUrl = getPublicationPageUrl();
+            $scope.allowRestartApproval = getRestartApprovalPermission();
           }).
           catch(function (response) {
             var data = response.data;
@@ -1545,6 +1546,15 @@ var pubmedIdStart =
             );
           }
           return url;
+        }
+        
+        function getRestartApprovalPermission() {
+          var sessionExists = ($scope.data.results && $scope.data.results.sessions.length > 0);
+          if ($scope.userIsAdmin && sessionExists) {
+            var sessionState = $scope.data.results.sessions[0].state;
+            return sessionState == 'APPROVED';
+          }
+          return false;
         }
       }
     };

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -1485,9 +1485,9 @@ var pubmedIdStart =
               toaster.pop('error', results.message);
             } else {
               $scope.data.results = results;
+              $scope.publicationPageUrl = getPublicationPageUrl();
+              $scope.allowRestartApproval = getRestartApprovalPermission();
             }
-            $scope.publicationPageUrl = getPublicationPageUrl();
-            $scope.allowRestartApproval = getRestartApprovalPermission();
           }).
           catch(function (response) {
             var data = response.data;

--- a/root/static/js/canto-modules.js
+++ b/root/static/js/canto-modules.js
@@ -1525,10 +1525,12 @@ var pubmedIdStart =
         };
 
         $scope.restartApproval = function () {
-          if ($scope.userIsAdmin) {
-            window.location.href = CantoGlobals.application_root + '/curs/' +
-              $scope.data.results.sessions[0] +
-              '/restart_approval/';
+          var sessionId = $scope.data.results.sessions[0].session;
+          var sessionLink = (
+            CantoGlobals.application_root + '/curs/' + sessionId + '/restart_approval/'
+          );
+          if ($scope.allowRestartApproval) {
+            window.location.href = sessionLink;
           }
         };
 

--- a/root/static/ng_templates/pubmed_id_start.html
+++ b/root/static/ng_templates/pubmed_id_start.html
@@ -16,7 +16,7 @@
         Please contact the curation team to suggest changes to the
         annotation.</span>
       </div>
-      <span ng-if="userIsAdmin">
+      <span ng-if="userIsAdmin && publicationPageUrl">
         Admin only: <a href="{{publicationPageUrl}}">publication page</a>.
       </span>
       <div ng-if="publicMode">

--- a/root/static/ng_templates/pubmed_id_start.html
+++ b/root/static/ng_templates/pubmed_id_start.html
@@ -60,7 +60,7 @@
         <span ng-if="data.results.sessions.length == 0">Continue</span>
       </button>
       <button
-        ng-if="userIsAdmin && data.results.sessions.length > 0"
+        ng-if="allowRestartApproval"
         type="button"
         class="btn btn-primary"
         ng-click="restartApproval()">Restart approval</button>


### PR DESCRIPTION
References #2463

This PR should fix the remaining bugs with the publication search feature on Canto's homepage (the `pubmedIdStart` directive). The 'Restart approval' button now only shows if the curation session's state is 'APPROVED' (and if there is at least one session for the publication).

I also fixed a possible bug where the new code would try to run even if the publication data didn't load correctly.

@kimrutherford I've tested this locally and it seems to work fine. Feel free to merge if you don't notice any problems.