### PR TITLE
Don't store the metagenotype display name in extensions

### DIFF
--- a/lib/Canto/Curs/Serialise.pm
+++ b/lib/Canto/Curs/Serialise.pm
@@ -40,6 +40,7 @@ the Free Software Foundation, either version 3 of the License, or
 use strict;
 use warnings;
 use Carp;
+use feature 'state';
 
 use JSON;
 use Clone qw(clone);
@@ -180,7 +181,8 @@ sub _get_annotations
 
   die "no schema" unless $schema;
 
-  my $organism_lookup = Canto::Track::get_adaptor($config, 'organism');
+  state $ontology_lookup = Canto::Track::get_adaptor($config, 'ontology');
+  state $organism_lookup = Canto::Track::get_adaptor($config, 'organism');
 
   my $rs = $schema->resultset('Annotation');
 
@@ -313,6 +315,15 @@ sub _get_annotations
                 _get_metagenotype_by_id($schema, $extension_bit->{rangeValue});
 
               $extension_bit->{rangeValue} = $metagenotype->identifier();
+
+              my %metagenotype_details =
+                Canto::Curs::Utils::make_metagenotype_details($schema, $metagenotype,
+                                                              $config,
+                                                              $ontology_lookup,
+                                                              $organism_lookup);
+
+              $extension_bit->{rangeDisplayName} =
+                $metagenotype_details{metagenotype_display_name};
             }
           }
         } @$extension_part;

--- a/lib/Canto/Curs/Serialise.pm
+++ b/lib/Canto/Curs/Serialise.pm
@@ -314,7 +314,11 @@ sub _get_annotations
               my $metagenotype =
                 _get_metagenotype_by_id($schema, $extension_bit->{rangeValue});
 
-              $extension_bit->{rangeValue} = $metagenotype->identifier();
+              if ($metagenotype) {
+                $extension_bit->{rangeValue} = $metagenotype->identifier();
+              } else {
+                $extension_bit->{rangeValue} = "MISSING_METAGENOTYPE";
+              }
 
               my %metagenotype_details =
                 Canto::Curs::Utils::make_metagenotype_details($schema, $metagenotype,

--- a/lib/Canto/Curs/ServiceUtils.pm
+++ b/lib/Canto/Curs/ServiceUtils.pm
@@ -1320,7 +1320,23 @@ sub _ontology_change_keys
     },
     submitter_comment => 1,
     figure => 1,
-    extension => 1,
+    extension => sub {
+      my $extension = shift // [];
+
+      for my $and_group (@$extension) {
+        for my $ext_part (@$and_group) {
+          if ($ext_part->{rangeType} &&
+              $ext_part->{rangeType} eq 'Metagenotype') {
+            # the display name will be created as needed since it can change
+            # over time if the genotype details change
+            delete $ext_part->{rangeDisplayName};
+          }
+        }
+      }
+
+      # set the extension as usual
+      return 0;
+    },
     organism => 1,
     with_gene_id => sub {
       my $gene_id = shift;

--- a/lib/Canto/Curs/Utils.pm
+++ b/lib/Canto/Curs/Utils.pm
@@ -204,7 +204,30 @@ sub _make_genotype_details
   );
 }
 
