### PR TITLE
Update export JSON schema with new curators fields

### DIFF
--- a/etc/export.schema.json
+++ b/etc/export.schema.json
@@ -492,6 +492,46 @@
                   "description": "Boolean string that tracks whether the curation session is in admin mode. For internal use only.",
                   "$ref": "#/definitions/stringInteger"
                 },
+                "annotation_curators": {
+                  "title": "Annotation curators",
+                  "description": "Tracks statistics about the annotations made by all curators involved in the curation session.",
+                  "type": "array",
+                  "items": {
+                    "title": "Annotation curator details",
+                    "description": "Statistics about the annotations made by a curator involved in the curation session.",
+                    "type": "object",
+                    "properties": {
+                      "annotation_count": {
+                        "title": "Annotation count",
+                        "description": "The number of annotations made by the curator in the curation session.",
+                        "type": "integer",
+                        "minimum": 1
+                      },
+                      "community_curator": {
+                        "title": "Community curator",
+                        "description": "True if the curator who made the annotation was a community curator (that is, not a member of the admin curation team).",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "title": "Curator name",
+                        "description": "The full name of the curator.",
+                        "type": "string"
+                      },
+                      "orcid": {
+                        "title": "Curator ORCID identifier",
+                        "description": "The ORCID identifier of the curator. May be `null` if the curator did not provide an ORCID identifier.",
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/orcid"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
                 "annotation_mode": {
                   "title": "Annotation mode",
                   "description": "Tracks the annotation mode of the curation session in Canto. For internal use only.",

--- a/etc/export.schema.json
+++ b/etc/export.schema.json
@@ -587,6 +587,11 @@
                   "description": "The role of the current curator of the curation session; specifically whether they are an admin curator or a community curator.",
                   "type": "string"
                 },
+                "has_community_curation": {
+                  "title": "Session has community curation",
+                  "description": "True if any of the annotations in the curation session were created by a community curator.",
+                  "type": "boolean"
+                },
                 "initial_curator_name": {
                   "title": "Initial curator name",
                   "description": "The name of of the curator that created the curation session.",


### PR DESCRIPTION
(Closes https://github.com/pombase/canto/issues/2598)

This PR adds the `annotation_curators` and `has_community_curation` properties to the JSON schema for the Canto JSON export. The properties were originally added to the export by https://github.com/pombase/canto/issues/2594.

- - -

@kimrutherford The new schema could be made a bit stricter by adding `required` properties, but I've erred on the side of caution since I don't know what's guaranteed to be exported.

Can you just confirm the following assumptions? If so, I could add some more constraints.

* If the curation session has no annotations, the `annotation_curators` array is exported as an empty array.
* The `has_community_curation` flag is always exported, and is `false` if the session has no annotations.
* If the `annotation_curators` array is not empty, then all the properties of the objects in the array must always be present (meaning all four of the currently implemented object properties are required).
* If the `annotation_curators` array is not empty, then `annotation_count` must be greater than zero (presumably curators are not included here if they have made no annotations).

Note that all of the above assumes the export is exported with the `--export-curator-names` flag set.

Also, for the purposes of determining who's a community curator: are curators logged in as admins the only users who are _not_ classified as community curators?
