### PR TITLE
Fix canto_admin.pl not handling Unicode characters in arguments

### DIFF
--- a/script/canto_admin.pl
+++ b/script/canto_admin.pl
@@ -9,6 +9,7 @@ use Try::Tiny;
 
 use File::Basename;
 use Getopt::Long;
+use Encode qw(decode);
 
 BEGIN {
   my $script_name = basename $0;
@@ -124,8 +125,8 @@ my $util = Canto::Track::TrackUtil->new(config => $config, schema => $schema);
 my $proc = sub {
   if (defined $rename_strain) {
     my $taxonid = shift @ARGV;
-    my $old_name = shift @ARGV;
-    my $new_name = shift @ARGV;
+    my $old_name = decode("utf-8", shift @ARGV);
+    my $new_name = decode("utf-8", shift @ARGV);
 
     try {
       $util->rename_strain($taxonid, $old_name, $new_name);
@@ -137,8 +138,8 @@ my $proc = sub {
 
   if (defined $merge_strains) {
     my $taxonid = shift @ARGV;
-    my $old_name = shift @ARGV;
-    my $new_name = shift @ARGV;
+    my $old_name = decode("utf-8", shift @ARGV);
+    my $new_name = decode("utf-8", shift @ARGV);
 
     try {
       $util->merge_strains($taxonid, $old_name, $new_name);


### PR DESCRIPTION
It looks like commit a8e2c7edee4e77bca8df582f763fc80c64a7dc05 caused a regression in `canto_admin.pl` by removing the `-CA` flags for Perl in the shebang line:
```diff
- #!/usr/bin/perl -CA
+ #!/usr/bin/env perl
```
These flags were being used to allow the script to process Unicode characters in its arguments, which PHI-Canto needed for the `--rename-strain` and `--merge-strains` options (see https://github.com/pombase/canto/issues/2268). I'm assuming that the change in the shebang line is in some way connected to the fix for the performance issues in the transaction, so I've come up with a different fix that uses the `Encode` package to decode the arguments to UTF-8 when they're parsed in the relevant subroutines:
```Perl
  if (defined $merge_strains) {
    my $taxonid = shift @ARGV;
    my $old_name = decode("utf-8", shift @ARGV);
    my $new_name = decode("utf-8", shift @ARGV);
```
I'm presuming this fix assumes that the arguments are being entered as UTF-8, so it might not work on systems where the encoding of the calling program is something else. I found a [more sophisticated fix](https://stackoverflow.com/a/2037520) that uses the `I18N::Langinfo` package to read the locale from the outside data source, but it didn't work for me (it just seemed to corrupt the Unicode characters instead).

@kimrutherford If you can think of any better fix for this, feel free to close this PR.