### PR TITLE
Update generic email templates to better support PHI-Canto

### DIFF
--- a/root/docs/md/canto_admin/configuration_file.md
+++ b/root/docs/md/canto_admin/configuration_file.md
@@ -212,6 +212,11 @@ to the page specified by the `url`.
 This email address is shown anytime a contact address is needed. See the
 `contact.mhtml` template.
 
+### email_signature
+A custom signature line that is displayed at the end of the generic email
+templates. If not set, the signature will default to "The \[database_name\]
+team", where the database name is the value of the `database_name` setting.
+
 ### external_links
 Each external link configuration has three possible parameters:
 

--- a/root/email_templates/generic/session_accepted_body.mhtml
+++ b/root/email_templates/generic/session_accepted_body.mhtml
@@ -46,8 +46,11 @@ up to date.
 
 Sincerely yours,
 
+% if ($config->{email_signature}) {
+<% $config->{email_signature} %>
+% } else {
 The <% $config->{database_name} %> team
-
+% }
 
 <%init>
 use Text::Wrap;

--- a/root/email_templates/generic/session_accepted_body.mhtml
+++ b/root/email_templates/generic/session_accepted_body.mhtml
@@ -22,25 +22,31 @@ able to modify any annotations your colleague made.
 
 % if ($existing_annotation_count > 0) {
 For this paper, there are also several previously curated annotations in the
-database.  These existing annotations will be shown in the curation tool, but
+database. These existing annotations will be shown in the curation tool, but
 cannot be altered. If you notice any problems with existing annotations,
 please let the curators know.
 
 % }
-Help is available on each page, and you can also read the Canto manual
-(<% $help_index %>) or contact the help desk
+Help is available on each page, and you can also read the <% $config->{name} %>
+manual (<% $help_index %>) or contact the help desk
 (<% $config->{contact_email}->{address} %>) for assistance at any time. You
 will also have an opportunity to provide any data that the tool does not
 capture so that curators can include it with your curation.
 
 The curation link will work indefinitely, so you can leave and return to the
 same URL as often as you want. When you have added all the annotations you
-can, you may either submit the annotations to the curators, or send
-the paper to another co-author for further curation.
+can, you may either submit the annotations to the <% $config->{database_name} %>
+curators, or send the paper to another co-author for further curation.
 
-We greatly appreciate your contribution.
+We greatly appreciate your contribution: all community annotations help keep
+<% $config->{database_name} %> literature curation comprehensive, accurate, and
+up to date.
 
 <% $session_link %>
+
+Sincerely yours,
+
+The <% $config->{database_name} %> team
 
 
 <%init>

--- a/root/email_templates/generic/session_assigned_body.mhtml
+++ b/root/email_templates/generic/session_assigned_body.mhtml
@@ -4,11 +4,12 @@ $publication_uniquename
 $publication_title
 $session_link
 $curator_name
+$curator_known_as
 $help_index
 $existing_annotation_count
 $logged_in_user
 </%args>
-Dear <% $curator_name %>,
+Dear <% $curator_known_as // $curator_name %>,
 
 We invite you to contribute annotations based on your recently
 published paper, <% $publication_uniquename %> -

--- a/root/email_templates/generic/session_assigned_body.mhtml
+++ b/root/email_templates/generic/session_assigned_body.mhtml
@@ -53,7 +53,11 @@ up to date.
 
 Sincerely yours,
 
-<% $logged_in_user->name() %>
+% if ($config->{email_signature}) {
+<% $config->{email_signature} %>
+% } else {
+The <% $config->{database_name} %> team
+% }
 
 
 <%init>

--- a/root/email_templates/generic/session_assigned_body.mhtml
+++ b/root/email_templates/generic/session_assigned_body.mhtml
@@ -6,16 +6,16 @@ $session_link
 $curator_name
 $help_index
 $existing_annotation_count
+$logged_in_user
 </%args>
 Dear <% $curator_name %>,
 
