### PR TITLE
Add --publish option to canto_start_docker

### DIFF
--- a/script/canto_start_docker
+++ b/script/canto_start_docker
@@ -2,12 +2,13 @@
 
 if [ "$1" = "-h" ]
 then
-    echo "usage:"; echo "   $0 [--debug] [--auto]"
+    echo "usage:"; echo "   $0 [--debug] [--no-tty] [--publish port]"
     echo;
     echo "options:"
-    echo "  --debug: turn on the CANTO_DEBUG environment variable"
-    echo "  --no-tty: don't add the '-t' flag on the 'docker run' call so that"
-    echo "            this script can be called from a non-interactive script"
+    echo "     --debug         turn on the CANTO_DEBUG environment variable"
+    echo "     --no-tty        don't add the '-t' flag on the 'docker run' call so that"
+    echo "                     this script can be called from a non-interactive script"
+    echo " -p, --publish PORT  add ports to the '-p' flag on the 'docker run' call"
     exit 0
 fi
 
@@ -35,11 +36,6 @@ then
     exit 1
 fi
 
-if [ $(uname) = Linux ]
-then
-    EXTRA_ARGS="--net=host --env=OWLTOOLS_MEMORY"
-fi
-
 TTY_OPT="-t"
 
 while [[ $# -gt 0 ]]; do
@@ -52,10 +48,26 @@ while [[ $# -gt 0 ]]; do
             TTY_OPT=""
             shift
             ;;
+        -p|--publish)
+            PUBLISH_PORTS="$2"
+            shift
+            shift
+            ;;
         *)
             ;;
     esac
 done
+
+if [ $(uname) = Linux ]
+then
+    EXTRA_ARGS="--env=OWLTOOLS_MEMORY"
+    if [ -z "$PUBLISH_PORTS" ]
+    then
+        EXTRA_ARGS="$EXTRA_ARGS --net=host"
+    else
+        EXTRA_ARGS="$EXTRA_ARGS -p $PUBLISH_PORTS"
+    fi
+fi
 
 CANTO_DOCKER_RUN_ARGS="$EXTRA_ARGS -i $TTY_OPT --rm $DEBUG --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --mount type=bind,source=$(pwd)/logs,target=/logs  --mount type=bind,source=$(pwd)/data,target=/data --mount type=bind,source=$(pwd)/import_export,target=/import_export --mount type=bind,source=$(pwd)/canto,target=/canto -w=/canto pombase/canto-base:v15"
 

--- a/script/canto_start_docker
+++ b/script/canto_start_docker
@@ -40,18 +40,22 @@ then
     EXTRA_ARGS="--net=host --env=OWLTOOLS_MEMORY"
 fi
 
-if [ "$1" == "--debug" ]; then
-    shift
-    DEBUG="-e CANTO_DEBUG=TRUE"
-fi
-
 TTY_OPT="-t"
 
-if [ "$1" == "--no-tty" ]; then
-    shift
-    TTY_OPT=""
-fi
-
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --debug)
+            DEBUG="-e CANTO_DEBUG=TRUE"
+            shift
+            ;;
+        --no-tty)
+            TTY_OPT=""
+            shift
+            ;;
+        *)
+            ;;
+    esac
+done
 
 CANTO_DOCKER_RUN_ARGS="$EXTRA_ARGS -i $TTY_OPT --rm $DEBUG --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --mount type=bind,source=$(pwd)/logs,target=/logs  --mount type=bind,source=$(pwd)/data,target=/data --mount type=bind,source=$(pwd)/import_export,target=/import_export --mount type=bind,source=$(pwd)/canto,target=/canto -w=/canto pombase/canto-base:v15"
 

--- a/script/canto_start_docker
+++ b/script/canto_start_docker
@@ -13,26 +13,26 @@ fi
 
 if [ ! -d data ]
 then
-   echo 'missing "data" directory - exiting'
-   exit 1
+    echo 'missing "data" directory - exiting'
+    exit 1
 fi
 
 if [ ! -d canto ]
 then
-   echo 'missing "canto" directory - exiting'
-   exit 1
+    echo 'missing "canto" directory - exiting'
+    exit 1
 fi
 
 if [ ! -d import_export ]
 then
-   echo 'missing "import_export" directory - exiting'
-   exit 1
+    echo 'missing "import_export" directory - exiting'
+    exit 1
 fi
 
 if [ ! -d logs ]
 then
-   echo 'missing "logs" directory - exiting'
-   exit 1
+    echo 'missing "logs" directory - exiting'
+    exit 1
 fi
 
 if [ $(uname) = Linux ]


### PR DESCRIPTION
I've added a `--publish` option to the `canto_start_docker` script which passes its value to the `--publish` option of `docker run`. This provides an alternative to `--network=host` for cases where host networking is not supported or publishing a port is preferred (such as using Docker in rootless mode). The option can also be written as a flag (`-p`) to be consistent with Docker's specification.

If the `--publish` option is not set, then `docker run` defaults to `--network=host` to maintain compatibility with existing scripts.

I rewrote the option parsing to use a `case` command to make it easier to handle flags and long options at the same time. Thankfully the Docker implementation of `--publish` doesn't require an equals to separate the option from its argument, so parsing is simpler.

The script doesn't attempt to verify the port argument because Docker already does that.

I also fixed some indentation, reformatted the script's help text, and brought the help text up to date with the latest set of options.

@kimrutherford I've tested this in rootless mode and it seems to work fine, and I've tested using the default Docker daemon (as root) and I'm still able to connect using host networking.