### PR TITLE
Also check for "ordered locus" parsing UniProt XML

### DIFF
--- a/lib/Canto/UniProt/UniProtUtil.pm
+++ b/lib/Canto/UniProt/UniProtUtil.pm
@@ -102,6 +102,17 @@ sub parse_results
         for my $synonym (@{$entry->{gene}->[0]->{name}}) {
           my $synonym_content = _content($synonym);
 
+          if ($synonym->{type} eq 'ordered locus') {
+            $name = $synonym_content;
+            last;
+          }
+        }
+      }
+
+      if (!defined $name) {
+        for my $synonym (@{$entry->{gene}->[0]->{name}}) {
+          my $synonym_content = _content($synonym);
+
           if ($synonym->{type} eq 'ORF') {
             $name = $synonym_content;
             last;


### PR DESCRIPTION
Some entries have an useful "ordered locus" synonym, but no other synonyms or gene names.

Refs pombase/canto#1543