### PR TITLE
Toggle renaming of gene names in alleles in --change-gene-id

### DIFF
--- a/lib/Canto/Track/TrackUtil.pm
+++ b/lib/Canto/Track/TrackUtil.pm
@@ -432,7 +432,8 @@ sub update_annotation_curators
  Function: Change a gene ID (primary_identifier) in every session.
            Also change allele IDs containing the $from_id.
  Args    : $from_id - an existing primary_identifier
-           $to_id
+           $to_id - the primary_identifier that will replace $from_id
+           $no_rename - if true, do not rename alleles
  Returns : nothing - dies on failures
 
 =cut
@@ -443,6 +444,7 @@ sub change_gene_id
 
   my $from_id = shift;
   my $to_id = shift;
+  my $no_rename = shift;
 
   my $gene_lookup = Canto::Track::get_adaptor($self->config(), 'gene');
 
@@ -493,8 +495,10 @@ sub change_gene_id
       if ($primary_identifier =~ /^$from_id:/) {
         $primary_identifier =~ s/^$from_id:/$to_id:/;
         $allele->primary_identifier($primary_identifier);
-        $allele_name =~ s/$old_name/$new_name/;
-        $allele->name($allele_name);
+        if (!$no_rename) {
+          $allele_name =~ s/$old_name/$new_name/;
+          $allele->name($allele_name);
+        }
         $allele->update();
       }
     }

--- a/script/canto_admin.pl
+++ b/script/canto_admin.pl
@@ -40,6 +40,7 @@ my $change_taxonid = undef;
 my $delete_unused_strains = undef;
 my $update_annotation_curators = undef;
 my $change_gene_id = undef;
+my $no_rename = 0;
 
 my $dry_run = 0;
 my $do_help = 0;
@@ -52,7 +53,8 @@ my $result = GetOptions ("refresh-gene-cache" => \$refresh_gene_cache,
                          "update-annotation-curators" => \$update_annotation_curators,
                          "change-gene-id" => \$change_gene_id,
                          "dry-run|d" => \$dry_run,
-                         "help|h" => \$do_help);
+                         "help|h" => \$do_help,
+                         "no-rename" => \$no_rename);
 
 sub usage
 {
@@ -86,8 +88,9 @@ sub usage
   Set the curator_orcid field of the annotations if available in the
   person table
 
-  $0 --change-gene-id <from_id> <to_id>
-  Change <from_id> to <to_id> for all genes and alleles in every session
+  $0 --change-gene-id [--no-rename] <from_id> <to_id>
+  Change <from_id> to <to_id> for all genes and alleles in every session.
+  If --no-rename is set, skip renaming alleles.
 |;
 }
 
@@ -133,6 +136,11 @@ if ($update_annotation_curators && @ARGV > 0) {
 
 if ($change_gene_id && @ARGV != 2) {
   warn "Error: --change-gene-id needs two arguments\n\n";
+  usage();
+}
+
+if ($no_rename && !defined $change_gene_id) {
+  warn "Error: --no-rename is only allowed with --change-gene-id\n\n";
   usage();
 }
 
@@ -205,7 +213,7 @@ my $proc = sub {
     my $from_id = shift @ARGV;
     my $to_id = shift @ARGV;
 
-    $util->change_gene_id($from_id, $to_id);
+    $util->change_gene_id($from_id, $to_id, $no_rename);
 
     $exit_flag = 0;
   }


### PR DESCRIPTION
I've added a flag `--no-rename` to `canto_admin.pl` that, when set with `--change-gene-id`, skips the renaming of gene names in allele names. This was needed because PHI-base wanted to keep using the gene name that was specified in the publication for our annotations.

The `--no-rename` flag defaults to `0` instead of `undef`. If the `--no-rename` flag is set with any other flag, the script warns and exits:
```
Error: --no-rename is only allowed with --change-gene-id
```
This required adding an argument `$no_rename` to `change_gene_id` in TrackUtil.pm that skips the allele renaming when set. I didn't bother to set a default value for this argument because `change_gene_id` is currently only used in one place.

I've tested this with PHI-Canto where it works fine both with and without the new flag. I haven't tested  any other modes.