### PR TITLE
Autocomplete allele name for transformant allele type

### DIFF
--- a/canto.yaml
+++ b/canto.yaml
@@ -1451,6 +1451,7 @@ implementation_classes:
 
 wildtype_name_template: '@@gene_display_name@@+'
 deletion_name_template: '@@gene_display_name@@delta'
+transformant_name_template: '@@gene_display_name@@ transformant'
 
 allele_type_list:
   - name: wild type

--- a/lib/Canto/Config.pm
+++ b/lib/Canto/Config.pm
@@ -346,8 +346,11 @@ sub setup
       if ($allele_type->{name} =~ /^wild[ _]?type$/) {
         $allele_type->{autopopulate_name} = $self->{wildtype_name_template};
       }
-      if ($allele_type->{name} eq 'deletion') {
+      elsif ($allele_type->{name} eq 'deletion') {
         $allele_type->{autopopulate_name} = $self->{deletion_name_template};
+      }
+      elsif ($allele_type->{name} eq 'transformant') {
+        $allele_type->{autopopulate_name} = $self->{transformant_name_template};
       }
       my $export_type = $allele_type->{export_type} // $allele_type->{name};
       push @{$self->{export_type_to_allele_type}->{$export_type}}, $allele_type;


### PR DESCRIPTION
Requested in https://github.com/PHI-base/curation/issues/157#issuecomment-1632586675

I've added configuration to allow Canto to automatically complete allele names for the transformant allele type. The format is the allele name, followed by a space, followed by the string 'transformant'.

@kimrutherford Some points to consider:

* The transformant allele type isn't defined in `canto.yaml`, but I don't think this is a problem since the conditional that applies the autocomplete template will never be true unless the transformant allele type is configured somewhere (and even if the condition somehow becomes true, it shouldn't cause any errors).

* I changed a consecutive `if` statement in `Config.pm` to `elsif` since it looked like the cases were mutually exclusive. You might want to double-check this.