### PR TITLE
Update amino acid insertion notation in phenotype documentation

### DIFF
--- a/root/docs/fypo_annotation.mhtml
+++ b/root/docs/fypo_annotation.mhtml
@@ -93,7 +93,7 @@ box will pop up where you can add allele details:
       </li>
       <li>
 	For insertions, enter the one-letter symbol and number of the residue
-  before the insertion, a hyphen, and the inserted sequence.
+	before the insertion, a hyphen, and the inserted sequence.
       </li>
       <li>
 	For combinations of substitutions, insertions, and/or

--- a/root/docs/fypo_annotation.mhtml
+++ b/root/docs/fypo_annotation.mhtml
@@ -92,14 +92,14 @@ box will pop up where you can add allele details:
 	methionine is removed.
       </li>
       <li>
-	For insertions, enter the number of the residue before the
-	insertion, a hyphen, and the inserted sequence.
+	For insertions, enter the one-letter symbol and number of the residue
+  before the insertion, a hyphen, and the inserted sequence.
       </li>
       <li>
 	For combinations of substitutions, insertions, and/or
 	deletions, separate parts of the description with commas. For
-	example, "858-MKGYP,F124D" means five amino acid residues were
-	inserted after position 858, and Phe was changed to Asp at
+	example, "A858-MKGYP,F124D" means five amino acid residues were
+	inserted after Ala at position 858, and Phe was changed to Asp at
 	position 124.
       </li>
       <li>


### PR DESCRIPTION
(Follow up to #2691)

I noticed that the recommended notation for amino acid insertions was changed in `canto.yaml` (see PR #2692), but the corresponding guidance in `fypo_annotation.mhtml` hadn't been updated to match. This PR fixes that.