-sub _make_metagenotype_details
+=head2 make_metagenotype_details
+
+ Usage   : my %details = Utils::make_metagenotype_details($curs_schema
+                            $metagenotype, $config, $ontology_lookup, $organism_lookup);
+ Function: make a hash of metagenotype details
+ Args    : $schema - a Canto::CursDB object
+           $metagenotype - the Metagenotype object
+           $config - the Canto::Config object
+           $ontology_lookup - An OntologyLookup object
+           $organism_lookup - An OrganismLookup object
+ Returns : A hash like:
+           (
+             pathogen_genotype => {...},
+             host_genotype => {...}
+             metagenotype_display_name => "<metagenotype_display_name>",
+             metagenotype_id => <metagenotype_db_id>,
+             feature_type => 'metagenotype',
+             feature_display_name => (same as metagenotype_display_name)
+             feature_id => (same as metagenotype_id)
+           )
+
+=cut
+
+sub make_metagenotype_details
 {
   my $curs_schema = shift;
   my $metagenotype = shift;
@@ -260,7 +283,7 @@ sub _make_extension
           my $metagenotype = $rs->first();
           if ($metagenotype) {
             my %metagenotype_details =
-              _make_metagenotype_details($schema, $metagenotype, $config,
+              make_metagenotype_details($schema, $metagenotype, $config,
                                          $ontology_lookup, $organism_lookup);
             $ext_part->{rangeDisplayName} = $metagenotype_details{metagenotype_display_name};
             next;
@@ -351,7 +374,7 @@ sub make_ontology_annotation
 
     my $metagenotype = $annotation_metagenotypes[0];
 
-    %metagenotype_details = _make_metagenotype_details($schema, $metagenotype, $config,
+    %metagenotype_details = make_metagenotype_details($schema, $metagenotype, $config,
                                                        $ontology_lookup, $organism_lookup);
   }
 

--- a/lib/Canto/Curs/Utils.pm
+++ b/lib/Canto/Curs/Utils.pm
@@ -44,6 +44,8 @@ use Moose;
 use Clone qw(clone);
 use JSON;
 
+use Scalar::Util qw(looks_like_number);
+
 use Canto::Curs::GeneProxy;
 use Canto::Curs::ConditionUtil;
 use Canto::Curs::MetadataStorer;
@@ -221,10 +223,12 @@ sub _make_metagenotype_details
                            $ontology_lookup, $organism_lookup);
 
   my $metagenotype_display_name =
-    $pathogen_genotype_details{organism}->{full_name} . ' ' .
-    $pathogen_genotype_details{genotype_display_name} . ' / ' .
-    $host_genotype_details{organism}->{full_name} . ' ' .
-    $host_genotype_details{genotype_display_name};
+    $pathogen_genotype_details{genotype_display_name} . ' ' .
+    $pathogen_genotype_details{organism}->{full_name} . ' (' .
+    $pathogen_genotype_details{strain_name} . ') / ' .
+    $host_genotype_details{genotype_display_name} . ' ' .
+    $host_genotype_details{organism}->{full_name} . ' (' .
+    $host_genotype_details{strain_name} . ')';
 
   return (
     pathogen_genotype => \%pathogen_genotype_details,
@@ -235,6 +239,39 @@ sub _make_metagenotype_details
     feature_display_name => $metagenotype_display_name,
     feature_id => $metagenotype->metagenotype_id(),
   );
+}
+
+sub _make_extension
+{
+  my $config = shift;
+  my $schema = shift;
+  my $ontology_lookup = shift;
+  my $organism_lookup = shift;
+  my $extension = shift // [];
+
+  for my $and_group (@$extension) {
+    for my $ext_part (@$and_group) {
+      if ($ext_part->{rangeType} &&
+          $ext_part->{rangeType} eq 'Metagenotype') {
+        my $metagenotype_id = $ext_part->{rangeValue};
+        if (looks_like_number($metagenotype_id)) {
+          my $rs = $schema->resultset('Metagenotype')
+            ->search({ metagenotype_id => $metagenotype_id });
+          my $metagenotype = $rs->first();
+          if ($metagenotype) {
+            my %metagenotype_details =
+              _make_metagenotype_details($schema, $metagenotype, $config,
+                                         $ontology_lookup, $organism_lookup);
+            $ext_part->{rangeDisplayName} = $metagenotype_details{metagenotype_display_name};
+            next;
+          }
+        }
+        $ext_part->{rangeDisplayName} = 'Unknown Metagenotype';
+      }
+    }
+  }
+
+  return $extension;
 }
 
 =head2 make_ontology_annotation
@@ -400,6 +437,10 @@ sub make_ontology_annotation
   my $completed = defined $evidence_code &&
     (!$needs_with || defined $with_gene_identifier);
 
+  my $extension = _make_extension($config, $schema,
+                                  $ontology_lookup, $organism_lookup,
+                                  $data->{extension});
+
   my $ret = {
     %gene_details,
     %genotype_details,
@@ -426,7 +467,7 @@ sub make_ontology_annotation
     with_gene_id => $with_gene_id,
     taxonid => $taxonid,
     completed => $completed,
-    extension => $data->{extension} || [],
+    extension => $extension,
     is_obsolete_term => $is_obsolete_term,
     curator => $curator,
     status => $annotation->status(),


### PR DESCRIPTION
This PR changes the code to:
  - not store the rangeDisplayName for metagenotypes in extensions
  - fill in the rangeDisplayName for metagenotypes in extensions when annotation details are requested from the server
     - the Metagenotype ID in the the rangeValue field of the extensions is used to look up the metagenotype as needed