### PR TITLE
Add a privacy policy notice to the Curator details page

### DIFF
--- a/root/curs/assign_session.mhtml
+++ b/root/curs/assign_session.mhtml
@@ -18,5 +18,8 @@ $reassign
 %   }
 % }
     <% $form |n %>
+%   if ($c->config()->{privacy_policy_url}) {
+      <p>Your name, email and ORCID ID will be used under the terms of the <% $c->config()->{database_name} %> <a href="<% $c->config()->{privacy_policy_url} %>">privacy policy</a>. By continuing past this page, you agree to the terms of this policy.
+%   }
   </div>
 </div>

--- a/root/docs/md/canto_admin/configuration_file.md
+++ b/root/docs/md/canto_admin/configuration_file.md
@@ -217,6 +217,17 @@ A custom signature line that is displayed at the end of the generic email
 templates. If not set, the signature will default to "The \[database_name\]
 team", where the database name is the value of the `database_name` setting.
 
+### privacy_policy_url
+The URL to the privacy policy for the database that runs the Canto instance.
+If configured, the following message will be shown on the _Curator details_
+page where the curator is asked to enter their personal details:
+
+> Your name, email and ORCID ID will be used under the terms of the
+> \[database_name\] privacy policy. By continuing past this page, you agree
+> to the terms of the policy.
+
+The text 'privacy policy' will be linked to the privacy policy URL.
+
 ### external_links
 Each external link configuration has three possible parameters:
 


### PR DESCRIPTION
I've added a `privacy_policy_url` configuration option that stores the URL to the privacy policy for the Canto instance. If configured, a message like the following will be shown on the Curator details page before the curators enters their details:

> Your name, email and ORCID ID will be used under the terms of the \[database_name\] privacy policy. By continuing past this page, you agree to the terms of this policy.

Here's how it looks on the webpage:

![image](https://github.com/pombase/canto/assets/37659591/8e024f70-5352-40d7-85ba-eca11b5fff59)

@kimrutherford If you want to apply this to PomBase, here's the configuration:

```yaml
privacy_policy_url: "https://pombase.org/about/privacy-policy"
```

I've also documented the configuration property in `configuration_file.md`.