### PR TITLE
Allow wild-type pathogen genotypes in metagenotypes

### DIFF
--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -2220,6 +2220,9 @@ sub _metagenotype_store
   my $body_data = _decode_json_content($c);
 
   my $pathogen_genotype_id = $body_data->{pathogen_genotype_id};
+  my $pathogen_taxonid = $body_data->{pathogen_taxon_id};
+  my $pathogen_strain_name = $body_data->{pathogen_strain_name};
+  
   my $host_genotype_id = $body_data->{host_genotype_id};
   my $host_taxonid = $body_data->{host_taxon_id};
   my $host_strain_name = $body_data->{host_strain_name};
@@ -2251,10 +2254,16 @@ sub _metagenotype_store
   my @alleles = ();
 
   try {
-    my $pathogen_genotype = $schema->find_with_type('Genotype', $pathogen_genotype_id);
-
     my $genotype_manager =
       Canto::Curs::GenotypeManager->new(config => $c->config(), curs_schema => $schema);
+
+    my $pathogen_genotype;
+    
+    if ($pathogen_genotype_id) {
+      $pathogen_genotype = $schema->find_with_type('Genotype', $pathogen_genotype_id);
+    } else {
+      $pathogen_genotype = $genotype_manager->get_wildtype_genotype($pathogen_taxonid, $pathogen_strain_name);
+    }
 
     my $host_genotype;
 

--- a/lib/Canto/Controller/Curs.pm
+++ b/lib/Canto/Controller/Curs.pm
@@ -2251,6 +2251,30 @@ sub _metagenotype_store
     return;
   }
 
+  if (!$pathogen_genotype_id && !$pathogen_taxonid) {
+    $c->stash->{json_data} = {
+      status => "error",
+      message => "Storing new metagenotype failed: internal error - " .
+        "metagenotype call must have 'pathogen_genotype_id' or 'pathogen_taxonid' param",
+    };
+
+    $c->forward('View::JSON');
+
+    return;
+  }
+
+  if ($pathogen_genotype_id && $pathogen_taxonid) {
+    $c->stash->{json_data} = {
+      status => "error",
+      message => "Storing new metagenotype failed: internal error - " .
+        "metagenotype call has both 'pathogen_genotype_id' and 'pathogen_taxonid' params",
+    };
+
+    $c->forward('View::JSON');
+
+    return;
+  }
+
   my @alleles = ();
 
   try {

--- a/root/static/ng_templates/genotype_simple_list_view.html
+++ b/root/static/ng_templates/genotype_simple_list_view.html
@@ -19,7 +19,7 @@
         show-check-box-actions="showCheckBoxActions"
         genotype="currentGenotype"
         on-genotype-select="onGenotypeChange(genotype)"
-        show-background="showBackground"
+        show-background="showBackground">
       </tbody>
     </table>
   </div>

--- a/root/static/ng_templates/metagenotype_genotype_picker.html
+++ b/root/static/ng_templates/metagenotype_genotype_picker.html
@@ -24,11 +24,12 @@
             </genotype-simple-list-view>
         </div>
 
-        <div ng-if="isHost">
+        <div>
             <div class="curs-genotype-list-instructions curs-genotype-list-view-no-checkbox">
                 <span>Wild type genotypes</span>
             </div>
             <wild-type-genotype-picker
+                is-host="isHost"
                 strains="data.wildTypeStrains"
                 on-strain-select="onStrainChange(strain)">
             </wild-type-genotype-picker>

--- a/root/static/ng_templates/metagenotype_manage.html
+++ b/root/static/ng_templates/metagenotype_manage.html
@@ -15,7 +15,8 @@
                     is-host="false"
                     selected-organism="selectedPathogen"
                     genotypes="selectedPathogenGenotypes"
-                    on-genotype-select="onPathogenGenotypeSelect(genotype)">
+                    on-genotype-select="onPathogenGenotypeSelect(genotype)"
+                    on-strain-select="onPathogenStrainSelect(strain)">
                 </metagenotype-genotype-picker>
             </div>
             <div class="curs-metagenotype-picker-column-host">

--- a/root/static/ng_templates/wild_type_genotype_picker.html
+++ b/root/static/ng_templates/wild_type_genotype_picker.html
@@ -4,7 +4,7 @@
       <input
         id="wild-type-strain-{{$index}}"
         type="radio"
-        name="host_genotype"
+        name="{{organismType}}_genotype"
         ng-model="selectedStrain"
         ng-click="onStrainSelect({strain: strain})"
         value="{{strain}}"


### PR DESCRIPTION
The PHI-base team has been curating more publications that focus on the host species, so we've decided to remove the constraint that pathogen genotypes in a metagenotype must have one or more genes (meaning pathogen genotypes can be wild-type now).

Previously, only the host genotype in a metagenotype could be wild-type. Now, both pathogen and host genotypes can be, but not at the same time: creating a metagenotype where both pathogen genotype _and_ host genotype are wild-type is still prevented by the 'Create metagenotype' button being disabled (see `isMetagenotypeInvalid`).

The changes mostly involved duplicating the existing logic for hosts and removing conditionals on the `isHost` scope variable.

I've tested the changes on my local copy in pathogen-host mode and it seems to work fine.

@kimrutherford I'm not sure if we also need checks on the backend to forbid metagenotypes with both wild-type pathogen and wild-type host genotypes. I don't think this problem is as serious as what the existing checks catch, so as long as the database can handle it, I'm fine to leave it as is.

(As a reminder, the existing checks in Controller/Curs.pm prevent metagenotypes that doesn't have either a genotype ID *or* a taxon ID, or which have both a genotype ID *and* a taxon ID at the same time.)