### PR TITLE
Allow experimental conditions ontology namespace to be configured

### DIFF
--- a/canto.yaml
+++ b/canto.yaml
@@ -1746,6 +1746,11 @@ ontology_namespace_config:
     - "is_a(canto_root_subset)"
     - "is_a(qc_do_not_annotate)"
 
+# Namespace used for the phenotype condition ontology. If you
+# use an ontology other than FYECO for your phenotype conditions, then
+# change this to the default namespace of your ontology.
+phenotype_condition_namespace: fission_yeast_phenotype_condition
+
 namespace_term_evidence_codes: {}
 
 available_annotation_type_list:
@@ -2316,6 +2321,7 @@ config_service:
     max_term_name_select_count: 1
     show_quick_deletion_buttons: 1
     pathogen_host_mode: 1
+    phenotype_condition_namespace: 1
     multi_organism_mode: 1
     help_text: 1
     public_mode: 1

--- a/lib/Canto/Curs/ConditionUtil.pm
+++ b/lib/Canto/Curs/ConditionUtil.pm
@@ -38,6 +38,8 @@ under the same terms as Perl itself.
 use strict;
 use warnings;
 
+use Canto::Config;
+
 =head2 get_conditions_with_names
 
  Usage   : my @cond_data = get_conditions_with_names($ontology_lookup, [@conditions]);
@@ -123,7 +125,9 @@ sub _get_id_from_name
   my $ontology_lookup = shift;
   my $name = shift;
 
-  my $result = $ontology_lookup->lookup_by_name(ontology_name => 'fission_yeast_phenotype_condition',
+  my $config = Canto::Config::get_config();
+
+  my $result = $ontology_lookup->lookup_by_name(ontology_name => $config->{phenotype_condition_namespace},
                                                 term_name => $name);
   if (defined $result) {
     return $result->{id};

--- a/lib/Canto/Curs/TermUpdate.pm
+++ b/lib/Canto/Curs/TermUpdate.pm
@@ -166,7 +166,7 @@ sub update_curs_terms
       # replace term names with the ID if we know it otherwise assume that the
       # user has made up a condition
       map { my $name = $_;
-            my $res = $self->_cached_lookup_by_name('fission_yeast_phenotype_condition', $name);
+            my $res = $self->_cached_lookup_by_name($config->{phenotype_condition_namespace}, $name);
             if (defined $res) {
               $_ = $res->{id};
               $changed = 1;


### PR DESCRIPTION
(Fixes #2523)

This pull request allows the namespace for the conditions ontology to be configured in `canto_deploy.yaml`, rather than being hard-coded to 'fission_yeast_phenotype_condition'. The namespace defaults to its original value in `canto.yaml`, so this change shouldn't cause any problems for existing instances.

This was needed because PHI-base doesn't use the same conditions ontology as PomBase (or any other Canto instance, as far as I know). The change in commit 21b3d6adfb94a96f2fb2085c4254fba39b6238eb broke the conditions lookup and the replacement of unknown conditions terms with their IDs from the ontology. With this change, PHI-base can configure the phenotype namespace as it appears in PHI-ECO, and everything works fine.

I've tested the term lookup and the term updating process using PHI-base's configuration on my local copy. @kimrutherford You might want to confirm this works with FYECO before merging this. 

See below for a summary of changes:

### canto.yaml

I added the `phenotype_condition_namespace` property, plus a comment describing its purpose. The property defaults to 'fission_yeast_phenotype_condition'.

### TermUpdate.pm

This was just a simple case of replacing the hard-coded string 'fission_yeast_phenotype_condition' with the ontology namespace value from the configuration. The `$config` object was already accessible.

### ConditionUtil.pm

I decided to `use` the `Canto::Config` package here and access the `phenotype_condition_namespace` property directly from the `_get_id_from_name` subroutine, instead of adding the conditions namespace as an argument, just because it was easier.

I probably should've opted for the argument since it keeps the function more self-contained, so let me know if you'd prefer this. It might not be much work to add the namespace as an argument: `_get_id_from_name` is only used by `get_conditions_from_names` and that has a small footprint, only being used in three files, all of which (I think) have access to `$config`.

### canto_modules.js

- I introduced a wrapper function for `fetch_conditions` in order to supply the `conditionsNamespace` argument, because I assumed that the `termSource` configuration property of `$field.tagit` required the `search` and `showChoices` arguments to satisfy the interface.
- I injected the `CantoConfig` service into the `conditionPicker` directive and put the tagit field inside the promise for the 'phenotype_condition_namespace' getter. The `tagSource` property now uses the partially applied wrapper function described above, with the applied argument being the phenotype condition namespace name from the configuration file.