-Congratulations on the recent publication of your paper:
-  <% $publication_uniquename %>
-<% wrap('  ', '  ', '"' . $publication_title . '"') %>
-
-We invite you to contribute annotations based on this paper. We have
-identified the paper as suitable for curation in Canto, but if it
-reports data for a large number of genes, please let us know so we can
+We invite you to contribute annotations based on your recently
+published paper, <% $publication_uniquename %> -
+<% wrap('  ', '  ', '"' . $publication_title . '"') %>,
+to <% $config->{database_name} %>.  We have
+identified the paper as suitable for curation in <% $config->{name} %>, but if
+it reports data for a large number of genes, please let us know so we can
 collect the data by a different route.
 
 Your curation link is:
@@ -35,7 +35,7 @@ please let the curators know.
 % }
 
 Help is available on each page, and you can also read
-the Canto manual (<% $help_index %>) or contact
+the <% $config->{name} %> manual (<% $help_index %>) or contact
 the help desk (<% $config->{contact_email}->{address} %>)
 for assistance at any time. You will also have an opportunity to provide any
 data that the tool does not capture so that curators can include it with your
@@ -44,10 +44,15 @@ curation.
 The curation link will work indefinitely, so you can leave and return to the
 same URL as often as you want.
 
-We greatly appreciate your contribution.
-
+We greatly appreciate your contribution: all community annotations help keep
+<% $config->{database_name} %> literature curation comprehensive, accurate, and
+up to date.
 
 <% $session_link %>
+
+Sincerely yours,
+
+<% $logged_in_user->name() %>
 
 
 <%init>

--- a/root/email_templates/generic/session_reassigned_body.mhtml
+++ b/root/email_templates/generic/session_reassigned_body.mhtml
@@ -4,12 +4,13 @@ $publication_uniquename
 $publication_title
 $session_link
 $curator_name
+$curator_known_as
 $help_index
 $existing_annotation_count
 $reassigner_email
 $reassigner_name
 </%args>
-Dear <% $curator_name %>,
+Dear <% $curator_known_as // $curator_name %>,
 
 <% $reassigner_name %> <<% $reassigner_email %>> has invited you to contribute
 annotations to <% $config->{database_name} %> based on this paper:

--- a/root/email_templates/generic/session_reassigned_body.mhtml
+++ b/root/email_templates/generic/session_reassigned_body.mhtml
@@ -4,13 +4,12 @@ $publication_uniquename
 $publication_title
 $session_link
 $curator_name
-$curator_known_as
 $help_index
 $existing_annotation_count
 $reassigner_email
 $reassigner_name
 </%args>
-Dear <% $curator_known_as // $curator_name %>,
+Dear <% $curator_name %>,
 
 <% $reassigner_name %> <<% $reassigner_email %>> has invited you to contribute
 annotations to <% $config->{database_name} %> based on this paper:

--- a/root/email_templates/generic/session_reassigned_body.mhtml
+++ b/root/email_templates/generic/session_reassigned_body.mhtml
@@ -12,7 +12,7 @@ $reassigner_name
 Dear <% $curator_name %>,
 
 <% $reassigner_name %> <<% $reassigner_email %>> has invited you to contribute
-annotations to based on this paper:
+annotations to <% $config->{database_name} %> based on this paper:
   <% $publication_uniquename %>
 <% wrap('  ', '  ', '"' . $publication_title . '"') %>
 
@@ -38,8 +38,8 @@ cannot be altered. If you notice any problems with existing annotations,
 please let the curators know.
 
 % }
-Help is available on each page, and you can also read the Canto manual
-(<% $help_index %>) or contact the help desk
+Help is available on each page, and you can also read the <% $config->{name} %>
+manual (<% $help_index %>) or contact the help desk
 (<% $config->{contact_email}->{address} %>) for assistance at any time. You
 will also have an opportunity to provide any data that the tool does not
 capture so that curators can include it with your curation.
@@ -49,9 +49,15 @@ same URL as often as you want. When you have added all the annotations you
 can, you may either submit the annotations to the curators, or send
 the paper to another co-author for further curation.
 
-We greatly appreciate your contribution.
+We greatly appreciate your contribution: all community annotations help keep
+<% $config->{database_name} %> literature curation comprehensive, accurate, and
+up to date.
 
 <% $session_link %>
+
+Sincerely yours,
+
+The <% $config->{database_name} %> Team
 
 
 <%init>

--- a/root/email_templates/generic/session_resent_body.mhtml
+++ b/root/email_templates/generic/session_resent_body.mhtml
@@ -16,9 +16,10 @@ We recently invited you to contribute annotations based on your paper,
 to <% $config->{database_name} %>.
 
 We have noticed, however, that no action has been taken on the curation
-session. Please visit this page, where you can either start curating the
-paper, or reassign it to another author (e.g. the first author).
+session. Please visit the page linked below, where you can either start
+curating the paper, or reassign it to another author (e.g. the first author).
 
+Your curation link is:
   <% $session_link %>
 
 To reassign this session, use the "reassign" button, and enter the author's

--- a/root/email_templates/generic/session_resent_body.mhtml
+++ b/root/email_templates/generic/session_resent_body.mhtml
@@ -4,11 +4,12 @@ $publication_uniquename
 $publication_title
 $session_link
 $curator_name
+$curator_known_as
 $help_index
 $existing_annotation_count
 $logged_in_user
 </%args>
-Dear <% $curator_name %>,
+Dear <% $curator_known_as // $curator_name %>,
 
 We recently invited you to contribute annotations based on your paper,
 <% $publication_uniquename %> -

--- a/root/email_templates/generic/session_resent_body.mhtml
+++ b/root/email_templates/generic/session_resent_body.mhtml
@@ -40,7 +40,11 @@ up to date.
 
 Sincerely yours,
 
-<% $logged_in_user->name() %>
+% if ($config->{email_signature}) {
+<% $config->{email_signature} %>
+% } else {
+The <% $config->{database_name} %> team
+% }
 
 
 <%init>

--- a/root/email_templates/generic/session_resent_body.mhtml
+++ b/root/email_templates/generic/session_resent_body.mhtml
@@ -22,15 +22,14 @@ curating the paper, or reassign it to another author (e.g. the first author).
 Your curation link is:
   <% $session_link %>
 
+If you are unsure of how to curate this paper, or if you believe that this paper
+is not suitable for curation in <% $config->{name} %>, please send a message to
+<% $config->{contact_email}->{address} %> for assistance or advice.
+
 To reassign this session, use the "reassign" button, and enter the author's
 name and email address. To curate the publication yourself, click "start
 curating" and then follow the simple step-by-step instructions to capture the
 experimental data reported in your paper.
-
-If you begin curation, and are then unsure what to do next, or if you believe
-that this paper is not suitable for curation in <% $config->{name} %>, please
-send a message to <% $config->{contact_email}->{address} %> for assistance or
-advice.
 
 We greatly appreciate your contribution: all community annotations help keep
 <% $config->{database_name} %> literature curation comprehensive, accurate, and

--- a/root/email_templates/generic/session_resent_body.mhtml
+++ b/root/email_templates/generic/session_resent_body.mhtml
@@ -6,48 +6,40 @@ $session_link
 $curator_name
 $help_index
 $existing_annotation_count
+$logged_in_user
 </%args>
 Dear <% $curator_name %>,
 
-Congratulations on the recent publication of your paper:
-  <% $publication_uniquename %>
-<% wrap('  ', '  ', '"' . $publication_title . '"') %>
+We recently invited you to contribute annotations based on your paper,
+<% $publication_uniquename %> -
+<% wrap('  ', '  ', '"' . $publication_title . '"') %>,
+to <% $config->{database_name} %>.
 
-We invite you to contribute annotations based on this paper. We have
-identified the paper as suitable for curation in Canto, but if it
-reports data for a large number of genes, please let us know so we can
-collect the data by a different route.
+We have noticed, however, that no action has been taken on the curation
+session. Please visit this page, where you can either start curating the
+paper, or reassign it to another author (e.g. the first author).
 
-Your curation link is:
   <% $session_link %>
 
-When you follow the above link, you can start curating, or assign the session
-to a colleague (e.g. a member of your lab). You can annotate these data types
-in the tool:
+To reassign this session, use the "reassign" button, and enter the author's
+name and email address. To curate the publication yourself, click "start
+curating" and then follow the simple step-by-step instructions to capture the
+experimental data reported in your paper.
 
-<& ../annotation_type_list.mhtml, config => $config &>\
-% if ($existing_annotation_count > 0) {
+If you begin curation, and are then unsure what to do next, or if you believe
+that this paper is not suitable for curation in <% $config->{name} %>, please
+send a message to <% $config->{contact_email}->{address} %> for assistance or
+advice.
 
-For this paper, there are several previously curated annotations in the
-database. These existing annotations will be shown in the curation tool, but
-cannot be altered. If you notice any problems with existing annotations,
-please let the curators know.
-% }
-
-Help is available on each page, and you can also read
-the Canto manual (<% $help_index %>) or contact
-the help desk (<% $config->{contact_email}->{address} %>)
-for assistance at any time. You will also have an opportunity to provide any
-data that the tool does not capture so that curators can include it with your
-curation.
-
-The curation link will work indefinitely, so you can leave and return to the
-same URL as often as you want.
-
-We greatly appreciate your contribution.
-
+We greatly appreciate your contribution: all community annotations help keep
+<% $config->{database_name} %> literature curation comprehensive, accurate, and
+up to date.
 
 <% $session_link %>
+
+Sincerely yours,
+
+<% $logged_in_user->name() %>
 
 
 <%init>


### PR DESCRIPTION
See also: https://github.com/PHI-base/canto-docs/issues/1

This pull request updates the generic Canto email templates with some changes that we need for PHI-base (but which should be helpful for other databases too). Key changes include adding subsitutions for the curation application name, adding a signature lines to all the templates:
```
Sincerely yours,

The <% $config->{database_name} %> team
```
And rewriting the re-sent email template to be like a generic version of the PomBase template: previously, it just seemed to be a duplicate of another generic template.

- - -

Comments for @CuzickA:

* Note that in some cases (e.g. assigning sessions), the email is signed off with the name of the logged in user, rather than 'The PHI-base team'. If you'd prefer to keep the emails more anonymous, please let me know.

* You might want to check through the template for the reminder email for community curators who haven't started curating (`session_resent_body.mhtml`). I think there's a possibility it could come across as too assertive, especially considering that **a)** we're not well-known in the community like PomBase is, and **b)** we probably have nearly as much clout as they do. 

Comments for @kimrutherford:

* The PomBase templates can display  the name the curator is 'known as', where such an alias exists, using the following markup: `Dear <% $curator_known_as // $curator_name %>`. Should this change be added to the generic templates as well?

* I've used `<% $config->{name} %>` in place of 'Canto' so that the application name is substituted with 'PHI-Canto'. I assume that the `name` property in `canto_deploy.yaml` is always meant to be used as the name of the curation _application_, but the [Configuration settings](https://curation.pombase.org/pombe/docs/canto_admin/configuration_file) documentation isn't totally clear in this regard:

  > name
  > A one word name for the site. default: Canto

* Out of curiosity, is it really necessary to use the `Text::Wrap` formatter for the publication title? It looks a bit odd to have that wrapping when none of the other text does.

* If there's any changes you think shouldn't be in these generic templates (i.e. changes that are making the templates too specific) please let me know and I'll move the templates to their own versioned folder, like what was done for Japonicus.